### PR TITLE
Add migration for kurikulum materi table

### DIFF
--- a/backend/database/migrations/2025_09_15_032424_create_kurikulum_materi_table.php
+++ b/backend/database/migrations/2025_09_15_032424_create_kurikulum_materi_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('kurikulum_materi', function (Blueprint $table) {
+            $table->unsignedBigInteger('id_kurikulum');
+            $table->unsignedBigInteger('id_mata_pelajaran');
+            $table->unsignedBigInteger('id_materi');
+            $table->unsignedInteger('urutan');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('kurikulum_materi');
+    }
+};


### PR DESCRIPTION
## Summary
- add migration for `kurikulum_materi` table including `id_kurikulum`, `id_mata_pelajaran`, `id_materi`, `urutan`, and timestamps

## Testing
- `php -l backend/database/migrations/2025_09_15_032424_create_kurikulum_materi_table.php`
- `php artisan migrate` *(fails: Could not open input file: artisan)*

------
https://chatgpt.com/codex/tasks/task_e_68c786a0790483239ff4ad129b122b26