### PR TITLE
Add shelter curriculum activation and sync command

### DIFF
--- a/backend/app/Console/Commands/FillSemesterKurikulumId.php
+++ b/backend/app/Console/Commands/FillSemesterKurikulumId.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Semester;
+use App\Models\Kurikulum;
+
+class FillSemesterKurikulumId extends Command
+{
+    protected $signature = 'semester:fill-kurikulum';
+
+    protected $description = 'Fill semester.kurikulum_id with active kurikulum id for its cabang';
+
+    public function handle(): int
+    {
+        $updated = 0;
+
+        $semesters = Semester::whereNull('kurikulum_id')->get();
+
+        foreach ($semesters as $semester) {
+            $kurikulum = Kurikulum::where('id_kacab', $semester->id_kacab)
+                ->where(function($q) {
+                    $q->where('is_active', true)
+                      ->orWhere('status', 'aktif');
+                })
+                ->first();
+
+            if ($kurikulum) {
+                $semester->kurikulum_id = $kurikulum->id_kurikulum;
+                $semester->save();
+                $updated++;
+            }
+        }
+
+        $this->info("Updated {$updated} semester records.");
+        return Command::SUCCESS;
+    }
+}
+

--- a/backend/app/Http/Controllers/API/AdminCabang/SemesterController.php
+++ b/backend/app/Http/Controllers/API/AdminCabang/SemesterController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\API\AdminCabang;
 
 use App\Http\Controllers\Controller;
 use App\Models\Semester;
+use App\Models\Kurikulum;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Validator;
@@ -383,8 +384,20 @@ class SemesterController extends Controller
                 ->where('id_semester', '!=', $id)
                 ->update(['is_active' => false, 'status' => 'draft']);
 
-            // Set this semester as active
-            $semester->update(['is_active' => true, 'status' => 'active']);
+            // Set this semester as active and assign active kurikulum
+            $activeKurikulum = Kurikulum::where('id_kacab', $kacabId)
+                ->where(function($q) {
+                    $q->where('is_active', true)
+                      ->orWhere('status', 'aktif');
+                })
+                ->first();
+
+            $updateData = ['is_active' => true, 'status' => 'active'];
+            if ($activeKurikulum) {
+                $updateData['kurikulum_id'] = $activeKurikulum->id_kurikulum;
+            }
+
+            $semester->update($updateData);
             $semester->load(['kurikulum']);
 
             return response()->json([

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -275,6 +275,7 @@ Route::middleware('role:admin_pusat')->prefix('admin-pusat')->group(function () 
         Route::get('/kurikulum/dashboard', [App\Http\Controllers\API\AdminShelter\KurikulumDashboardController::class, 'getDashboard']);
         Route::get('/kurikulum/semester-info', [App\Http\Controllers\API\AdminShelter\KurikulumDashboardController::class, 'getSemesterInfo']);
         Route::get('/kurikulum/today-activities', [App\Http\Controllers\API\AdminShelter\KurikulumDashboardController::class, 'getTodayActivities']);
+        Route::post('/kurikulum/{id}/set-active', [App\Http\Controllers\API\AdminShelter\AdminShelterKurikulumController::class, 'setActive']);
 
         // Semester Management for Admin Shelter (Read-only access to cabang semesters)
         Route::get('/semester', [App\Http\Controllers\API\AdminShelter\SemesterController::class, 'index']);


### PR DESCRIPTION
## Summary
- assign active curriculum when activating a semester
- allow admin shelter to set active curriculum per shelter
- add artisan command to backfill semester.kurikulum_id values

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c787aa5a348323a599df51a7df9b56