### PR TITLE
Admin shelter navigates to raport screens

### DIFF
--- a/frontend/src/features/adminShelter/screens/anakDetail/RaporShelterScreen.js
+++ b/frontend/src/features/adminShelter/screens/anakDetail/RaporShelterScreen.js
@@ -3,12 +3,10 @@ import {
   View,
   Text,
   StyleSheet,
-  ScrollView,
   Image,
   TouchableOpacity,
   FlatList,
-  RefreshControl,
-  Alert
+  RefreshControl
 } from 'react-native';
 import { useRoute, useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
@@ -77,27 +75,13 @@ const RaportScreen = () => {
   };
 
   // Handle view raport detail
-  const handleViewRaport = (raport) => {
-    // Navigation to detail screen would go here
-    Alert.alert(
-      'Lihat Detail Raport',
-      `Raport ${raport.semester} - ${raport.tingkat}`,
-      [
-        { text: 'OK' }
-      ]
-    );
+  const handleViewRaport = (item) => {
+    navigation.navigate('RaportView', { raportId: item.id_raport });
   };
 
   // Handle create new raport
   const handleCreateRaport = () => {
-    // Navigation to create raport screen would go here
-    Alert.alert(
-      'Tambah Raport Baru',
-      'Fitur tambah raport baru akan segera tersedia',
-      [
-        { text: 'OK' }
-      ]
-    );
+    navigation.navigate('RaportGenerate', { anakId, anakData });
   };
 
   // Render raport item


### PR DESCRIPTION
## Summary
- Navigate to RaportView and RaportGenerate screens from raport list
- Use `raportApi.getRaportByAnak` to load anak raport data
- Clean up unused imports in RaporShelterScreen

## Testing
- `npm test` (fails: Missing script "test")
- `php artisan test` (fails: Could not open input file: artisan)


------
https://chatgpt.com/codex/tasks/task_e_68c7960c0aac8323adffc67d4420e6bd