### PR TITLE
Update admin shelter raport endpoints to new route

### DIFF
--- a/frontend/src/constants/endpoints.js
+++ b/frontend/src/constants/endpoints.js
@@ -183,10 +183,19 @@ export const ADMIN_SHELTER_ENDPOINTS = {
     TODAY_ACTIVITIES: '/admin-shelter/kurikulum/today-activities'
   },
   RAPORT: {
-    LIST: (childId) => `/admin-shelter/anak/${childId}/raport`,
-    CREATE: (childId) => `/admin-shelter/anak/${childId}/raport/create`,
-    DETAIL: (childId, raportId) => `/admin-shelter/anak/${childId}/raport/${raportId}`,
-    UPDATE: (childId, raportId) => `/admin-shelter/anak/${childId}/raport/${raportId}/update`
+    LIST: '/admin-shelter/raport',
+    BY_CHILD: (childId) => `/admin-shelter/raport/anak/${childId}`,
+    DETAIL: (id) => `/admin-shelter/raport/${id}`,
+    GENERATE: '/admin-shelter/raport/generate',
+    UPDATE: (id) => `/admin-shelter/raport/${id}`,
+    PUBLISH: (id) => `/admin-shelter/raport/${id}/publish`,
+    ARCHIVE: (id) => `/admin-shelter/raport/${id}/archive`,
+    DELETE: (id) => `/admin-shelter/raport/${id}`,
+    PREVIEW: (childId, semesterId) => `/admin-shelter/raport/preview/${childId}/${semesterId}`,
+    CHECK_EXISTING: (childId, semesterId) => `/admin-shelter/raport/check-existing/${childId}/${semesterId}`,
+    UPDATE_DETAIL: (raportId, detailId) => `/admin-shelter/raport/${raportId}/detail/${detailId}`,
+    EXPORT_PDF: (id) => `/admin-shelter/raport/${id}/export-pdf`,
+    RANKING: (semesterId) => `/admin-shelter/raport/ranking/${semesterId}`
   },
   PRESTASI: {
     LIST: (childId) => `/admin-shelter/anak/${childId}/prestasi`,


### PR DESCRIPTION
## Summary
- update `ADMIN_SHELTER_ENDPOINTS.RAPORT` to use `/admin-shelter/raport` routes and add helpers for listing, detail, generation, publishing, and other actions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68c79bb026388323acca9a8f6878333c