### PR TITLE
Handle missing curriculum table in RaportController

### DIFF
--- a/backend/app/Http/Controllers/API/AdminShelter/RaportController.php
+++ b/backend/app/Http/Controllers/API/AdminShelter/RaportController.php
@@ -104,10 +104,17 @@ class RaportController extends Controller
                 $penilaianData = $this->getValidPenilaian($request->id_anak, $semester);
             } catch (\InvalidArgumentException $e) {
                 DB::rollBack();
-                return response()->json([
+
+                $response = [
                     'success' => false,
                     'message' => $e->getMessage()
-                ], 422);
+                ];
+
+                if (str_contains($e->getMessage(), 'kurikulum_materi')) {
+                    $response['needs_curriculum_setup'] = true;
+                }
+
+                return response()->json($response, 422);
             }
 
             // Calculate attendance
@@ -514,10 +521,16 @@ class RaportController extends Controller
         try {
             $penilaianData = $this->getValidPenilaian($idAnak, $semester);
         } catch (\InvalidArgumentException $e) {
-            return response()->json([
+            $response = [
                 'success' => false,
                 'message' => $e->getMessage()
-            ], 422);
+            ];
+
+            if (str_contains($e->getMessage(), 'kurikulum_materi')) {
+                $response['needs_curriculum_setup'] = true;
+            }
+
+            return response()->json($response, 422);
         }
 
         // Calculate attendance


### PR DESCRIPTION
## Summary
- return `needs_curriculum_setup` flag when curriculum table is missing during raport generation and preview

## Testing
- `php -l backend/app/Http/Controllers/API/AdminShelter/RaportController.php`
- `phpunit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c7af5bc1248323ae2741adb4f48de8