### PR TITLE
fix: handle alternate semester name

### DIFF
--- a/frontend/src/features/adminShelter/screens/RaportGenerateScreen.js
+++ b/frontend/src/features/adminShelter/screens/RaportGenerateScreen.js
@@ -224,7 +224,7 @@ const RaportGenerateScreen = () => {
               {semesters.map(semester => (
                 <Picker.Item
                   key={semester.id}
-                  label={`${semester.nama_semester} - ${semester.tahun_ajaran} ${semester.aktif ? '(Aktif)' : ''}`}
+                  label={`${semester.nama || semester.nama_semester} - ${semester.tahun_ajaran} ${semester.aktif ? '(Aktif)' : ''}`}
                   value={semester.id}
                 />
               ))}


### PR DESCRIPTION
## Summary
- use `semester.nama` fallback before `nama_semester` when generating semester labels in raport generator

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7c5c4e3b08323ba445f1961fb8b42