### PR TITLE
Handle missing curriculum errors in raport preview

### DIFF
--- a/frontend/src/features/adminShelter/screens/RaportGenerateScreen.js
+++ b/frontend/src/features/adminShelter/screens/RaportGenerateScreen.js
@@ -104,15 +104,22 @@ const RaportGenerateScreen = () => {
       }
 
       const response = await raportApi.getPreviewData(anakId, selectedSemester);
-      
+
       if (response.data.success) {
         setPreviewData(response.data.data);
       } else {
-        setError(response.data.message || 'Gagal memuat preview raport');
+        setError(
+          response.data.message ||
+            'Kurikulum untuk semester ini belum tersedia.'
+        );
       }
     } catch (err) {
       console.error('Error getting preview:', err);
-      setError('Gagal memuat preview. Silakan coba lagi.');
+      const apiMessage = err.response?.data?.message;
+      setError(
+        apiMessage ||
+          'Kurikulum untuk semester ini belum tersedia. Silakan hubungi admin.'
+      );
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- Display API-provided message when raport preview request fails
- Show localized fallback error when curriculum for a semester is missing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c825acbc508323a41e2a5d2abb470a