### PR TITLE
Add kurikulum materi endpoints

### DIFF
--- a/frontend/src/features/adminCabang/api/kurikulumApi.js
+++ b/frontend/src/features/adminCabang/api/kurikulumApi.js
@@ -141,10 +141,46 @@ export const kurikulumApi = createApi({
       providesTags: (result, error, id) => [{ type: 'Materi', id }],
     }),
 
+    getKurikulumMateri: builder.query({
+      query: ({ kurikulumId, mataPelajaranId }) => ({
+        url: `/kurikulum/${kurikulumId}/materi`,
+        params: mataPelajaranId ? { mata_pelajaran: mataPelajaranId } : undefined,
+      }),
+      providesTags: ['Kurikulum'],
+    }),
+
+    addKurikulumMateri: builder.mutation({
+      query: ({ kurikulumId, mataPelajaranId, materiId, urutan }) => {
+        const body = {
+          id_mata_pelajaran: mataPelajaranId,
+          id_materi: materiId,
+        };
+
+        if (urutan !== undefined && urutan !== null) {
+          body.urutan = urutan;
+        }
+
+        return {
+          url: `/kurikulum/${kurikulumId}/materi`,
+          method: 'POST',
+          body,
+        };
+      },
+      invalidatesTags: ['Kurikulum'],
+    }),
+
+    deleteKurikulumMateri: builder.mutation({
+      query: ({ kurikulumId, materiId }) => ({
+        url: `/kurikulum/${kurikulumId}/materi/${materiId}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: ['Kurikulum'],
+    }),
+
     createMateri: builder.mutation({
       query: (data) => {
         const formData = new FormData();
-        
+
         // Append all form fields
         Object.keys(data).forEach(key => {
           if (data[key] !== null && data[key] !== undefined && data[key] !== '') {
@@ -603,6 +639,9 @@ export const {
   // Materi hooks
   useGetMateriListQuery,
   useGetMateriQuery,
+  useGetKurikulumMateriQuery,
+  useAddKurikulumMateriMutation,
+  useDeleteKurikulumMateriMutation,
   useCreateMateriMutation,
   useUpdateMateriMutation,
   useDeleteMateriMutation,


### PR DESCRIPTION
## Summary
- add RTK Query endpoints to load, create, and delete kurikulum-materi mappings
- expose the corresponding hooks and ensure they share the Kurikulum tag for cache invalidation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8a6cc5a008323b4a67b3b5f5d6643