### PR TITLE
Remove kurikulum subject column references

### DIFF
--- a/backend/app/Http/Requests/BaseCRUDRequest.php
+++ b/backend/app/Http/Requests/BaseCRUDRequest.php
@@ -164,7 +164,6 @@ class BaseCRUDRequest extends FormRequest
             'kode_kurikulum' => ['required', 'string', 'max:50'],
             'tahun_berlaku' => ['required', 'integer', 'min:2020', 'max:2030'],
             'id_jenjang' => ['required', 'integer', 'exists:jenjang,id_jenjang'],
-            'id_mata_pelajaran' => ['required', 'integer', 'exists:mata_pelajaran,id_mata_pelajaran'],
             'deskripsi' => ['nullable', 'string', 'max:1000'],
             'tujuan' => ['nullable', 'string', 'max:1000'],
             'tanggal_mulai' => ['required', 'date'],

--- a/backend/database/migrations/2025_09_15_040000_drop_id_mata_pelajaran_from_kurikulum_table.php
+++ b/backend/database/migrations/2025_09_15_040000_drop_id_mata_pelajaran_from_kurikulum_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('kurikulum', 'id_mata_pelajaran')) {
+            Schema::table('kurikulum', function (Blueprint $table) {
+                try {
+                    $table->dropConstrainedForeignId('id_mata_pelajaran');
+                } catch (\Throwable $exception) {
+                    $table->dropColumn('id_mata_pelajaran');
+                }
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasColumn('kurikulum', 'id_mata_pelajaran')) {
+            Schema::table('kurikulum', function (Blueprint $table) {
+                $table->foreignId('id_mata_pelajaran')
+                    ->after('id_jenjang')
+                    ->constrained('mata_pelajaran', 'id_mata_pelajaran');
+            });
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- drop the obsolete `id_mata_pelajaran` column from the kurikulum table via a new migration
- update the Kurikulum model logic to rely on pivot data for subject relations and counts
- align request validation and admin shelter kurikulum queries with the new relationship structure

## Testing
- php -l backend/app/Models/Kurikulum.php
- php -l backend/app/Http/Controllers/API/AdminShelter/AdminShelterKurikulumController.php
- php -l backend/app/Http/Requests/BaseCRUDRequest.php
- php -l backend/database/migrations/2025_09_15_040000_drop_id_mata_pelajaran_from_kurikulum_table.php
- php artisan test *(fails: artisan entry point is not present in this trimmed project)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e03d3104832389f71edd20018a1d