### PR TITLE
Remove RTK Query debug logging from kurikulum API

### DIFF
--- a/frontend/src/features/adminCabang/api/kurikulumApi.js
+++ b/frontend/src/features/adminCabang/api/kurikulumApi.js
@@ -11,56 +11,13 @@ export const kurikulumApi = createApi({
     baseUrl: `${API_BASE_URL}/admin-cabang`,
     prepareHeaders: (headers, { getState }) => {
       const token = getState().auth.token;
-      console.log('=== RTK QUERY NETWORK DEBUG ===');
-      console.log('- Preparing headers for request');
-      console.log('- Token exists:', !!token);
-      console.log('- Token length:', token ? token.length : 'No token');
       if (token) {
         headers.set('Authorization', `Bearer ${token}`);
-        console.log('- Authorization header set');
       }
       headers.set('Accept', 'application/json');
-      console.log('- Accept header set to application/json');
       return headers;
     },
-    fetchFn: async (url, options) => {
-      console.log('=== RTK QUERY FETCH DEBUG ===');
-      console.log('- URL:', url);
-      console.log('- Method:', options?.method || 'GET');
-      console.log('- Headers:', options?.headers ? Object.fromEntries(options.headers.entries()) : 'No headers');
-      
-      try {
-        const response = await fetch(url, options);
-        console.log('- Response status:', response.status);
-        console.log('- Response ok:', response.ok);
-        console.log('- Response headers:', Object.fromEntries(response.headers.entries()));
-        
-        // Always read response body for debugging
-        try {
-          const responseText = await response.clone().text();
-          console.log('- Response body length:', responseText.length);
-          console.log('- Response body (first 500 chars):', responseText.substring(0, 500));
-          
-          // Try to parse as JSON
-          const responseJson = JSON.parse(responseText);
-          console.log('- Parsed JSON success:', !!responseJson);
-          console.log('- JSON keys:', Object.keys(responseJson));
-        } catch (parseError) {
-          console.log('- JSON parse error:', parseError.message);
-          console.log('- Response body (first 200 chars):', responseText?.substring(0, 200));
-        }
-        
-        if (!response.ok) {
-          console.log('- Response not ok');
-        }
-        
-        return response;
-      } catch (error) {
-        console.log('- Fetch error:', error.message);
-        console.log('- Error details:', error);
-        throw error;
-      }
-    },
+    fetchFn: (url, options) => fetch(url, options),
   }),
   tagTypes: ['Kurikulum', 'Materi', 'Semester', 'Statistics', 'TemplateAdoption', 'KelasCustom', 'MataPelajaranCustom', 'MasterDataDropdown', 'Jenjang'],
   endpoints: (builder) => ({
@@ -99,40 +56,16 @@ export const kurikulumApi = createApi({
         url: '/materi',
         params,
       }),
-      transformResponse: (response) => {
-        console.log('=== RTK QUERY TRANSFORM RESPONSE ===');
-        console.log('- Raw response:', response);
-        console.log('- Response type:', typeof response);
-        console.log('- Response keys:', response ? Object.keys(response) : 'No keys');
-        
-        if (response && response.success && response.data) {
-          console.log('- Success response detected');
-          console.log('- Data type:', typeof response.data);
-          console.log('- Data keys:', Object.keys(response.data));
-          console.log('- Items array length:', response.data.data ? response.data.data.length : 'No data array');
-          return response;
-        } else {
-          console.log('- Unexpected response structure');
-          return response;
-        }
-      },
+      transformResponse: (response) => response,
       providesTags: (result) => {
-        console.log('=== RTK QUERY PROVIDE TAGS ===');
-        console.log('- Result for tags:', result);
-        console.log('- Result.data exists:', !!result?.data);
-        console.log('- Result.data.data exists:', !!result?.data?.data);
-        
         const materiData = result?.data?.data;
         if (materiData && Array.isArray(materiData)) {
-          console.log('- Creating tags for', materiData.length, 'items');
           return [
             ...materiData.map(({ id_materi }) => ({ type: 'Materi', id: id_materi })),
             { type: 'Materi', id: 'LIST' },
           ];
-        } else {
-          console.log('- No valid data array, returning default tags');
-          return [{ type: 'Materi', id: 'LIST' }];
         }
+        return [{ type: 'Materi', id: 'LIST' }];
       },
     }),
 
@@ -259,19 +192,13 @@ export const kurikulumApi = createApi({
         params,
       }),
       transformResponse: (response) => {
-        console.log('=== TEMPLATE ADOPTIONS TRANSFORM ===');
-        console.log('- Raw response:', response);
-        
         // Handle Laravel pagination structure
         if (response?.success && response?.data?.data) {
-          console.log('- Transformed data:', response.data.data);
           return {
             ...response,
             data: response.data.data, // Extract nested data array
           };
         }
-        
-        console.log('- Fallback response:', response);
         return response;
       },
       providesTags: (result) =>
@@ -330,36 +257,13 @@ export const kurikulumApi = createApi({
         params,
       }),
       transformResponse: (response) => {
-        console.log('=== SEMESTER LIST TRANSFORM ===');
-        console.log('- Raw response:', response);
-        
         // Handle Laravel pagination structure
-        if (response?.success && response?.data) {
-          console.log('- Response data exists');
-          
-          // Check if it's paginated (has pagination structure)
-          if (response.data.data && Array.isArray(response.data.data)) {
-            console.log('- Paginated data found, items:', response.data.data.length);
-            console.log('- Transformed data:', response.data.data);
-            return {
-              ...response,
-              data: response.data.data, // Extract nested data array from pagination
-            };
-          }
-          // Check if it's direct array
-          else if (Array.isArray(response.data)) {
-            console.log('- Direct array data found, items:', response.data.length);
-            console.log('- Transformed data:', response.data);
-            return response; // Return as is for direct array
-          }
-          // Single item or object
-          else {
-            console.log('- Single item or object data');
-            return response;
-          }
+        if (response?.success && Array.isArray(response?.data?.data)) {
+          return {
+            ...response,
+            data: response.data.data, // Extract nested data array from pagination
+          };
         }
-        
-        console.log('- Fallback response:', response);
         return response;
       },
       providesTags: (result) => {
@@ -376,55 +280,19 @@ export const kurikulumApi = createApi({
 
     getSemester: builder.query({
       query: (id) => `/semester/${id}`,
-      transformResponse: (response) => {
-        console.log('=== SEMESTER DETAIL TRANSFORM ===');
-        console.log('- Raw response:', response);
-        
-        // Handle single semester response
-        if (response?.success && response?.data) {
-          console.log('- Transformed data:', response.data);
-          return response;
-        }
-        
-        console.log('- Fallback response:', response);
-        return response;
-      },
+      transformResponse: (response) => response,
       providesTags: (result, error, id) => [{ type: 'Semester', id }],
     }),
 
     getActiveSemester: builder.query({
       query: () => '/semester/active',
-      transformResponse: (response) => {
-        console.log('=== ACTIVE SEMESTER TRANSFORM ===');
-        console.log('- Raw response:', response);
-        
-        // Handle active semester response
-        if (response?.success && response?.data) {
-          console.log('- Transformed data:', response.data);
-          return response;
-        }
-        
-        console.log('- Fallback response:', response);
-        return response;
-      },
+      transformResponse: (response) => response,
       providesTags: [{ type: 'Semester', id: 'ACTIVE' }],
     }),
 
     getSemesterStatistics: builder.query({
       query: () => '/semester/statistics',
-      transformResponse: (response) => {
-        console.log('=== SEMESTER STATISTICS TRANSFORM ===');
-        console.log('- Raw response:', response);
-        
-        // Handle statistics response
-        if (response?.success && response?.data) {
-          console.log('- Transformed data:', response.data);
-          return response;
-        }
-        
-        console.log('- Fallback response:', response);
-        return response;
-      },
+      transformResponse: (response) => response,
       providesTags: ['Statistics'],
     }),
 
@@ -482,11 +350,7 @@ export const kurikulumApi = createApi({
         url: '/kelas-custom',
         params,
       }),
-      transformResponse: (response) => {
-        console.log('=== KELAS CUSTOM TRANSFORM ===');
-        console.log('- Raw response:', response);
-        return response;
-      },
+      transformResponse: (response) => response,
       providesTags: (result) =>
         result?.data
           ? [
@@ -542,11 +406,7 @@ export const kurikulumApi = createApi({
         url: '/mata-pelajaran-custom',
         params,
       }),
-      transformResponse: (response) => {
-        console.log('=== MATA PELAJARAN CUSTOM TRANSFORM ===');
-        console.log('- Raw response:', response);
-        return response;
-      },
+      transformResponse: (response) => response,
       providesTags: (result) =>
         result?.data
           ? [
@@ -602,26 +462,17 @@ export const kurikulumApi = createApi({
         url: '/master-data/dropdown',
         params,
       }),
-      transformResponse: (response) => {
-        console.log('=== MASTER DATA DROPDOWN TRANSFORM ===');
-        console.log('- Raw response:', response);
-        return response;
-      },
+      transformResponse: (response) => response,
       providesTags: ['MasterDataDropdown'],
     }),
 
     // Jenjang endpoint for backward compatibility
     getJenjang: builder.query({
       query: () => '/master-data/dropdown?include_jenjang=1',
-      transformResponse: (response) => {
-        console.log('=== JENJANG TRANSFORM ===');
-        console.log('- Raw response:', response);
-        // Extract jenjang from dropdown response
-        return {
-          ...response,
-          data: response?.data?.jenjang || []
-        };
-      },
+      transformResponse: (response) => ({
+        ...response,
+        data: response?.data?.jenjang || [],
+      }),
       providesTags: ['Jenjang'],
     }),
   }),


### PR DESCRIPTION
## Summary
- remove RTK Query debug console logging from the Admin Cabang kurikulum API slice
- simplify transform handlers to return the data they need without emitting noise
- streamline the custom fetch override to delegate to the browser fetch implementation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8ecf297b88323a9310d7b963ab59b