### PR TITLE
Add lazy materi list hook export

### DIFF
--- a/frontend/src/features/adminCabang/api/kurikulumApi.js
+++ b/frontend/src/features/adminCabang/api/kurikulumApi.js
@@ -489,6 +489,7 @@ export const {
   
   // Materi hooks
   useGetMateriListQuery,
+  useLazyGetMateriListQuery,
   useGetMateriQuery,
   useGetKurikulumMateriQuery,
   useAddKurikulumMateriMutation,


### PR DESCRIPTION
## Summary
- export the `useLazyGetMateriListQuery` hook from the admin cabang kurikulum API so lazy loading is available to consumers

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8fa66ab748323a4c4ed54ee0246b1