### PR TITLE
feat(admin-cabang): add kurikulum selection flow

### DIFF
--- a/frontend/src/features/adminCabang/api/kurikulumApi.js
+++ b/frontend/src/features/adminCabang/api/kurikulumApi.js
@@ -23,8 +23,52 @@ export const kurikulumApi = createApi({
   endpoints: (builder) => ({
     // Kurikulum endpoints
     getKurikulumStruktur: builder.query({
-      query: () => '/kurikulum/struktur',
+      query: (kurikulumId) => ({
+        url: '/kurikulum/struktur',
+        params: kurikulumId ? { kurikulum_id: kurikulumId } : undefined,
+      }),
       providesTags: ['Kurikulum'],
+    }),
+
+    getKurikulumList: builder.query({
+      query: (params) => ({
+        url: '/kurikulum',
+        params,
+      }),
+      transformResponse: (response) => {
+        if (Array.isArray(response)) {
+          return { data: response };
+        }
+
+        if (Array.isArray(response?.data)) {
+          return { ...response, data: response.data };
+        }
+
+        if (Array.isArray(response?.data?.data)) {
+          return { ...response, data: response.data.data };
+        }
+
+        return response;
+      },
+      providesTags: (result) => {
+        const list = Array.isArray(result)
+          ? result
+          : Array.isArray(result?.data)
+            ? result.data
+            : [];
+
+        if (list.length > 0) {
+          return [
+            ...list.map((item) => ({
+              type: 'Kurikulum',
+              id: item?.id_kurikulum ?? item?.id,
+            })),
+            { type: 'Kurikulum', id: 'LIST' },
+          ];
+        }
+
+        return [{ type: 'Kurikulum', id: 'LIST' }];
+      },
     }),
 
     getMataPelajaran: builder.query({
@@ -482,6 +526,7 @@ export const kurikulumApi = createApi({
 export const {
   // Kurikulum hooks
   useGetKurikulumStrukturQuery,
+  useGetKurikulumListQuery,
   useGetMataPelajaranQuery,
   useGetKurikulumDropdownDataQuery,
   useGetKelasByJenjangQuery,

--- a/frontend/src/features/adminCabang/redux/kurikulumSlice.js
+++ b/frontend/src/features/adminCabang/redux/kurikulumSlice.js
@@ -8,6 +8,8 @@ const kurikulumSlice = createSlice({
   name: 'kurikulum',
   initialState: {
     // Navigation state
+    selectedKurikulumId: null,
+    selectedKurikulum: null,
     currentJenjang: null,
     currentKelas: null,
     currentMataPelajaran: null,
@@ -45,6 +47,16 @@ const kurikulumSlice = createSlice({
   },
   reducers: {
     // Navigation actions
+    setSelectedKurikulum: (state, action) => {
+      state.selectedKurikulum = action.payload || null;
+      state.selectedKurikulumId = action.payload?.id_kurikulum ?? action.payload?.id ?? null;
+    },
+
+    clearSelectedKurikulum: (state) => {
+      state.selectedKurikulum = null;
+      state.selectedKurikulumId = null;
+    },
+
     setCurrentJenjang: (state, action) => {
       state.currentJenjang = action.payload;
       // Reset dependent states
@@ -151,6 +163,8 @@ const kurikulumSlice = createSlice({
     
     // Clear all data
     clearKurikulumData: (state) => {
+      state.selectedKurikulum = null;
+      state.selectedKurikulumId = null;
       state.struktur = [];
       state.kelasList = [];
       state.mataPelajaranList = [];
@@ -179,6 +193,8 @@ const kurikulumSlice = createSlice({
 });
 
 export const {
+  setSelectedKurikulum,
+  clearSelectedKurikulum,
   setCurrentJenjang,
   setCurrentKelas,
   setCurrentMataPelajaran,

--- a/frontend/src/features/adminCabang/screens/kurikulum/KurikulumHomeScreen.js
+++ b/frontend/src/features/adminCabang/screens/kurikulum/KurikulumHomeScreen.js
@@ -22,6 +22,7 @@ import ErrorMessage from '../../../../common/components/ErrorMessage';
  */
 const KurikulumHomeScreen = ({ navigation }) => {
   const dispatch = useDispatch();
+  const { selectedKurikulum } = useSelector(state => state?.kurikulum || {});
   
   // Get statistics from API
   const {
@@ -55,7 +56,7 @@ const KurikulumHomeScreen = ({ navigation }) => {
   const handleMenuPress = (menuType) => {
     switch (menuType) {
       case 'kelola_kurikulum':
-        navigation.navigate('JenjangSelection');
+        navigation.navigate('SelectKurikulum');
         break;
       case 'semester':
         navigation.navigate('SemesterManagement');
@@ -103,6 +104,23 @@ const KurikulumHomeScreen = ({ navigation }) => {
         <Text style={styles.headerSubtitle}>
           Sistem manajemen kurikulum untuk Admin Cabang
         </Text>
+        {selectedKurikulum && (
+          <View style={styles.selectedKurikulumBanner}>
+            <Ionicons name="ribbon" size={22} color="#0d6efd" style={{ marginRight: 12 }} />
+            <View style={styles.selectedKurikulumTextContainer}>
+              <Text style={styles.selectedKurikulumLabel}>Kurikulum aktif</Text>
+              <Text style={styles.selectedKurikulumName} numberOfLines={1}>
+                {selectedKurikulum?.nama_kurikulum || 'Kurikulum tanpa nama'}
+              </Text>
+            </View>
+            <TouchableOpacity
+              style={styles.changeKurikulumButton}
+              onPress={() => navigation.navigate('SelectKurikulum')}
+            >
+              <Text style={styles.changeKurikulumButtonText}>Ganti</Text>
+            </TouchableOpacity>
+          </View>
+        )}
       </View>
 
       {/* Statistics Cards */}
@@ -250,6 +268,42 @@ const styles = StyleSheet.create({
   headerSubtitle: {
     fontSize: 14,
     color: '#6c757d',
+  },
+  selectedKurikulumBanner: {
+    marginTop: 18,
+    backgroundColor: '#eef4ff',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  selectedKurikulumTextContainer: {
+    flex: 1,
+  },
+  selectedKurikulumLabel: {
+    fontSize: 12,
+    color: '#4c6ef5',
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+  selectedKurikulumName: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#1c3d8f',
+    marginTop: 4,
+  },
+  changeKurikulumButton: {
+    backgroundColor: '#0d6efd',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 20,
+    marginLeft: 12,
+  },
+  changeKurikulumButtonText: {
+    color: '#fff',
+    fontWeight: '600',
+    fontSize: 13,
   },
   statsContainer: {
     padding: 20,

--- a/frontend/src/features/adminCabang/screens/kurikulum/MateriFormScreen.js
+++ b/frontend/src/features/adminCabang/screens/kurikulum/MateriFormScreen.js
@@ -26,11 +26,16 @@ const getFirstDefined = (...values) => values.find((value) => value !== undefine
  * Form for adding/editing learning materials
  */
 const MateriFormScreen = ({ navigation, route }) => {
-  const { jenjang, kelas, mataPelajaran, isEdit, materi, kurikulumId: routeKurikulumId } = route.params || {};
+  const { jenjang, kelas, mataPelajaran, isEdit, materi, kurikulumId: routeKurikulumId, kurikulum } = route.params || {};
 
   const kurikulumState = useSelector(state => state?.kurikulum);
   const kurikulumId = getFirstDefined(
     routeKurikulumId,
+    kurikulum?.id_kurikulum,
+    kurikulum?.id,
+    kurikulumState?.selectedKurikulumId,
+    kurikulumState?.selectedKurikulum?.id_kurikulum,
+    kurikulumState?.selectedKurikulum?.kurikulum_id,
     materi?.kurikulum_id,
     materi?.id_kurikulum,
     materi?.pivot?.id_kurikulum,

--- a/frontend/src/features/adminCabang/screens/kurikulum/MateriManagementScreen.js
+++ b/frontend/src/features/adminCabang/screens/kurikulum/MateriManagementScreen.js
@@ -20,11 +20,17 @@ const getFirstDefined = (...values) => values.find((value) => value !== undefine
  * CRUD interface for learning materials
  */
 const MateriManagementScreen = ({ navigation, route }) => {
-  const { jenjang, kelas, mataPelajaran, kurikulumId: routeKurikulumId } = route.params || {};
+  const { jenjang, kelas, mataPelajaran, kurikulumId: routeKurikulumId, kurikulum } = route.params || {};
 
   const kurikulumState = useSelector(state => state?.kurikulum);
+  const activeKurikulum = kurikulum || kurikulumState?.selectedKurikulum || null;
   const kurikulumId = getFirstDefined(
     routeKurikulumId,
+    kurikulum?.id_kurikulum,
+    kurikulum?.id,
+    kurikulumState?.selectedKurikulumId,
+    kurikulumState?.selectedKurikulum?.id_kurikulum,
+    kurikulumState?.selectedKurikulum?.kurikulum_id,
     mataPelajaran?.kurikulum_id,
     mataPelajaran?.id_kurikulum,
     kelas?.kurikulum_id,
@@ -94,6 +100,7 @@ const MateriManagementScreen = ({ navigation, route }) => {
       kelas,
       mataPelajaran,
       kurikulumId,
+      kurikulum: activeKurikulum,
       isEdit: false
     });
   };
@@ -109,6 +116,7 @@ const MateriManagementScreen = ({ navigation, route }) => {
       kelas,
       mataPelajaran,
       kurikulumId,
+      kurikulum: activeKurikulum,
       isEdit: true,
       materi: materiData
     });

--- a/frontend/src/features/adminCabang/screens/kurikulum/SelectKurikulumScreen.js
+++ b/frontend/src/features/adminCabang/screens/kurikulum/SelectKurikulumScreen.js
@@ -1,0 +1,403 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+  RefreshControl
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useDispatch, useSelector } from 'react-redux';
+
+import LoadingSpinner from '../../../../common/components/LoadingSpinner';
+import ErrorMessage from '../../../../common/components/ErrorMessage';
+import { useGetKurikulumListQuery } from '../../api/kurikulumApi';
+import { setSelectedKurikulum } from '../../redux/kurikulumSlice';
+
+const getKurikulumId = (item) => item?.id_kurikulum ?? item?.id;
+
+const normalizeKurikulumList = (response) => {
+  if (!response) {
+    return [];
+  }
+
+  if (Array.isArray(response)) {
+    return response;
+  }
+
+  if (Array.isArray(response?.data)) {
+    return response.data;
+  }
+
+  if (Array.isArray(response?.data?.data)) {
+    return response.data.data;
+  }
+
+  return [];
+};
+
+const getStatusInfo = (item) => {
+  const rawStatus = typeof item?.status_text === 'string' ? item.status_text : item?.status;
+  const normalized = rawStatus ? rawStatus.toLowerCase() : null;
+
+  if (normalized) {
+    if (normalized.includes('aktif')) {
+      return { color: '#28a745', label: 'Aktif' };
+    }
+
+    if (normalized.includes('draft')) {
+      return { color: '#ffc107', label: 'Draft' };
+    }
+
+    if (normalized.includes('pending') || normalized.includes('menunggu')) {
+      return { color: '#ff9800', label: rawStatus };
+    }
+
+    if (normalized.includes('non') || normalized.includes('tidak')) {
+      return { color: '#dc3545', label: rawStatus };
+    }
+
+    return { color: '#6c757d', label: rawStatus };
+  }
+
+  if (typeof item?.is_active === 'boolean') {
+    return {
+      color: item.is_active ? '#28a745' : '#dc3545',
+      label: item.is_active ? 'Aktif' : 'Tidak Aktif'
+    };
+  }
+
+  return null;
+};
+
+const SelectKurikulumScreen = ({ navigation }) => {
+  const dispatch = useDispatch();
+  const { selectedKurikulumId, selectedKurikulum } = useSelector(state => state?.kurikulum || {});
+
+  const {
+    data,
+    isLoading,
+    isFetching,
+    error,
+    refetch
+  } = useGetKurikulumListQuery();
+
+  const kurikulumList = React.useMemo(() => normalizeKurikulumList(data), [data]);
+  const selectedId = React.useMemo(() => {
+    if (selectedKurikulumId) {
+      return selectedKurikulumId.toString();
+    }
+
+    const fallbackId = getKurikulumId(selectedKurikulum);
+    return fallbackId ? fallbackId.toString() : null;
+  }, [selectedKurikulumId, selectedKurikulum]);
+
+  const handleSelect = (kurikulum) => {
+    dispatch(setSelectedKurikulum(kurikulum));
+    navigation.navigate('JenjangSelection', {
+      kurikulumId: getKurikulumId(kurikulum),
+      kurikulum
+    });
+  };
+
+  const handleCreateNew = () => {
+    navigation.navigate('TemplateAdoption');
+  };
+
+  const renderHeader = () => (
+    <View style={styles.header}>
+      <Text style={styles.headerTitle}>Pilih Kurikulum Cabang</Text>
+      <Text style={styles.headerSubtitle}>
+        Pilih salah satu kurikulum untuk mulai mengelola jenjang, kelas, dan materi.
+      </Text>
+      {selectedKurikulum && (
+        <View style={styles.currentSelectionCard}>
+          <Ionicons name="checkmark-circle" size={20} color="#28a745" style={styles.currentSelectionIcon} />
+          <View style={styles.currentSelectionTextContainer}>
+            <Text style={styles.currentSelectionLabel}>Terakhir dipilih</Text>
+            <Text style={styles.currentSelectionTitle} numberOfLines={1}>
+              {selectedKurikulum?.nama_kurikulum || 'Kurikulum tanpa nama'}
+            </Text>
+          </View>
+        </View>
+      )}
+    </View>
+  );
+
+  const renderCreateButton = () => (
+    <TouchableOpacity style={styles.createButton} onPress={handleCreateNew}>
+      <Ionicons name="add-circle" size={22} color="#fff" style={{ marginRight: 8 }} />
+      <Text style={styles.createButtonText}>Buat Kurikulum Baru</Text>
+    </TouchableOpacity>
+  );
+
+  const renderEmptyState = () => (
+    <View style={styles.emptyContainer}>
+      <Ionicons name="school-outline" size={72} color="#ced4da" style={{ marginBottom: 16 }} />
+      <Text style={styles.emptyTitle}>Belum Ada Kurikulum</Text>
+      <Text style={styles.emptySubtitle}>
+        Mulai dengan membuat kurikulum baru agar materi pembelajaran dapat dikelola.
+      </Text>
+      {renderCreateButton()}
+    </View>
+  );
+
+  const renderItem = ({ item }) => {
+    const itemId = getKurikulumId(item);
+    const isSelected = itemId && selectedId ? itemId.toString() === selectedId : false;
+    const statusInfo = getStatusInfo(item);
+
+    return (
+      <TouchableOpacity
+        style={[styles.card, isSelected && styles.cardSelected]}
+        onPress={() => handleSelect(item)}
+        activeOpacity={0.85}
+      >
+        <View style={styles.cardHeader}>
+          <View style={styles.iconContainer}>
+            <Ionicons name="library" size={22} color="#0d6efd" />
+          </View>
+          <View style={styles.cardContent}>
+            <Text style={styles.cardTitle} numberOfLines={1}>
+              {item?.nama_kurikulum || 'Kurikulum tanpa nama'}
+            </Text>
+            {(item?.tahun_berlaku || item?.kode_kurikulum) && (
+              <Text style={styles.cardSubtitle} numberOfLines={1}>
+                {item?.tahun_berlaku ? `Tahun ${item.tahun_berlaku}` : ''}
+                {item?.tahun_berlaku && item?.kode_kurikulum ? ' • ' : ''}
+                {item?.kode_kurikulum || ''}
+              </Text>
+            )}
+          </View>
+          {isSelected && (
+            <Ionicons name="checkmark-circle" size={24} color="#28a745" />
+          )}
+        </View>
+
+        <View style={styles.cardFooter}>
+          <View style={styles.statItem}>
+            <Ionicons name="book-outline" size={16} color="#6c757d" style={{ marginRight: 6 }} />
+            <Text style={styles.statText}>
+              {(item?.mata_pelajaran_count ?? item?.total_mata_pelajaran ?? 0)} Mata Pelajaran
+            </Text>
+          </View>
+          <View style={styles.statItem}>
+            <Ionicons name="document-text-outline" size={16} color="#6c757d" style={{ marginRight: 6 }} />
+            <Text style={styles.statText}>
+              {(item?.kurikulum_materi_count ?? item?.total_materi ?? 0)} Materi
+            </Text>
+          </View>
+        </View>
+
+        {statusInfo && (
+          <View style={styles.statusBadge}>
+            <Ionicons name="ellipse" size={10} color={statusInfo.color} style={{ marginRight: 6 }} />
+            <Text style={[styles.statusBadgeText, { color: statusInfo.color }]}>{statusInfo.label}</Text>
+          </View>
+        )}
+      </TouchableOpacity>
+    );
+  };
+
+  if (isLoading) {
+    return <LoadingSpinner message="Memuat daftar kurikulum..." />;
+  }
+
+  if (error) {
+    return (
+      <ErrorMessage
+        message="Gagal memuat daftar kurikulum"
+        onRetry={refetch}
+      />
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={kurikulumList}
+        renderItem={renderItem}
+        keyExtractor={(item, index) => `${getKurikulumId(item) ?? index}`}
+        extraData={selectedId}
+        ListHeaderComponent={renderHeader}
+        ListEmptyComponent={renderEmptyState}
+        ListFooterComponent={kurikulumList.length > 0 ? (
+          <View style={styles.footer}>{renderCreateButton()}</View>
+        ) : null}
+        contentContainerStyle={styles.listContent}
+        refreshControl={(
+          <RefreshControl
+            refreshing={isFetching}
+            onRefresh={refetch}
+            colors={['#0d6efd']}
+          />
+        )}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f8f9fa',
+  },
+  listContent: {
+    padding: 20,
+    paddingBottom: 40,
+  },
+  header: {
+    marginBottom: 20,
+  },
+  headerTitle: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#1f2937',
+    marginBottom: 6,
+  },
+  headerSubtitle: {
+    fontSize: 14,
+    color: '#6c757d',
+    lineHeight: 20,
+  },
+  currentSelectionCard: {
+    marginTop: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#e8f6ed',
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  currentSelectionIcon: {
+    marginRight: 12,
+  },
+  currentSelectionTextContainer: {
+    flex: 1,
+  },
+  currentSelectionLabel: {
+    fontSize: 12,
+    color: '#198754',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  currentSelectionTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#14532d',
+    marginTop: 2,
+  },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 6,
+    elevation: 3,
+    borderWidth: 1,
+    borderColor: '#eef2ff',
+  },
+  cardSelected: {
+    borderColor: '#0d6efd',
+    shadowOpacity: 0.15,
+    shadowRadius: 8,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  iconContainer: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: '#edf2ff',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 14,
+  },
+  cardContent: {
+    flex: 1,
+  },
+  cardTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#1f2937',
+  },
+  cardSubtitle: {
+    fontSize: 13,
+    color: '#6c757d',
+    marginTop: 2,
+  },
+  cardFooter: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 16,
+  },
+  statItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  statText: {
+    fontSize: 12,
+    color: '#6c757d',
+    fontWeight: '600',
+  },
+  statusBadge: {
+    marginTop: 14,
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 20,
+    backgroundColor: '#f1f3f5',
+  },
+  statusBadgeText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  createButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#0d6efd',
+    borderRadius: 30,
+    paddingVertical: 14,
+    paddingHorizontal: 20,
+    marginTop: 8,
+  },
+  createButtonText: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 15,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 40,
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#343a40',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    color: '#6c757d',
+    textAlign: 'center',
+    lineHeight: 20,
+    marginBottom: 20,
+  },
+  footer: {
+    marginTop: 8,
+  },
+});
+
+export default SelectKurikulumScreen;

--- a/frontend/src/navigation/AdminCabangNavigator.js
+++ b/frontend/src/navigation/AdminCabangNavigator.js
@@ -25,6 +25,7 @@ import KelasSelectionScreen from '../features/adminCabang/screens/kurikulum/Kela
 import MataPelajaranListScreen from '../features/adminCabang/screens/kurikulum/MataPelajaranListScreen';
 import MateriManagementScreen from '../features/adminCabang/screens/kurikulum/MateriManagementScreen';
 import MateriFormScreen from '../features/adminCabang/screens/kurikulum/MateriFormScreen';
+import SelectKurikulumScreen from '../features/adminCabang/screens/kurikulum/SelectKurikulumScreen';
 import SemesterManagementScreen from '../features/adminCabang/screens/kurikulum/SemesterManagementScreen';
 import TemplateAdoptionScreen from '../features/adminCabang/screens/kurikulum/TemplateAdoptionScreen';
 import MasterDataScreen from '../features/adminCabang/screens/kurikulum/MasterDataScreen';
@@ -108,6 +109,11 @@ const KurikulumStackNavigator = () => (
       name="KurikulumHome"
       component={KurikulumHomeScreen}
       options={{ headerTitle: 'Kurikulum' }}
+    />
+    <KurikulumStack.Screen
+      name="SelectKurikulum"
+      component={SelectKurikulumScreen}
+      options={{ headerTitle: 'Pilih Kurikulum' }}
     />
     <KurikulumStack.Screen
       name="JenjangSelection"


### PR DESCRIPTION
## Summary
- add SelectKurikulumScreen to let admin cabang pick an existing kurikulum or jump to creation
- store the chosen kurikulum in redux and expose a query for fetching available kurikulum
- update kurikulum navigation and detail screens to require the selection and surface the active choice

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9028ac46c8323ae56c50e2620d969