### PR TITLE
Ensure materi management receives kurikulumId

### DIFF
--- a/frontend/src/features/adminCabang/screens/kurikulum/MataPelajaranListScreen.js
+++ b/frontend/src/features/adminCabang/screens/kurikulum/MataPelajaranListScreen.js
@@ -7,6 +7,8 @@ import LoadingSpinner from '../../../../common/components/LoadingSpinner';
 import ErrorMessage from '../../../../common/components/ErrorMessage';
 import { useGetMataPelajaranQuery } from '../../api/kurikulumApi';
 
+const getFirstDefined = (...values) => values.find((value) => value !== undefined && value !== null);
+
 /**
  * Mata Pelajaran List Screen - API Integrated
  * Shows list of subjects for selected jenjang and kelas
@@ -17,7 +19,13 @@ const MataPelajaranListScreen = ({ navigation, route }) => {
   const { selectedKurikulumId, selectedKurikulum } = useSelector(state => state?.kurikulum || {});
 
   const activeKurikulum = routeKurikulum || selectedKurikulum;
-  const activeKurikulumId = routeKurikulumId ?? selectedKurikulumId ?? activeKurikulum?.id_kurikulum;
+  const activeKurikulumId = getFirstDefined(
+    routeKurikulumId,
+    selectedKurikulumId,
+    activeKurikulum?.id_kurikulum,
+    activeKurikulum?.kurikulum_id,
+    activeKurikulum?.id
+  );
   const shouldSkipQuery = !jenjang?.id_jenjang || !kelas?.id_kelas || !activeKurikulumId;
 
   // API hooks


### PR DESCRIPTION
## Summary
- derive kurikulumId and mataPelajaranId from route parameters or global state inside MateriManagementScreen and show a guided message when either is missing
- pass kurikulum and subject identifiers to the lazy materi library query and guard library access with the resolved ids
- reuse a helper in MataPelajaranListScreen so navigation towards MateriManagement always carries a kurikulumId value

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9105f2a708323950ffd113b3b259a