### PR TITLE
Filter kurikulum materi berdasarkan kelas

### DIFF
--- a/backend/app/Http/Controllers/API/AdminCabang/KurikulumMateriController.php
+++ b/backend/app/Http/Controllers/API/AdminCabang/KurikulumMateriController.php
@@ -43,6 +43,11 @@ class KurikulumMateriController extends Controller
                 $query->where('id_mata_pelajaran', $request->query('mata_pelajaran'));
             }
 
+            if ($request->filled('kelas')) {
+                $kelasId = $request->query('kelas');
+                $query->whereHas('materi', fn ($q) => $q->where('id_kelas', $kelasId));
+            }
+
             $materi = $query->get();
 
             return response()->json([

--- a/frontend/src/features/adminCabang/api/kurikulumApi.js
+++ b/frontend/src/features/adminCabang/api/kurikulumApi.js
@@ -128,10 +128,22 @@ export const kurikulumApi = createApi({
     }),
 
     getKurikulumMateri: builder.query({
-      query: ({ kurikulumId, mataPelajaranId }) => ({
-        url: `/kurikulum/${kurikulumId}/materi`,
-        params: mataPelajaranId ? { mata_pelajaran: mataPelajaranId } : undefined,
-      }),
+      query: ({ kurikulumId, mataPelajaranId, kelasId }) => {
+        const params = {};
+
+        if (mataPelajaranId) {
+          params.mata_pelajaran = mataPelajaranId;
+        }
+
+        if (kelasId) {
+          params.kelas = kelasId;
+        }
+
+        return {
+          url: `/kurikulum/${kurikulumId}/materi`,
+          params: Object.keys(params).length > 0 ? params : undefined,
+        };
+      },
       providesTags: ['Kurikulum'],
     }),
 

--- a/frontend/src/features/adminCabang/screens/kurikulum/MateriManagementScreen.js
+++ b/frontend/src/features/adminCabang/screens/kurikulum/MateriManagementScreen.js
@@ -69,7 +69,8 @@ const MateriManagementScreen = ({ navigation, route }) => {
   } = useGetKurikulumMateriQuery(
     {
       kurikulumId,
-      mataPelajaranId
+      mataPelajaranId,
+      kelasId: kelas?.id_kelas
     },
     {
       skip: shouldSkipQuery


### PR DESCRIPTION
## Summary
- add the selected class identifier when requesting kurikulum materi from the frontend
- propagate the class parameter through the API client and filter materi by class in the backend controller

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca1ecbdea483239996c9319906817a