### PR TITLE
Fix materi count priority in kurikulum index

### DIFF
--- a/backend/app/Http/Controllers/API/AdminCabang/KurikulumController.php
+++ b/backend/app/Http/Controllers/API/AdminCabang/KurikulumController.php
@@ -86,7 +86,15 @@ class KurikulumController extends Controller
 
             $kurikulum = $query->get()->map(function($kurikulum) {
                 $mataPelajaranCount = (int) ($kurikulum->mata_pelajaran_count ?? $kurikulum->getTotalMataPelajaran());
-                $materiCount = (int) ($kurikulum->kurikulum_materi_count ?? $kurikulum->materi_count ?? $kurikulum->getTotalMateri());
+
+                $materiCount = $kurikulum->materi_count;
+                if ($materiCount === null) {
+                    $materiCount = $kurikulum->kurikulum_materi_count;
+                }
+                if ($materiCount === null) {
+                    $materiCount = $kurikulum->getTotalMateri();
+                }
+                $materiCount = (int) $materiCount;
                 $semesterCount = (int) ($kurikulum->semester_count ?? $kurikulum->semester()->count());
 
                 return [


### PR DESCRIPTION
## Summary
- adjust materi count resolution in AdminCabang KurikulumController to prioritize the eager-loaded materi_count
- ensure both kurikulum_materi_count and total_materi respond with the same prioritized count value

## Testing
- php -l backend/app/Http/Controllers/API/AdminCabang/KurikulumController.php

------
https://chatgpt.com/codex/tasks/task_e_68ca2cc6db3c832394eadf776f4509c5