### PR TITLE
Fix default export for NilaiSikapFormScreen

### DIFF
--- a/frontend/src/features/adminShelter/screens/NilaiSikapFormScreen.js
+++ b/frontend/src/features/adminShelter/screens/NilaiSikapFormScreen.js
@@ -395,3 +395,5 @@ const styles = StyleSheet.create({
     marginTop: 12,
   },
 });
+
+export default NilaiSikapFormScreen;


### PR DESCRIPTION
## Summary
- add a default export for `NilaiSikapFormScreen` after the StyleSheet block so the navigator can import it without warnings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cad30d2d548323aa8e0d65450fe987