### PR TITLE
Handle missing NilaiSikap responses

### DIFF
--- a/backend/app/Http/Controllers/API/AdminShelter/RaportController.php
+++ b/backend/app/Http/Controllers/API/AdminShelter/RaportController.php
@@ -433,9 +433,10 @@ class RaportController extends Controller
 
             if (!$nilaiSikap) {
                 return response()->json([
-                    'success' => false,
-                    'message' => 'Nilai sikap tidak ditemukan'
-                ], 404);
+                    'success' => true,
+                    'message' => 'Nilai sikap tidak ditemukan',
+                    'data' => null
+                ]);
             }
 
             $nilaiSikap->append(['rata_rata', 'predikat', 'nilai_huruf']);


### PR DESCRIPTION
## Summary
- return a successful empty payload when NilaiSikap data is not available
- only append accessor attributes after a NilaiSikap record is retrieved

## Testing
- php artisan test --testsuite=Feature --filter=NilaiSikap *(fails: Could not open input file: artisan)*

------
https://chatgpt.com/codex/tasks/task_e_68cadb79a4e083239d71787b31b52640