### PR TITLE
Fix active semester handling on Nilai Sikap form

### DIFF
--- a/frontend/src/features/adminShelter/screens/NilaiSikapFormScreen.js
+++ b/frontend/src/features/adminShelter/screens/NilaiSikapFormScreen.js
@@ -55,10 +55,11 @@ const NilaiSikapFormScreen = () => {
     try {
       const response = await semesterApi.getActive();
       if (response.data.success) {
-        setActiveSemester(response.data.data);
+        const activeSemesterData = response.data.data;
+        setActiveSemester(activeSemesterData);
         setFormData(prev => ({
           ...prev,
-          id_semester: response.data.data.id_semester
+          id_semester: activeSemesterData?.id ?? activeSemesterData?.id_semester || ''
         }));
       }
     } catch (err) {
@@ -186,7 +187,9 @@ const NilaiSikapFormScreen = () => {
               <Ionicons name="school-outline" size={20} color="#3498db" />
               <Text style={styles.infoLabel}>Semester:</Text>
               <Text style={styles.infoText}>
-                {activeSemester?.nama_semester || nilaiSikap?.semester?.nama_semester}
+                {activeSemester
+                  ? activeSemester?.nama || activeSemester?.nama_semester
+                  : nilaiSikap?.semester?.nama || nilaiSikap?.semester?.nama_semester}
               </Text>
             </View>
           )}


### PR DESCRIPTION
## Summary
- ensure the active semester ID falls back to either `id` or `id_semester` when loading the form
- update the semester label to display either `nama` or `nama_semester` for the active semester data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cadec061d88323aca4a70bc906f207