### PR TITLE
Fix Nilai Sikap active semester fallback logic

### DIFF
--- a/frontend/src/features/adminShelter/screens/NilaiSikapFormScreen.js
+++ b/frontend/src/features/adminShelter/screens/NilaiSikapFormScreen.js
@@ -59,7 +59,7 @@ const NilaiSikapFormScreen = () => {
         setActiveSemester(activeSemesterData);
         setFormData(prev => ({
           ...prev,
-          id_semester: activeSemesterData?.id ?? activeSemesterData?.id_semester || ''
+          id_semester: (activeSemesterData?.id ?? activeSemesterData?.id_semester) ?? ''
         }));
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- wrap the active semester fallback logic in NilaiSikapFormScreen so nullish coalescing and logical OR are not mixed without parentheses

## Testing
- npm run web -- --clear *(fails: TypeError: fetch failed while Expo CLI attempted to check dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cb605a69448323a500320ad0a3a013