### PR TITLE
Remove Nilai Sikap form success callback

### DIFF
--- a/frontend/src/features/adminShelter/screens/NilaiSikapFormScreen.js
+++ b/frontend/src/features/adminShelter/screens/NilaiSikapFormScreen.js
@@ -23,7 +23,7 @@ import { semesterApi } from '../api/semesterApi';
 const NilaiSikapFormScreen = () => {
   const navigation = useNavigation();
   const route = useRoute();
-  const { anakId, anakData, nilaiSikap, semesterId, onSuccess } = route.params || {};
+  const { anakId, anakData, nilaiSikap, semesterId } = route.params || {};
   
   const isEdit = !!nilaiSikap;
 
@@ -86,13 +86,6 @@ const NilaiSikapFormScreen = () => {
       }
 
       if (response.data.success) {
-        if (typeof onSuccess === 'function') {
-          try {
-            onSuccess();
-          } catch (callbackError) {
-            console.error('Error executing onSuccess callback:', callbackError);
-          }
-        }
         Alert.alert(
           'Sukses',
           isEdit ? 'Nilai sikap berhasil diperbarui' : 'Nilai sikap berhasil disimpan',

--- a/frontend/src/features/adminShelter/screens/NilaiSikapScreen.js
+++ b/frontend/src/features/adminShelter/screens/NilaiSikapScreen.js
@@ -23,8 +23,7 @@ const NilaiSikapScreen = () => {
     anakId,
     anakData,
     semesterId: semesterIdParam,
-    semesterName: semesterNameParam,
-    onNilaiSikapUpdated
+    semesterName: semesterNameParam
   } = route.params || {};
 
   const [activeSemester, setActiveSemester] = useState(null);
@@ -148,13 +147,7 @@ const NilaiSikapScreen = () => {
       anakId,
       anakData,
       semesterId: semesterInfo.id,
-      nilaiSikap,
-      onSuccess: async () => {
-        await loadData({ showLoading: false });
-        if (typeof onNilaiSikapUpdated === 'function') {
-          onNilaiSikapUpdated();
-        }
-      }
+      nilaiSikap
     });
   };
 


### PR DESCRIPTION
## Summary
- stop passing an onSuccess callback from the Nilai Sikap listing screen when opening the form
- simplify the form submission handler to only show the success alert and navigate back after confirmation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb6a6f6814832388e60c479f85d0db