### PR TITLE
Restrict admin cabang user show access

### DIFF
--- a/backend/app/Http/Controllers/API/AdminCabang/AdminCabangUserController.php
+++ b/backend/app/Http/Controllers/API/AdminCabang/AdminCabangUserController.php
@@ -59,6 +59,11 @@ class AdminCabangUserController extends Controller
     public function show($id)
     {
         $user = User::with(['adminCabang', 'adminShelter'])->findOrFail($id);
+
+        if (!in_array($user->level, ['admin_cabang', 'admin_shelter'], true)) {
+            abort(404);
+        }
+
         return new UserResource($user);
     }
 

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <env name="APP_ENV" value="testing"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="TELESCOPE_ENABLED" value="false"/>
+    </php>
+</phpunit>

--- a/backend/tests/Unit/AdminCabang/AdminCabangUserControllerTest.php
+++ b/backend/tests/Unit/AdminCabang/AdminCabangUserControllerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit\AdminCabang;
+
+use App\Http\Controllers\API\AdminCabang\AdminCabangUserController;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class AdminCabangUserControllerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    /** @runInSeparateProcess */
+    public function test_admin_cabang_cannot_view_user_outside_allowed_levels(): void
+    {
+        $controller = new AdminCabangUserController();
+
+        $user = (object) ['level' => 'admin_pusat'];
+
+        $builderMock = Mockery::mock();
+        $builderMock->shouldReceive('findOrFail')->once()->with(42)->andReturn($user);
+
+        Mockery::mock('alias:App\\Models\\User')
+            ->shouldReceive('with')
+            ->once()
+            ->with(['adminCabang', 'adminShelter'])
+            ->andReturn($builderMock);
+
+        try {
+            $controller->show(42);
+            $this->fail('Expected HttpException to be thrown.');
+        } catch (HttpException $exception) {
+            $this->assertSame(404, $exception->getStatusCode());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- guard the admin cabang user detail endpoint against records outside the admin cabang/admin shelter levels
- add a PHPUnit configuration and unit coverage to assert the controller aborts when an unauthorized level is requested

## Testing
- composer install *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- ./vendor/bin/phpunit *(fails: file not found because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cb7c447e9c8323b288a77bacc06cdd