### PR TITLE
Fix admin cabang user dropdown routes and data loading

### DIFF
--- a/frontend/src/constants/endpoints.js
+++ b/frontend/src/constants/endpoints.js
@@ -125,8 +125,9 @@ export const ADMIN_CABANG_ENDPOINTS = {
     DETAIL: (id) => `/admin-cabang/users/${id}`,
     UPDATE: (id) => `/admin-cabang/users/${id}`,
     DROPDOWN: {
-      WILBIN: '/admin-cabang/users/wilbin-dropdown',
-      SHELTER_BY_WILBIN: (wilbinId) => `/admin-cabang/users/wilbin/${wilbinId}/shelter-dropdown`
+      KACAB: '/admin-cabang/kacab',
+      WILBIN: (kacabId) => `/admin-cabang/kacab/${kacabId}/wilbin`,
+      SHELTER_BY_WILBIN: (wilbinId) => `/admin-cabang/wilbin/${wilbinId}/shelter`
     }
   },
   DONATUR: {

--- a/frontend/src/features/adminCabang/api/adminCabangUserManagementApi.js
+++ b/frontend/src/features/adminCabang/api/adminCabangUserManagementApi.js
@@ -45,8 +45,13 @@ export const adminCabangUserManagementApi = {
   },
 
   /** Dropdown wilbin untuk cabang */
-  getWilbinDropdown: async () => {
-    return await api.get(USER_ENDPOINTS.DROPDOWN.WILBIN);
+  getWilbinDropdown: async (kacabId) => {
+    if (!kacabId && kacabId !== 0) {
+      const error = new Error('Parameter id kacab wajib diisi');
+      error.code = 'KACAB_ID_REQUIRED';
+      throw error;
+    }
+    return await api.get(USER_ENDPOINTS.DROPDOWN.WILBIN(kacabId));
   },
 
   /** Dropdown shelter berdasarkan wilbin */

--- a/frontend/src/features/adminCabang/screens/user/UserFormScreen.js
+++ b/frontend/src/features/adminCabang/screens/user/UserFormScreen.js
@@ -118,10 +118,14 @@ const UserFormScreen = () => {
     setKacabName(profile?.kacab?.nama_cabang || profile?.nama_cabang || 'Cabang Anda');
   }, [profile]);
 
-  const fetchWilbinDropdown = useCallback(async () => {
+  const fetchWilbinDropdown = useCallback(async (kacabId) => {
+    if (!kacabId) {
+      setWilbinList([]);
+      return;
+    }
     try {
       setLoadingDropdown(true);
-      const res = await adminCabangUserManagementApi.getWilbinDropdown();
+      const res = await adminCabangUserManagementApi.getWilbinDropdown(kacabId);
       const list = res?.data?.data || res?.data || [];
       setWilbinList(Array.isArray(list) ? list : []);
     } catch (e) {
@@ -199,14 +203,21 @@ const UserFormScreen = () => {
   }, [defaultLevel, editingId, fetchShelterOptions]);
 
   useEffect(() => {
-    const init = async () => {
-      await fetchWilbinDropdown();
-      if (mode === 'edit' && editingId) {
-        await fetchDetail();
-      }
-    };
-    init();
-  }, [mode, editingId, fetchWilbinDropdown, fetchDetail]);
+    if (!id_kacab) {
+      setWilbinList([]);
+      setIdWilbin('');
+      setShelterList([]);
+      setIdShelter('');
+      return;
+    }
+    fetchWilbinDropdown(id_kacab);
+  }, [id_kacab, fetchWilbinDropdown]);
+
+  useEffect(() => {
+    if (mode === 'edit' && editingId) {
+      fetchDetail();
+    }
+  }, [mode, editingId, fetchDetail]);
 
   const handleWilbinChange = useCallback(
     (value) => {


### PR DESCRIPTION
## Summary
- update admin cabang user dropdown endpoints to match the backend routes
- require cabang id when loading wilbin options and use the new shelter route in the API client
- only load wilbin data after the profile cabang id is available in the user form screen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb8a416f848323a33e46170547e3f0