### PR TITLE
Improve AdminPusat user profile syncing

### DIFF
--- a/backend/app/Http/Controllers/API/AdminPusat/AdminPusatUserController.php
+++ b/backend/app/Http/Controllers/API/AdminPusat/AdminPusatUserController.php
@@ -11,7 +11,9 @@ use App\Models\Kacab;
 use App\Models\Wilbin;
 use App\Models\Shelter;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 
 class AdminPusatUserController extends Controller
 {
@@ -40,6 +42,12 @@ class AdminPusatUserController extends Controller
             'email' => 'required|email|unique:users,email',
             'password' => 'required|string|min:6',
             'level' => 'required|string|in:admin_pusat,admin_cabang,admin_shelter',
+            'nama_lengkap' => 'required|string|max:255',
+            'alamat' => 'nullable|string|max:500',
+            'no_hp' => 'nullable|string|max:20',
+            'id_kacab' => 'required_if:level,admin_cabang,admin_shelter|integer|exists:kacab,id_kacab',
+            'id_wilbin' => 'required_if:level,admin_shelter|integer|exists:wilbin,id_wilbin',
+            'id_shelter' => 'required_if:level,admin_shelter|integer|exists:shelter,id_shelter',
         ]);
 
         if ($validator->fails()) {
@@ -52,22 +60,39 @@ class AdminPusatUserController extends Controller
 
         try {
             $validated = $validator->validated();
-            $validated['password'] = bcrypt($validated['password']);
 
-            $user = User::create($validated);
+            $userData = Arr::only($validated, ['username', 'email', 'password', 'level']);
+            $userData['password'] = bcrypt($userData['password']);
 
-            $user->load(match ($user->level) {
-                'admin_pusat' => 'adminPusat',
-                'admin_cabang' => 'adminCabang',
-                'admin_shelter' => 'adminShelter',
-                default => []
-            });
+            $profileData = Arr::only($validated, [
+                'nama_lengkap',
+                'alamat',
+                'no_hp',
+                'id_kacab',
+                'id_wilbin',
+                'id_shelter',
+            ]);
+
+            $user = User::create($userData);
+
+            $this->syncAdminProfile($user, $user->level, $profileData);
+
+            $relations = $this->relationsForLevel($user->level);
+            if (!empty($relations)) {
+                $user->load($relations);
+            }
 
             return response()->json([
                 'status' => true,
                 'message' => 'User berhasil dibuat',
                 'data' => (new UserResource($user))->resolve(),
             ], 201);
+        } catch (ValidationException $exception) {
+            return response()->json([
+                'status' => false,
+                'message' => 'Validasi gagal',
+                'errors' => $exception->errors(),
+            ], 422);
         } catch (\Throwable $th) {
             return response()->json([
                 'status' => false,
@@ -98,6 +123,12 @@ class AdminPusatUserController extends Controller
             'email' => 'sometimes|required|email|unique:users,email,' . $user->id_users . ',id_users',
             'password' => 'nullable|string|min:6',
             'level' => 'sometimes|required|string|in:admin_pusat,admin_cabang,admin_shelter',
+            'nama_lengkap' => 'sometimes|required|string|max:255',
+            'alamat' => 'sometimes|nullable|string|max:500',
+            'no_hp' => 'sometimes|nullable|string|max:20',
+            'id_kacab' => 'sometimes|integer|exists:kacab,id_kacab',
+            'id_wilbin' => 'sometimes|integer|exists:wilbin,id_wilbin',
+            'id_shelter' => 'sometimes|integer|exists:shelter,id_shelter',
         ]);
 
         if ($validator->fails()) {
@@ -111,20 +142,53 @@ class AdminPusatUserController extends Controller
         try {
             $validated = $validator->validated();
 
-            if (!empty($validated['password'])) {
-                $validated['password'] = bcrypt($validated['password']);
-            } else {
-                unset($validated['password']);
+            if (array_key_exists('password', $validated)) {
+                if (!empty($validated['password'])) {
+                    $validated['password'] = bcrypt($validated['password']);
+                } else {
+                    unset($validated['password']);
+                }
             }
 
-            $user->update($validated);
-            $user->load(['adminPusat', 'adminCabang', 'adminShelter']);
+            $profileData = Arr::only($validated, [
+                'nama_lengkap',
+                'alamat',
+                'no_hp',
+                'id_kacab',
+                'id_wilbin',
+                'id_shelter',
+            ]);
+
+            $targetLevel = $validated['level'] ?? $user->level;
+
+            $user->loadMissing(['adminPusat', 'adminCabang', 'adminShelter']);
+            $this->ensureRequiredProfileData($user, $targetLevel, $profileData);
+
+            $this->syncAdminProfile($user, $targetLevel, $profileData);
+
+            $userData = Arr::only($validated, ['username', 'email', 'password', 'level']);
+            if (!empty($userData)) {
+                $user->update($userData);
+            }
+
+            $user->refresh();
+
+            $relations = $this->relationsForLevel($user->level);
+            if (!empty($relations)) {
+                $user->load($relations);
+            }
 
             return response()->json([
                 'status' => true,
                 'message' => 'User berhasil diupdate',
                 'data' => (new UserResource($user))->resolve(),
             ]);
+        } catch (ValidationException $exception) {
+            return response()->json([
+                'status' => false,
+                'message' => 'Validasi gagal',
+                'errors' => $exception->errors(),
+            ], 422);
         } catch (\Throwable $th) {
             return response()->json([
                 'status' => false,
@@ -132,6 +196,129 @@ class AdminPusatUserController extends Controller
                 'error' => $th->getMessage(),
             ], 500);
         }
+    }
+
+    private function relationsForLevel(string $level): array
+    {
+        return match ($level) {
+            'admin_pusat' => ['adminPusat'],
+            'admin_cabang' => ['adminCabang'],
+            'admin_shelter' => ['adminShelter'],
+            default => [],
+        };
+    }
+
+    private function syncAdminProfile(User $user, string $targetLevel, array $profileData): void
+    {
+        if ($targetLevel === 'admin_pusat') {
+            $payload = $this->extractProfilePayload($profileData, ['nama_lengkap', 'alamat', 'no_hp']);
+
+            $user->adminPusat()->updateOrCreate(
+                ['id_users' => $user->id_users],
+                $payload
+            );
+
+            if ($user->level !== 'admin_pusat') {
+                $user->adminCabang()->delete();
+                $user->adminShelter()->delete();
+            }
+        } elseif ($targetLevel === 'admin_cabang') {
+            $payload = $this->extractProfilePayload($profileData, ['id_kacab', 'nama_lengkap', 'alamat', 'no_hp']);
+
+            $user->adminCabang()->updateOrCreate(
+                ['user_id' => $user->id_users],
+                $payload
+            );
+
+            if ($user->level !== 'admin_cabang') {
+                $user->adminPusat()->delete();
+                $user->adminShelter()->delete();
+            }
+        } elseif ($targetLevel === 'admin_shelter') {
+            $payload = $this->extractProfilePayload($profileData, ['id_kacab', 'id_wilbin', 'id_shelter', 'nama_lengkap', 'no_hp']);
+
+            if (array_key_exists('alamat', $profileData)) {
+                $payload['alamat_adm'] = $profileData['alamat'];
+            }
+
+            $user->adminShelter()->updateOrCreate(
+                ['user_id' => $user->id_users],
+                $payload
+            );
+
+            if ($user->level !== 'admin_shelter') {
+                $user->adminPusat()->delete();
+                $user->adminCabang()->delete();
+            }
+        }
+    }
+
+    private function ensureRequiredProfileData(User $user, string $targetLevel, array $profileData): void
+    {
+        if ($targetLevel === 'admin_pusat') {
+            $namaLengkap = array_key_exists('nama_lengkap', $profileData)
+                ? $profileData['nama_lengkap']
+                : $user->adminPusat?->nama_lengkap;
+
+            if ($namaLengkap === null) {
+                throw ValidationException::withMessages([
+                    'nama_lengkap' => 'The nama_lengkap field is required.',
+                ]);
+            }
+        } elseif ($targetLevel === 'admin_cabang') {
+            $idKacab = array_key_exists('id_kacab', $profileData)
+                ? $profileData['id_kacab']
+                : $user->adminCabang?->id_kacab;
+
+            if ($idKacab === null) {
+                throw ValidationException::withMessages([
+                    'id_kacab' => 'The id_kacab field is required.',
+                ]);
+            }
+        } elseif ($targetLevel === 'admin_shelter') {
+            $existing = $user->adminShelter;
+
+            $idKacab = array_key_exists('id_kacab', $profileData)
+                ? $profileData['id_kacab']
+                : $existing?->id_kacab;
+            $idWilbin = array_key_exists('id_wilbin', $profileData)
+                ? $profileData['id_wilbin']
+                : $existing?->id_wilbin;
+            $idShelter = array_key_exists('id_shelter', $profileData)
+                ? $profileData['id_shelter']
+                : $existing?->id_shelter;
+
+            $messages = [];
+
+            if ($idKacab === null) {
+                $messages['id_kacab'] = 'The id_kacab field is required.';
+            }
+
+            if ($idWilbin === null) {
+                $messages['id_wilbin'] = 'The id_wilbin field is required.';
+            }
+
+            if ($idShelter === null) {
+                $messages['id_shelter'] = 'The id_shelter field is required.';
+            }
+
+            if (!empty($messages)) {
+                throw ValidationException::withMessages($messages);
+            }
+        }
+    }
+
+    private function extractProfilePayload(array $data, array $allowedKeys): array
+    {
+        $payload = [];
+
+        foreach ($allowedKeys as $key) {
+            if (array_key_exists($key, $data)) {
+                $payload[$key] = $data[$key];
+            }
+        }
+
+        return $payload;
     }
 
     /**

--- a/backend/tests/Integration/AdminPusatUserControllerTest.php
+++ b/backend/tests/Integration/AdminPusatUserControllerTest.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Tests\Integration;
+
+use App\Http\Controllers\API\AdminPusat\AdminPusatUserController;
+use App\Models\Kacab;
+use App\Models\Shelter;
+use App\Models\User;
+use App\Models\Wilbin;
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Hashing\BcryptHasher;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Factory;
+use PHPUnit\Framework\TestCase;
+
+class AdminPusatUserControllerTest extends TestCase
+{
+    private Capsule $database;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Model::clearBootedModels();
+
+        $this->setUpContainer();
+        $this->setUpDatabase();
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->database)) {
+            $schema = $this->database->schema();
+            $schema->dropIfExists('admin_shelter');
+            $schema->dropIfExists('admin_cabang');
+            $schema->dropIfExists('admin_pusat');
+            $schema->dropIfExists('shelter');
+            $schema->dropIfExists('wilbin');
+            $schema->dropIfExists('kacab');
+            $schema->dropIfExists('users');
+        }
+
+        Facade::clearResolvedInstances();
+        Container::setInstance(null);
+        Model::unsetEventDispatcher();
+
+        parent::tearDown();
+    }
+
+    public function test_store_creates_user_and_admin_pusat_profile(): void
+    {
+        $controller = new AdminPusatUserController();
+
+        $request = Request::create('/admin-pusat/create-user', 'POST', [
+            'username' => 'central-admin',
+            'email' => 'central@example.com',
+            'password' => 'secret123',
+            'level' => 'admin_pusat',
+            'nama_lengkap' => 'Central Admin',
+            'alamat' => 'Central Address',
+            'no_hp' => '0800111222',
+        ]);
+
+        $response = $controller->store($request);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(201, $response->getStatusCode());
+
+        $payload = $response->getData(true);
+        $this->assertTrue($payload['status']);
+        $this->assertArrayHasKey('admin_pusat', $payload['data']);
+
+        $user = User::where('email', 'central@example.com')->first();
+        $this->assertNotNull($user);
+        $this->assertSame('admin_pusat', $user->level);
+        $this->assertTrue(Container::getInstance()->make('hash')->check('secret123', $user->password));
+
+        $profile = $user->adminPusat()->first();
+        $this->assertNotNull($profile);
+        $this->assertSame('Central Admin', $profile->nama_lengkap);
+        $this->assertSame('Central Address', $profile->alamat);
+        $this->assertSame('0800111222', $profile->no_hp);
+
+        $this->assertSame('Central Admin', $payload['data']['admin_pusat']['nama_lengkap']);
+        $this->assertSame('Central Address', $payload['data']['admin_pusat']['alamat']);
+    }
+
+    public function test_update_switches_to_admin_shelter_and_syncs_profiles(): void
+    {
+        $controller = new AdminPusatUserController();
+        $locations = $this->createLocationHierarchy();
+
+        $user = User::create([
+            'username' => 'central-admin',
+            'email' => 'central@example.com',
+            'password' => Container::getInstance()->make('hash')->make('secret123'),
+            'level' => 'admin_pusat',
+        ]);
+
+        $user->adminPusat()->create([
+            'nama_lengkap' => 'Central Admin',
+            'alamat' => 'Central Address',
+            'no_hp' => '0800111222',
+        ]);
+
+        $request = Request::create('/admin-pusat/users/' . $user->id_users, 'PUT', [
+            'level' => 'admin_shelter',
+            'nama_lengkap' => 'Shelter Admin',
+            'alamat' => 'Shelter Address',
+            'no_hp' => '08123456789',
+            'id_kacab' => $locations['kacab']->id_kacab,
+            'id_wilbin' => $locations['wilbin']->id_wilbin,
+            'id_shelter' => $locations['shelter']->id_shelter,
+        ]);
+
+        $response = $controller->update($request, $user->id_users);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $payload = $response->getData(true);
+        $this->assertTrue($payload['status']);
+        $this->assertArrayHasKey('admin_shelter', $payload['data']);
+        $this->assertArrayNotHasKey('admin_pusat', $payload['data']);
+
+        $user->refresh();
+        $this->assertSame('admin_shelter', $user->level);
+
+        $shelterProfile = $user->adminShelter()->first();
+        $this->assertNotNull($shelterProfile);
+        $this->assertSame($locations['kacab']->id_kacab, $shelterProfile->id_kacab);
+        $this->assertSame($locations['wilbin']->id_wilbin, $shelterProfile->id_wilbin);
+        $this->assertSame($locations['shelter']->id_shelter, $shelterProfile->id_shelter);
+        $this->assertSame('Shelter Admin', $shelterProfile->nama_lengkap);
+        $this->assertSame('Shelter Address', $shelterProfile->alamat_adm);
+
+        $this->assertNull($user->adminPusat()->first());
+
+        $this->assertSame('Shelter Admin', $payload['data']['admin_shelter']['nama_lengkap']);
+        $this->assertSame('Shelter Address', $payload['data']['admin_shelter']['alamat']);
+    }
+
+    private function setUpContainer(): void
+    {
+        $container = new Container();
+        Container::setInstance($container);
+
+        $config = new Repository([
+            'app.locale' => 'en',
+            'app.fallback_locale' => 'en',
+            'database.default' => 'sqlite',
+            'database.connections.sqlite' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+            ],
+        ]);
+
+        $container->instance('config', $config);
+        $container->instance('app', $container);
+
+        $loader = new ArrayLoader();
+        $translator = new Translator($loader, 'en');
+        $container->instance('translator', $translator);
+
+        $validator = new Factory($translator, $container);
+        $container->instance('validator', $validator);
+
+        $container->singleton('hash', static fn () => new BcryptHasher());
+
+        Facade::setFacadeApplication($container);
+
+        $capsule = new Capsule($container);
+        $capsule->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        $events = new Dispatcher($container);
+        $capsule->setEventDispatcher($events);
+
+        $capsule->setAsGlobal();
+        $capsule->bootEloquent();
+
+        $container->instance('events', $events);
+        $container->instance('db', $capsule->getDatabaseManager());
+
+        Model::setConnectionResolver($capsule->getDatabaseManager());
+        Model::setEventDispatcher($events);
+
+        $this->database = $capsule;
+    }
+
+    private function setUpDatabase(): void
+    {
+        $schema = $this->database->schema();
+
+        $schema->create('users', function (Blueprint $table) {
+            $table->increments('id_users');
+            $table->string('username');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('level');
+            $table->string('status')->nullable();
+            $table->timestamps();
+        });
+
+        $schema->create('kacab', function (Blueprint $table) {
+            $table->increments('id_kacab');
+            $table->string('nama_kacab')->nullable();
+            $table->timestamps();
+        });
+
+        $schema->create('wilbin', function (Blueprint $table) {
+            $table->increments('id_wilbin');
+            $table->unsignedInteger('id_kacab')->nullable();
+            $table->string('nama_wilbin')->nullable();
+            $table->timestamps();
+        });
+
+        $schema->create('shelter', function (Blueprint $table) {
+            $table->increments('id_shelter');
+            $table->unsignedInteger('id_wilbin')->nullable();
+            $table->string('nama_shelter')->nullable();
+            $table->timestamps();
+        });
+
+        $schema->create('admin_pusat', function (Blueprint $table) {
+            $table->increments('id_admin_pusat');
+            $table->unsignedInteger('id_users')->unique();
+            $table->string('nama_lengkap')->nullable();
+            $table->string('alamat')->nullable();
+            $table->string('no_hp')->nullable();
+            $table->timestamps();
+        });
+
+        $schema->create('admin_cabang', function (Blueprint $table) {
+            $table->increments('id_admin_cabang');
+            $table->unsignedInteger('user_id')->unique();
+            $table->unsignedInteger('id_kacab')->nullable();
+            $table->string('nama_lengkap')->nullable();
+            $table->string('alamat')->nullable();
+            $table->string('no_hp')->nullable();
+            $table->timestamps();
+        });
+
+        $schema->create('admin_shelter', function (Blueprint $table) {
+            $table->increments('id_admin_shelter');
+            $table->unsignedInteger('user_id')->unique();
+            $table->unsignedInteger('id_kacab')->nullable();
+            $table->unsignedInteger('id_wilbin')->nullable();
+            $table->unsignedInteger('id_shelter')->nullable();
+            $table->string('nama_lengkap')->nullable();
+            $table->string('alamat_adm')->nullable();
+            $table->string('no_hp')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function createLocationHierarchy(): array
+    {
+        $kacab = Kacab::create(['nama_kacab' => 'Cabang']);
+        $wilbin = Wilbin::create([
+            'id_kacab' => $kacab->id_kacab,
+            'nama_wilbin' => 'Wilbin',
+        ]);
+        $shelter = Shelter::create([
+            'id_wilbin' => $wilbin->id_wilbin,
+            'nama_shelter' => 'Shelter',
+        ]);
+
+        return compact('kacab', 'wilbin', 'shelter');
+    }
+}


### PR DESCRIPTION
## Summary
- expand AdminPusat user controller validation to accept profile fields and related IDs per level
- synchronise admin_pusat, admin_cabang, and admin_shelter profiles when creating or updating users and load the relevant relations for responses
- add integration coverage to confirm profile persistence through the AdminPusat controller

## Testing
- `./vendor/bin/phpunit` *(fails: vendor binaries unavailable because Composer install cannot run in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cba81022cc8323a1fd98af0043534a