### PR TITLE
Adjust keyboard avoiding behavior on user form screen

### DIFF
--- a/frontend/src/features/adminPusat/screens/user/UserFormScreen.js
+++ b/frontend/src/features/adminPusat/screens/user/UserFormScreen.js
@@ -200,7 +200,7 @@ const UserFormScreen = () => {
     <SafeAreaView style={styles.safe}> 
       <KeyboardAvoidingView
         style={styles.flex}
-        behavior={Platform.select({ ios: 'padding', android: undefined })}
+        behavior={Platform.select({ ios: 'padding', android: 'height' })}
         keyboardVerticalOffset={Platform.select({ ios: 64, android: 0 })}
       >
         <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>


### PR DESCRIPTION
## Summary
- update the admin user form screen to use height behavior on Android so content remains visible when the keyboard is open

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccc3da2e188323b55b44f3a27a67fe