### PR TITLE
Adjust keyboard avoiding behavior on user form screen

### DIFF
--- a/frontend/src/features/adminCabang/screens/user/UserFormScreen.js
+++ b/frontend/src/features/adminCabang/screens/user/UserFormScreen.js
@@ -296,8 +296,8 @@ const UserFormScreen = () => {
     <SafeAreaView style={styles.safe}>
       <KeyboardAvoidingView
         style={styles.flex}
-        behavior={Platform.select({ ios: 'padding', android: undefined })}
-        keyboardVerticalOffset={Platform.select({ ios: 64, android: 0 })}
+        behavior={Platform.select({ ios: 'padding', android: 'height' })}
+        keyboardVerticalOffset={Platform.select({ ios: 64, android: 90 })}
       >
         <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
           <View style={styles.container}>


### PR DESCRIPTION
## Summary
- update the KeyboardAvoidingView in the admin cabang user form to use platform-specific behavior
- raise the Android keyboard offset so the bottom of the form remains visible when the keyboard opens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccc771f1688323b7a92e8c54ed8863