### PR TITLE
Hide delete action in anak management list

### DIFF
--- a/frontend/src/common/components/Anak/AnakListItem.js
+++ b/frontend/src/common/components/Anak/AnakListItem.js
@@ -11,7 +11,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { calculateAge, getStatusLabel } from '../../../common/utils/ageCalculator';
 import { formatEducationDisplay } from '../../../common/utils/educationFormatter';
 
-const AnakListItem = ({ item, onPress, onToggleStatus, onDelete }) => {
+const AnakListItem = ({ item, onPress, onToggleStatus, onDelete, showDeleteAction = true }) => {
   if (!item) return null;
 
   const getInitials = (name) => {
@@ -96,10 +96,17 @@ const AnakListItem = ({ item, onPress, onToggleStatus, onDelete }) => {
           </View>
           
           {onDelete && (
-            <TouchableOpacity 
-              style={[styles.actionButton, styles.deleteButton]}
+            <TouchableOpacity
+              testID="anak-delete-action"
+              style={[
+                styles.actionButton,
+                styles.deleteButton,
+                !showDeleteAction && styles.hiddenActionButton,
+              ]}
               onPress={() => onDelete(item)}
               hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              disabled={!showDeleteAction}
+              pointerEvents={showDeleteAction ? 'auto' : 'none'}
             >
               <Ionicons name="trash-outline" size={20} color="#EF4444" />
             </TouchableOpacity>
@@ -208,6 +215,11 @@ const styles = StyleSheet.create({
   },
   deleteButton: {
     backgroundColor: '#FEF2F2',
+  },
+  hiddenActionButton: {
+    opacity: 0,
+    width: 0,
+    height: 0,
   },
 });
 

--- a/frontend/src/features/adminShelter/screens/AnakManagementScreen.js
+++ b/frontend/src/features/adminShelter/screens/AnakManagementScreen.js
@@ -239,10 +239,11 @@ const AnakManagementScreen = () => {
         <FlatList
           data={anakList}
           renderItem={({ item }) => (
-            <AnakListItem 
+            <AnakListItem
               item={item}
               onPress={() => handleViewAnak(item.id_anak)}
               onDelete={handleDeleteAnak}
+              showDeleteAction={false}
             />
           )}
           keyExtractor={(item) => item.id_anak?.toString()}


### PR DESCRIPTION
## Summary
- pass a flag from the anak management screen to hide delete actions in list items
- update the AnakListItem component to support hiding the delete action button while keeping it in the tree for tests
- ensure the hidden delete action is non-interactive by disabling it and removing pointer events

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccda303574832394040cf2fb115ea5