### PR TITLE
Enhance admin cabang survey detail view

### DIFF
--- a/backend/app/Http/Controllers/API/AdminCabang/AdminCabangSurveyController.php
+++ b/backend/app/Http/Controllers/API/AdminCabang/AdminCabangSurveyController.php
@@ -60,7 +60,15 @@ class AdminCabangSurveyController extends Controller
         $admin = $this->getAdminCabang();
         
         $survey = Survey::byKacab($admin->id_kacab)->with([
-            'keluarga' => fn($q) => $q->with(['shelter.wilbin', 'kacab', 'bank', 'anak', 'ayah', 'ibu', 'wali']),
+            'keluarga' => fn($q) => $q->with([
+                'shelter.wilbin',
+                'kacab',
+                'bank',
+                'anak' => fn($anak) => $anak->with(['anakPendidikan']),
+                'ayah',
+                'ibu',
+                'wali'
+            ]),
             'approvedBy'
         ])->find($id);
 

--- a/frontend/src/features/adminCabang/screens/SurveyApprovalDetailScreen.js
+++ b/frontend/src/features/adminCabang/screens/SurveyApprovalDetailScreen.js
@@ -5,6 +5,9 @@ import { Ionicons } from '@expo/vector-icons';
 import LoadingSpinner from '../../../common/components/LoadingSpinner';
 import ErrorMessage from '../../../common/components/ErrorMessage';
 import { adminCabangSurveyApi } from '../api/adminCabangSurveyApi';
+import { formatDateToIndonesian } from '../../../common/utils/dateFormatter';
+import { formatEducationLevel, getParentStatusDescription } from '../../adminShelter/utils/keluargaFormUtils';
+import { formatCurrency } from '../../../utils/currencyFormatter';
 
 const SurveyApprovalDetailScreen = () => {
   const route = useRoute();
@@ -20,23 +23,11 @@ const SurveyApprovalDetailScreen = () => {
   const [notes, setNotes] = useState('');
   const [rejectionReason, setRejectionReason] = useState('');
 
-  const formatDate = (dateString) => {
-    if (!dateString || dateString === '' || dateString === null) {
-      return 'Tanggal tidak tersedia';
+  const formatCurrencyValue = (value) => {
+    if (value === null || value === undefined || value === '') {
+      return '-';
     }
-    
-    const date = new Date(dateString);
-    
-    // Check if date is valid and not epoch (1970-01-01)
-    if (isNaN(date.getTime()) || date.getFullYear() === 1970) {
-      return 'Tanggal tidak valid';
-    }
-    
-    return date.toLocaleDateString('id-ID', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric'
-    });
+    return formatCurrency(value);
   };
 
   const fetchSurveyDetail = async () => {
@@ -82,16 +73,24 @@ const SurveyApprovalDetailScreen = () => {
     }
   };
 
-  const InfoSection = ({ title, data }) => (
+  const InfoRow = ({ label, value }) => {
+    const displayValue = value !== undefined && value !== null && value !== '' ? value : '-';
+    return (
+      <View style={styles.infoRow}>
+        <Text style={styles.infoLabel}>{label}:</Text>
+        <Text style={styles.infoValue}>{displayValue}</Text>
+      </View>
+    );
+  };
+
+  const InfoSection = ({ title, rows = [], children }) => (
     <View style={styles.section}>
       <Text style={styles.sectionTitle}>{title}</Text>
       <View style={styles.sectionContent}>
-        {Object.entries(data).map(([key, value]) => (
-          <View key={key} style={styles.infoRow}>
-            <Text style={styles.infoLabel}>{key}:</Text>
-            <Text style={styles.infoValue}>{value || '-'}</Text>
-          </View>
+        {rows.map(({ label, value }, index) => (
+          <InfoRow key={`${label}-${index}`} label={label} value={value} />
         ))}
+        {children}
       </View>
     </View>
   );
@@ -124,52 +123,251 @@ const SurveyApprovalDetailScreen = () => {
   if (error) return <View style={styles.container}><ErrorMessage message={error} onRetry={fetchSurveyDetail} /></View>;
 
   const { keluarga } = survey;
-  const anak = keluarga?.anak?.[0];
 
-  const sections = [
-    ['Informasi Keluarga', {
-      'Kepala Keluarga': keluarga?.kepala_keluarga,
-      'Nomor KK': keluarga?.no_kk,
-      'Telepon': keluarga?.no_telp,
-      'Shelter': keluarga?.shelter?.nama_shelter,
-      'Wilbin': keluarga?.shelter?.wilbin?.nama_wilbin
-    }],
-    ...(anak ? [['Informasi Anak', {
-      'Nama Lengkap': anak.full_name,
-      'Nama Panggilan': anak.nick_name,
-      'Tanggal Lahir': formatDate(anak.tanggal_lahir),
-      'Status Saat Ini': anak.status_cpb
-    }]] : []),
-    ...(keluarga?.ayah ? [['Informasi Ayah', {
-      'Nama': keluarga.ayah.nama_ayah,
-      'NIK': keluarga.ayah.nik_ayah,
-      'Tempat Lahir': keluarga.ayah.tempat_lahir,
-      'Penghasilan': keluarga.ayah.penghasilan
-    }]] : []),
-    ...(keluarga?.ibu ? [['Informasi Ibu', {
-      'Nama': keluarga.ibu.nama_ibu,
-      'NIK': keluarga.ibu.nik_ibu,
-      'Tempat Lahir': keluarga.ibu.tempat_lahir,
-      'Penghasilan': keluarga.ibu.penghasilan
-    }]] : []),
-    ['Informasi Survei', {
-      'Pekerjaan Kepala Keluarga': survey.pekerjaan_kepala_keluarga,
-      'Penghasilan': survey.penghasilan,
-      'Pendidikan': survey.pendidikan_kepala_keluarga,
-      'Jumlah Tanggungan': survey.jumlah_tanggungan,
-      'Kepemilikan Rumah': survey.kepemilikan_rumah,
-      'Kondisi Dinding': survey.kondisi_rumah_dinding,
-      'Kondisi Lantai': survey.kondisi_rumah_lantai,
-      'Sumber Air Bersih': survey.sumber_air_bersih,
-      'Tanggal Survei': formatDate(survey.tanggal_survey),
-      'Petugas Survei': survey.petugas_survey
-    }]
-  ];
+  const sections = [];
+
+  sections.push({
+    title: 'Informasi Keluarga',
+    rows: [
+      { label: 'Nomor KK', value: keluarga?.no_kk },
+      { label: 'Kepala Keluarga', value: keluarga?.kepala_keluarga },
+      { label: 'Status', value: getParentStatusDescription(keluarga?.status_ortu) },
+      { label: 'Bank', value: keluarga?.bank?.nama_bank },
+      {
+        label: 'Rekening',
+        value: keluarga?.no_rek
+          ? `${keluarga.no_rek}${keluarga?.an_rek ? ` (${keluarga.an_rek})` : ''}`
+          : '-'
+      },
+      {
+        label: 'Kontak',
+        value: keluarga?.no_tlp
+          ? `${keluarga.no_tlp}${keluarga?.an_tlp ? ` (${keluarga.an_tlp})` : ''}`
+          : '-'
+      },
+      { label: 'Shelter', value: keluarga?.shelter?.nama_shelter },
+      { label: 'Wilbin', value: keluarga?.shelter?.wilbin?.nama_wilbin },
+      { label: 'Kacab', value: keluarga?.kacab?.nama_kacab }
+    ]
+  });
+
+  if (keluarga?.ayah) {
+    sections.push({
+      title: 'Informasi Ayah',
+      rows: [
+        { label: 'Nama', value: keluarga.ayah.nama_ayah },
+        { label: 'NIK', value: keluarga.ayah.nik_ayah },
+        { label: 'Agama', value: keluarga.ayah.agama },
+        {
+          label: 'Tempat & Tanggal Lahir',
+          value: keluarga.ayah.tempat_lahir
+            ? `${keluarga.ayah.tempat_lahir}, ${formatDateToIndonesian(keluarga.ayah.tanggal_lahir)}`
+            : '-'
+        },
+        { label: 'Alamat', value: keluarga.ayah.alamat },
+        { label: 'Penghasilan', value: keluarga.ayah.penghasilan },
+        ...(keluarga.ayah.tanggal_kematian
+          ? [
+              { label: 'Meninggal', value: formatDateToIndonesian(keluarga.ayah.tanggal_kematian) },
+              { label: 'Penyebab', value: keluarga.ayah.penyebab_kematian }
+            ]
+          : [])
+      ]
+    });
+  }
+
+  if (keluarga?.ibu) {
+    sections.push({
+      title: 'Informasi Ibu',
+      rows: [
+        { label: 'Nama', value: keluarga.ibu.nama_ibu },
+        { label: 'NIK', value: keluarga.ibu.nik_ibu },
+        { label: 'Agama', value: keluarga.ibu.agama },
+        {
+          label: 'Tempat & Tanggal Lahir',
+          value: keluarga.ibu.tempat_lahir
+            ? `${keluarga.ibu.tempat_lahir}, ${formatDateToIndonesian(keluarga.ibu.tanggal_lahir)}`
+            : '-'
+        },
+        { label: 'Alamat', value: keluarga.ibu.alamat },
+        { label: 'Penghasilan', value: keluarga.ibu.penghasilan },
+        ...(keluarga.ibu.tanggal_kematian
+          ? [
+              { label: 'Meninggal', value: formatDateToIndonesian(keluarga.ibu.tanggal_kematian) },
+              { label: 'Penyebab', value: keluarga.ibu.penyebab_kematian }
+            ]
+          : [])
+      ]
+    });
+  }
+
+  if (keluarga?.wali && (keluarga.wali.nama_wali || keluarga.wali.nik_wali)) {
+    sections.push({
+      title: 'Informasi Wali',
+      rows: [
+        { label: 'Nama', value: keluarga.wali.nama_wali },
+        { label: 'NIK', value: keluarga.wali.nik_wali },
+        { label: 'Hubungan', value: keluarga.wali.hub_kerabat },
+        { label: 'Agama', value: keluarga.wali.agama },
+        {
+          label: 'Tempat & Tanggal Lahir',
+          value: keluarga.wali.tempat_lahir
+            ? `${keluarga.wali.tempat_lahir}, ${formatDateToIndonesian(keluarga.wali.tanggal_lahir)}`
+            : '-'
+        },
+        { label: 'Alamat', value: keluarga.wali.alamat },
+        { label: 'Penghasilan', value: keluarga.wali.penghasilan }
+      ]
+    });
+  }
+
+  keluarga?.anak?.forEach((child, index) => {
+    sections.push({
+      title: `Informasi Anak ${child.full_name ? `- ${child.full_name}` : `#${index + 1}`}`,
+      rows: [
+        { label: 'Nama Lengkap', value: child.full_name },
+        { label: 'Nama Panggilan', value: child.nick_name },
+        { label: 'NIK', value: child.nik_anak },
+        { label: 'Jenis Kelamin', value: child.jenis_kelamin },
+        { label: 'Agama', value: child.agama },
+        {
+          label: 'Tempat & Tanggal Lahir',
+          value: child.tempat_lahir
+            ? `${child.tempat_lahir}, ${formatDateToIndonesian(child.tanggal_lahir)}`
+            : '-'
+        },
+        {
+          label: 'Urutan Anak',
+          value: child.anak_ke
+            ? `${child.anak_ke}${child.dari_bersaudara ? ` dari ${child.dari_bersaudara}` : ''}`
+            : '-'
+        },
+        { label: 'Status CPB', value: child.status_cpb },
+        { label: 'Tinggal Bersama', value: child.tinggal_bersama },
+        { label: 'Hafalan', value: child.hafalan },
+        { label: 'Hobi', value: child.hobi },
+        { label: 'Mata Pelajaran Favorit', value: child.pelajaran_favorit },
+        { label: 'Prestasi', value: child.prestasi },
+        {
+          label: 'Jarak Rumah',
+          value: child.jarak_rumah ? `${child.jarak_rumah} km` : '-'
+        },
+        { label: 'Transportasi', value: child.transportasi }
+      ]
+    });
+
+    if (child.anakPendidikan) {
+      sections.push({
+        title: `Pendidikan Anak ${child.full_name ? `- ${child.full_name}` : `#${index + 1}`}`,
+        rows: [
+          { label: 'Jenjang', value: formatEducationLevel(child.anakPendidikan.jenjang) },
+          { label: 'Kelas', value: child.anakPendidikan.kelas },
+          { label: 'Jurusan', value: child.anakPendidikan.jurusan },
+          { label: 'Semester', value: child.anakPendidikan.semester },
+          { label: 'Sekolah', value: child.anakPendidikan.nama_sekolah },
+          { label: 'Alamat Sekolah', value: child.anakPendidikan.alamat_sekolah },
+          { label: 'Perguruan Tinggi', value: child.anakPendidikan.nama_pt },
+          { label: 'Alamat Perguruan Tinggi', value: child.anakPendidikan.alamat_pt }
+        ]
+      });
+    }
+  });
+
+  sections.push({
+    title: 'Survei - Informasi Dasar',
+    rows: [
+      { label: 'Pekerjaan Kepala Keluarga', value: survey.pekerjaan_kepala_keluarga },
+      { label: 'Pendidikan Kepala Keluarga', value: survey.pendidikan_kepala_keluarga },
+      { label: 'Jumlah Tanggungan', value: survey.jumlah_tanggungan },
+      { label: 'Status Anak', value: survey.status_anak },
+      { label: 'Kepribadian Anak', value: survey.kepribadian_anak },
+      { label: 'Kondisi Fisik Anak', value: survey.kondisi_fisik_anak },
+      ...(survey.kondisi_fisik_anak === 'Disabilitas'
+        ? [{ label: 'Keterangan Disabilitas', value: survey.keterangan_disabilitas }]
+        : [])
+    ]
+  });
+
+  sections.push({
+    title: 'Survei - Informasi Keuangan',
+    rows: [
+      { label: 'Penghasilan', value: survey.penghasilan },
+      { label: 'Kepemilikan Tabungan', value: survey.kepemilikan_tabungan },
+      {
+        label: 'Biaya Pendidikan Per Bulan',
+        value: formatCurrencyValue(survey.biaya_pendidikan_perbulan)
+      },
+      { label: 'Bantuan Lembaga Lain', value: survey.bantuan_lembaga_formal_lain },
+      ...(survey.bantuan_lembaga_formal_lain === 'Ya'
+        ? [
+            {
+              label: 'Jumlah Bantuan',
+              value: formatCurrencyValue(survey.bantuan_lembaga_formal_lain_sebesar)
+            }
+          ]
+        : [])
+    ]
+  });
+
+  sections.push({
+    title: 'Survei - Informasi Aset',
+    rows: [
+      { label: 'Kepemilikan Tanah', value: survey.kepemilikan_tanah },
+      { label: 'Kepemilikan Rumah', value: survey.kepemilikan_rumah },
+      { label: 'Kondisi Dinding', value: survey.kondisi_rumah_dinding },
+      { label: 'Kondisi Lantai', value: survey.kondisi_rumah_lantai },
+      { label: 'Kepemilikan Kendaraan', value: survey.kepemilikan_kendaraan },
+      { label: 'Kepemilikan Elektronik', value: survey.kepemilikan_elektronik }
+    ]
+  });
+
+  sections.push({
+    title: 'Survei - Informasi Kesehatan',
+    rows: [
+      { label: 'Jumlah Makan per Hari', value: survey.jumlah_makan },
+      { label: 'Sumber Air Bersih', value: survey.sumber_air_bersih },
+      { label: 'Jamban', value: survey.jamban_limbah },
+      { label: 'Tempat Sampah', value: survey.tempat_sampah },
+      { label: 'Perokok', value: survey.perokok },
+      { label: 'Konsumen Minuman Keras', value: survey.konsumen_miras },
+      { label: 'Persediaan P3K', value: survey.persediaan_p3k },
+      { label: 'Konsumsi Buah & Sayur', value: survey.makan_buah_sayur }
+    ]
+  });
+
+  sections.push({
+    title: 'Survei - Keagamaan & Sosial',
+    rows: [
+      { label: 'Sholat Lima Waktu', value: survey.solat_lima_waktu },
+      { label: 'Membaca Al-Quran', value: survey.membaca_alquran },
+      { label: 'Majelis Taklim', value: survey.majelis_taklim },
+      { label: 'Membaca Berita', value: survey.membaca_koran },
+      { label: 'Pengurus Organisasi', value: survey.pengurus_organisasi },
+      ...(survey.pengurus_organisasi === 'Ya'
+        ? [{ label: 'Jabatan Organisasi', value: survey.pengurus_organisasi_sebagai }]
+        : []),
+      { label: 'Kondisi Penerima Manfaat', value: survey.kondisi_penerima_manfaat }
+    ]
+  });
+
+  sections.push({
+    title: 'Informasi Survei',
+    rows: [
+      { label: 'Tanggal Survei', value: formatDateToIndonesian(survey.tanggal_survey) },
+      { label: 'Petugas Survei', value: survey.petugas_survey },
+      { label: 'Hasil Survei', value: survey.hasil_survey },
+      { label: 'Catatan Survei', value: survey.keterangan_hasil }
+    ]
+  });
 
   return (
     <View style={styles.container}>
       <ScrollView style={styles.scrollView}>
-        {sections.map(([title, data], index) => <InfoSection key={index} title={title} data={data} />)}
+        {sections.map(({ title, rows, children }, index) => (
+          <InfoSection key={index} title={title} rows={rows}>
+            {children}
+          </InfoSection>
+        ))}
       </ScrollView>
 
       {survey?.hasil_survey === 'pending' && (


### PR DESCRIPTION
## Summary
- restructure the admin cabang survey approval detail screen to mirror the admin shelter review layout and formatting
- display comprehensive family, parent, guardian, child, education, and survey information using shared formatting helpers
- eager load child education data for survey detail responses so the frontend can render schooling information

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ccf69230ec8323a2cfd8acb43134d6