### PR TITLE
Add Data Wilayah screen and dashboard access

### DIFF
--- a/frontend/src/features/adminPusat/screens/AdminPusatDashboardScreen.js
+++ b/frontend/src/features/adminPusat/screens/AdminPusatDashboardScreen.js
@@ -60,6 +60,7 @@ const AdminPusatDashboardScreen = () => {
   const navigateToProfile = () => navigation.navigate('ProfileTab');
   const navigateToTutorHonorSettings = () => navigation.navigate('TutorHonorSettings');
   const navigateToUserManagement = () => navigation.navigate('UserManagement');
+  const navigateToDataWilayah = () => navigation.navigate('DataWilayah');
 
   // Show loading indicator
   if (loading && !refreshing) {
@@ -159,8 +160,8 @@ const AdminPusatDashboardScreen = () => {
             <Text style={styles.quickAccessSubtext}>Kelola template dan distribusi</Text>
           </TouchableOpacity>
           
-          <TouchableOpacity 
-            style={styles.quickAccessItem} 
+          <TouchableOpacity
+            style={styles.quickAccessItem}
             onPress={navigateToTutorHonorSettings}
           >
             <View style={[styles.iconContainer, { backgroundColor: '#e74c3c' }]}>
@@ -171,7 +172,7 @@ const AdminPusatDashboardScreen = () => {
           </TouchableOpacity>
 
           {/* NEW: Manajemen User */}
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.quickAccessItem}
             onPress={navigateToUserManagement}
           >
@@ -180,6 +181,17 @@ const AdminPusatDashboardScreen = () => {
             </View>
             <Text style={styles.quickAccessText}>Manajemen User</Text>
             <Text style={styles.quickAccessSubtext}>Kelola user pusat/cabang/shelter</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.quickAccessItem}
+            onPress={navigateToDataWilayah}
+          >
+            <View style={[styles.iconContainer, { backgroundColor: '#9b59b6' }]}>
+              <Ionicons name="map" size={24} color="#fff" />
+            </View>
+            <Text style={styles.quickAccessText}>Data Wilayah</Text>
+            <Text style={styles.quickAccessSubtext}>Lihat kantor cabang & shelter</Text>
           </TouchableOpacity>
         </View>
       </View>

--- a/frontend/src/features/adminPusat/screens/DataWilayahScreen.js
+++ b/frontend/src/features/adminPusat/screens/DataWilayahScreen.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+const menuItems = [
+  {
+    id: 'kantor-cabang',
+    label: 'Kantor Cabang',
+    description: 'Kelola informasi kantor cabang',
+    icon: 'business',
+    color: '#3498db',
+  },
+  {
+    id: 'wilayah-binaan',
+    label: 'Wilayah Binaan',
+    description: 'Lihat daftar wilayah binaan',
+    icon: 'map',
+    color: '#2ecc71',
+  },
+  {
+    id: 'shelter',
+    label: 'Shelter',
+    description: 'Data shelter dan fasilitas',
+    icon: 'home',
+    color: '#e67e22',
+  },
+];
+
+const DataWilayahScreen = () => {
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.contentContainer}>
+      <Text style={styles.title}>Data Wilayah</Text>
+      <Text style={styles.subtitle}>
+        Pilih menu di bawah untuk melihat informasi wilayah yang tersedia.
+      </Text>
+
+      <View style={styles.menuList}>
+        {menuItems.map((item) => (
+          <TouchableOpacity key={item.id} style={styles.menuCard} activeOpacity={0.8}>
+            <View style={[styles.iconContainer, { backgroundColor: item.color }]}>
+              <Ionicons name={item.icon} size={28} color="#fff" />
+            </View>
+            <View style={styles.menuContent}>
+              <Text style={styles.menuLabel}>{item.label}</Text>
+              <Text style={styles.menuDescription}>{item.description}</Text>
+            </View>
+            <Ionicons name="chevron-forward" size={20} color="#999" />
+          </TouchableOpacity>
+        ))}
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f5f5',
+  },
+  contentContainer: {
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#333',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '#666',
+    marginBottom: 20,
+  },
+  menuList: {
+    gap: 12,
+  },
+  menuCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+    padding: 16,
+    borderRadius: 12,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  iconContainer: {
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 16,
+  },
+  menuContent: {
+    flex: 1,
+  },
+  menuLabel: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#333',
+    marginBottom: 4,
+  },
+  menuDescription: {
+    fontSize: 13,
+    color: '#777',
+  },
+});
+
+export default DataWilayahScreen;

--- a/frontend/src/navigation/AdminPusatNavigator.js
+++ b/frontend/src/navigation/AdminPusatNavigator.js
@@ -7,6 +7,7 @@ import { Ionicons } from '@expo/vector-icons';
 import AdminPusatDashboardScreen from '../features/adminPusat/screens/AdminPusatDashboardScreen';
 import AdminPusatProfileScreen from '../features/adminPusat/screens/AdminPusatProfileScreen';
 import TutorHonorSettingsScreen from '../features/adminPusat/screens/TutorHonorSettingsScreen';
+import DataWilayahScreen from '../features/adminPusat/screens/DataWilayahScreen';
 
 // User Management Screens
 import UserManagementScreen from '../features/adminPusat/screens/user/UserManagementScreen';
@@ -35,14 +36,19 @@ const Stack = createStackNavigator();
 const HomeStackNavigator = () => {
   return (
     <Stack.Navigator>
-      <Stack.Screen 
-        name="Dashboard" 
-        component={AdminPusatDashboardScreen} 
+      <Stack.Screen
+        name="Dashboard"
+        component={AdminPusatDashboardScreen}
         options={{ headerTitle: 'Admin Pusat Dashboard' }}
       />
-      <Stack.Screen 
-        name="TutorHonorSettings" 
-        component={TutorHonorSettingsScreen} 
+      <Stack.Screen
+        name="DataWilayah"
+        component={DataWilayahScreen}
+        options={{ headerTitle: 'Data Wilayah' }}
+      />
+      <Stack.Screen
+        name="TutorHonorSettings"
+        component={TutorHonorSettingsScreen}
         options={{ headerTitle: 'Setting Honor Tutor' }}
       />
 


### PR DESCRIPTION
## Summary
- add a static Data Wilayah screen with three informational cards for Kantor Cabang, Wilayah Binaan, and Shelter
- register the new Data Wilayah screen in the Admin Pusat home stack navigator
- expose the screen from the Admin Pusat dashboard via a new quick access tile

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68cecdebacdc8323af201d8b36d42e68