### PR TITLE
Add admin pusat Kacab API resource endpoints

### DIFF
--- a/backend/app/Http/Controllers/API/AdminPusat/KacabController.php
+++ b/backend/app/Http/Controllers/API/AdminPusat/KacabController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers\API\AdminPusat;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Kacab\StoreKacabRequest;
+use App\Http\Requests\Kacab\UpdateKacabRequest;
+use App\Http\Resources\KacabResource;
+use App\Models\Kacab;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class KacabController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): AnonymousResourceCollection
+    {
+        $kacab = Kacab::query()
+            ->latest('id_kacab')
+            ->paginate();
+
+        return KacabResource::collection($kacab);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(StoreKacabRequest $request)
+    {
+        $data = $request->validated();
+
+        if (!empty($data['no_telpon']) && empty($data['no_telp'])) {
+            $data['no_telp'] = $data['no_telpon'];
+        }
+
+        unset($data['no_telpon']);
+
+        $kacab = Kacab::create($data);
+
+        return (new KacabResource($kacab->fresh()))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Kacab $kacab): KacabResource
+    {
+        return new KacabResource($kacab);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(UpdateKacabRequest $request, Kacab $kacab): KacabResource
+    {
+        $data = $request->validated();
+
+        if (!empty($data['no_telpon']) && empty($data['no_telp'])) {
+            $data['no_telp'] = $data['no_telpon'];
+        }
+
+        unset($data['no_telpon']);
+
+        $kacab->fill($data);
+        $kacab->save();
+
+        return new KacabResource($kacab->fresh());
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Kacab $kacab): JsonResponse
+    {
+        $kacab->delete();
+
+        return response()->json([
+            'message' => 'Kepala cabang berhasil dihapus.',
+        ]);
+    }
+}

--- a/backend/app/Http/Requests/Kacab/StoreKacabRequest.php
+++ b/backend/app/Http/Requests/Kacab/StoreKacabRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests\Kacab;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreKacabRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        if ($this->filled('no_telpon') && !$this->filled('no_telp')) {
+            $this->merge([
+                'no_telp' => $this->input('no_telpon'),
+            ]);
+        }
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'nama_kacab' => ['required', 'string', 'max:255'],
+            'no_telp' => ['required_without:no_telpon', 'nullable', 'string', 'max:25'],
+            'no_telpon' => ['required_without:no_telp', 'nullable', 'string', 'max:25'],
+            'alamat' => ['required', 'string'],
+            'email' => ['nullable', 'email', 'max:255'],
+            'status' => ['required', 'string', 'max:50'],
+            'id_prov' => ['nullable', 'integer'],
+            'id_kab' => ['nullable', 'integer'],
+            'id_kec' => ['nullable', 'integer'],
+            'id_kel' => ['nullable', 'integer'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/Kacab/UpdateKacabRequest.php
+++ b/backend/app/Http/Requests/Kacab/UpdateKacabRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests\Kacab;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateKacabRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        if ($this->filled('no_telpon') && !$this->filled('no_telp')) {
+            $this->merge([
+                'no_telp' => $this->input('no_telpon'),
+            ]);
+        }
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'nama_kacab' => ['required', 'string', 'max:255'],
+            'no_telp' => ['required_without:no_telpon', 'nullable', 'string', 'max:25'],
+            'no_telpon' => ['required_without:no_telp', 'nullable', 'string', 'max:25'],
+            'alamat' => ['required', 'string'],
+            'email' => ['nullable', 'email', 'max:255'],
+            'status' => ['required', 'string', 'max:50'],
+            'id_prov' => ['nullable', 'integer'],
+            'id_kab' => ['nullable', 'integer'],
+            'id_kec' => ['nullable', 'integer'],
+            'id_kel' => ['nullable', 'integer'],
+        ];
+    }
+}

--- a/backend/app/Http/Resources/KacabResource.php
+++ b/backend/app/Http/Resources/KacabResource.php
@@ -24,13 +24,23 @@ class KacabResource extends JsonResource
     public function toArray($request)
     {
         return [
-            'id_kacab'    => $this->id_kacab,
+            'id_kacab' => $this->id_kacab,
+            'nama_kacab' => $this->nama_kacab,
             'nama_cabang' => $this->nama_cabang
                 ?? $this->nama
                 ?? $this->nama_kacab
                 ?? null,
-            'created_at'  => optional($this->created_at)->toISOString(),
-            'updated_at'  => optional($this->updated_at)->toISOString(),
+            'no_telp' => $this->no_telp,
+            'no_telpon' => $this->no_telpon ?? $this->no_telp,
+            'alamat' => $this->alamat,
+            'email' => $this->email,
+            'status' => $this->status,
+            'id_prov' => $this->id_prov,
+            'id_kab' => $this->id_kab,
+            'id_kec' => $this->id_kec,
+            'id_kel' => $this->id_kel,
+            'created_at' => optional($this->created_at)->toISOString(),
+            'updated_at' => optional($this->updated_at)->toISOString(),
         ];
     }
 }

--- a/backend/app/Models/Kacab.php
+++ b/backend/app/Models/Kacab.php
@@ -17,13 +17,14 @@ class Kacab extends Model
     protected $keyType = 'int';
 
     protected $fillable = [
-        'nama_kacab', 
-        'no_telp', 
-        'alamat', 
+        'nama_kacab',
+        'no_telp',
+        'alamat',
         'email',
-        'id_prov', 
-        'id_kab', 
-        'id_kec', 
+        'status',
+        'id_prov',
+        'id_kab',
+        'id_kec',
         'id_kel'
     ];
 

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -21,9 +21,13 @@ Route::middleware('role:admin_pusat')->prefix('admin-pusat')->group(function () 
         Route::put('users/{id}', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'update']);
 
         // Dropdown berjenjang
-        Route::get('kacab', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'listKacab']);
-        Route::get('kacab/{id}/wilbin', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'listWilbinByKacab']);
-        Route::get('wilbin/{id}/shelter', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'listShelterByWilbin']);
+        Route::prefix('dropdowns')->group(function () {
+            Route::get('kacab', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'listKacab']);
+            Route::get('kacab/{id}/wilbin', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'listWilbinByKacab']);
+            Route::get('wilbin/{id}/shelter', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'listShelterByWilbin']);
+        });
+
+        Route::apiResource('kacab', App\Http\Controllers\API\AdminPusat\KacabController::class);
  Route::get('/tutor-honor-settings', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'index']);
     Route::get('/tutor-honor-settings/active', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'getActiveSetting']);
     Route::post('/tutor-honor-settings', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'store']);


### PR DESCRIPTION
## Summary
- add an admin pusat Kacab API controller with CRUD endpoints backed by dedicated form requests
- expand the Kacab resource/model to expose the fields needed for Postman testing
- register the new apiResource routes while moving the dropdown helpers under a non-conflicting prefix

## Testing
- php artisan test *(fails: Could not open input file: artisan)*

------
https://chatgpt.com/codex/tasks/task_e_68ced3a858f4832382f8cf7747f01388