### PR TITLE
Ensure Kacab status can be persisted

### DIFF
--- a/backend/app/Http/Requests/KacabRequest.php
+++ b/backend/app/Http/Requests/KacabRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class KacabRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $rules = [
+            'nama_kacab' => ['required', 'string', 'max:255'],
+            'alamat' => ['nullable', 'string', 'max:500'],
+            'email' => ['nullable', 'email', 'max:255'],
+            'no_telp' => ['nullable', 'string', 'max:20'],
+            'no_telpon' => ['nullable', 'string', 'max:20'],
+            'id_prov' => ['nullable', 'integer', 'exists:provinsi,id_prov'],
+            'id_kab' => ['nullable', 'integer', 'exists:kabupaten,id_kab'],
+            'id_kec' => ['nullable', 'integer', 'exists:kecamatan,id_kec'],
+            'id_kel' => ['nullable', 'integer', 'exists:kelurahan,id_kel'],
+            'status' => ['required', 'in:aktif,nonaktif'],
+        ];
+
+        if ($this->isMethod('put') || $this->isMethod('patch')) {
+            foreach ($rules as $attribute => $rule) {
+                $rules[$attribute] = array_merge(['sometimes'], $rule);
+            }
+        }
+
+        return $rules;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->isMethod('post') && !$this->filled('status')) {
+            $this->merge(['status' => 'aktif']);
+        }
+
+        if ($this->missing('no_telp') && $this->filled('no_telpon')) {
+            $this->merge(['no_telp' => $this->input('no_telpon')]);
+        }
+
+        if ($this->missing('no_telpon') && $this->filled('no_telp')) {
+            $this->merge(['no_telpon' => $this->input('no_telp')]);
+        }
+    }
+}

--- a/backend/app/Models/Kacab.php
+++ b/backend/app/Models/Kacab.php
@@ -17,14 +17,16 @@ class Kacab extends Model
     protected $keyType = 'int';
 
     protected $fillable = [
-        'nama_kacab', 
-        'no_telp', 
-        'alamat', 
+        'nama_kacab',
+        'no_telp',
+        'no_telpon',
+        'alamat',
         'email',
-        'id_prov', 
-        'id_kab', 
-        'id_kec', 
-        'id_kel'
+        'id_prov',
+        'id_kab',
+        'id_kec',
+        'id_kel',
+        'status'
     ];
 
     protected $casts = [


### PR DESCRIPTION
## Summary
- add the missing `status` and `no_telpon` attributes to the Kacab model's fillable list
- introduce a dedicated `KacabRequest` that validates the same fields and defaults the status to `aktif` for new records
- mirror the legacy `no_telp`/`no_telpon` inputs during validation so controllers can safely mass assign either key

## Testing
- ./vendor/bin/phpunit *(fails: vendor directory not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ced3a8a45883238e4b0f967cdb4ca6