### PR TITLE
Allow kacab model to mass assign both phone fields

### DIFF
--- a/backend/app/Models/Kacab.php
+++ b/backend/app/Models/Kacab.php
@@ -19,6 +19,7 @@ class Kacab extends Model
     protected $fillable = [
         'nama_kacab',
         'no_telp',
+        'no_telpon',
         'alamat',
         'email',
         'status',


### PR DESCRIPTION
## Summary
- allow the Kacab model to mass assign both `no_telp` and `no_telpon` values by adding the missing column to the `$fillable` list

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ced77cc7c483238c179be9e5a4cd16