### PR TITLE
Ensure kacab phone fields synchronize

### DIFF
--- a/backend/app/Http/Controllers/API/AdminPusat/KacabController.php
+++ b/backend/app/Http/Controllers/API/AdminPusat/KacabController.php
@@ -33,9 +33,9 @@ class KacabController extends Controller
 
         if (!empty($data['no_telpon']) && empty($data['no_telp'])) {
             $data['no_telp'] = $data['no_telpon'];
+        } elseif (!empty($data['no_telp']) && empty($data['no_telpon'])) {
+            $data['no_telpon'] = $data['no_telp'];
         }
-
-        unset($data['no_telpon']);
 
         $kacab = Kacab::create($data);
 
@@ -61,9 +61,9 @@ class KacabController extends Controller
 
         if (!empty($data['no_telpon']) && empty($data['no_telp'])) {
             $data['no_telp'] = $data['no_telpon'];
+        } elseif (!empty($data['no_telp']) && empty($data['no_telpon'])) {
+            $data['no_telpon'] = $data['no_telp'];
         }
-
-        unset($data['no_telpon']);
 
         $kacab->fill($data);
         $kacab->save();

--- a/backend/app/Http/Requests/Kacab/StoreKacabRequest.php
+++ b/backend/app/Http/Requests/Kacab/StoreKacabRequest.php
@@ -24,6 +24,12 @@ class StoreKacabRequest extends FormRequest
                 'no_telp' => $this->input('no_telpon'),
             ]);
         }
+
+        if ($this->filled('no_telp') && !$this->filled('no_telpon')) {
+            $this->merge([
+                'no_telpon' => $this->input('no_telp'),
+            ]);
+        }
     }
 
     /**

--- a/backend/app/Http/Requests/Kacab/UpdateKacabRequest.php
+++ b/backend/app/Http/Requests/Kacab/UpdateKacabRequest.php
@@ -24,6 +24,12 @@ class UpdateKacabRequest extends FormRequest
                 'no_telp' => $this->input('no_telpon'),
             ]);
         }
+
+        if ($this->filled('no_telp') && !$this->filled('no_telpon')) {
+            $this->merge([
+                'no_telpon' => $this->input('no_telp'),
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- mirror phone number fields in KacabController so both column names are populated before persistence
- update Kacab store and update requests to backfill the alternate phone field during validation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cedafcf0848323bbae43c5711bb82e