### PR TITLE
Restrict kacab status values

### DIFF
--- a/backend/app/Http/Requests/Kacab/StoreKacabRequest.php
+++ b/backend/app/Http/Requests/Kacab/StoreKacabRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Kacab;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreKacabRequest extends FormRequest
 {
@@ -30,6 +31,12 @@ class StoreKacabRequest extends FormRequest
                 'no_telpon' => $this->input('no_telp'),
             ]);
         }
+
+        if (!$this->filled('status')) {
+            $this->merge([
+                'status' => 'aktif',
+            ]);
+        }
     }
 
     /**
@@ -45,7 +52,7 @@ class StoreKacabRequest extends FormRequest
             'no_telpon' => ['required_without:no_telp', 'nullable', 'string', 'max:25'],
             'alamat' => ['required', 'string'],
             'email' => ['nullable', 'email', 'max:255'],
-            'status' => ['required', 'string', 'max:50'],
+            'status' => ['required', Rule::in(['aktif', 'nonaktif'])],
             'id_prov' => ['nullable', 'string', 'max:10'],
             'id_kab' => ['nullable', 'string', 'max:10'],
             'id_kec' => ['nullable', 'string', 'max:10'],

--- a/backend/app/Http/Requests/Kacab/UpdateKacabRequest.php
+++ b/backend/app/Http/Requests/Kacab/UpdateKacabRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Kacab;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateKacabRequest extends FormRequest
 {
@@ -45,7 +46,7 @@ class UpdateKacabRequest extends FormRequest
             'no_telpon' => ['required_without:no_telp', 'nullable', 'string', 'max:25'],
             'alamat' => ['required', 'string'],
             'email' => ['nullable', 'email', 'max:255'],
-            'status' => ['required', 'string', 'max:50'],
+            'status' => ['required', Rule::in(['aktif', 'nonaktif'])],
             'id_prov' => ['nullable', 'string', 'max:10'],
             'id_kab' => ['nullable', 'string', 'max:10'],
             'id_kec' => ['nullable', 'string', 'max:10'],


### PR DESCRIPTION
## Summary
- limit kacab request status validation to the allowed aktif and nonaktif values
- default missing create request statuses to aktif so clients can omit the field

## Testing
- composer install *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cf78da1b708323a483c09e008b1f3f