### PR TITLE
Add Admin Pusat Kantor Cabang CRUD

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -11,74 +11,76 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::middleware('role:admin_pusat')->group(function () {
         Route::apiResource('kacab', App\Http\Controllers\API\KacabController::class);
+
+        Route::prefix('admin-pusat')->as('admin-pusat.')->group(function () {
+            // Dashboard (tetap di AdminPusatController)
+            Route::get('dashboard', [App\Http\Controllers\API\AdminPusatController::class, 'dashboard']);
+
+            // User Management + Dropdown (dipindah ke AdminPusatUserController)
+            Route::get('users', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'index']);
+            Route::get('users/{id}', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'show']);
+            Route::post('create-user', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'store']);
+            Route::put('users/{id}', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'update']);
+
+            // Dropdown berjenjang
+            Route::prefix('dropdowns')->group(function () {
+                Route::get('kacab', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'listKacab']);
+                Route::get('kacab/{id}/wilbin', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'listWilbinByKacab']);
+                Route::get('wilbin/{id}/shelter', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'listShelterByWilbin']);
+            });
+
+            Route::apiResource('kacab', App\Http\Controllers\API\AdminPusat\KacabController::class);
+
+            Route::get('/tutor-honor-settings', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'index']);
+            Route::get('/tutor-honor-settings/active', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'getActiveSetting']);
+            Route::post('/tutor-honor-settings', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'store']);
+            Route::get('/tutor-honor-settings/{id}', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'show']);
+            Route::put('/tutor-honor-settings/{id}', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'update']);
+            Route::post('/tutor-honor-settings/{id}/set-active', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'setActive']);
+            Route::delete('/tutor-honor-settings/{id}', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'destroy']);
+            Route::post('/tutor-honor-settings/calculate-preview', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'calculatePreview']);
+            Route::get('/tutor-honor-settings-statistics', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'getStatistics']);
+
+            // Admin Pusat Template Management Routes
+            Route::prefix('template-kurikulum')->group(function () {
+                // Hierarchy & Navigation
+                Route::get('/struktur', [App\Http\Controllers\API\AdminPusat\HierarchyController::class, 'getStruktur']);
+                Route::get('/kelas/{jenjang}', [App\Http\Controllers\API\AdminPusat\HierarchyController::class, 'getKelas']);
+                Route::get('/mata-pelajaran/{kelas}', [App\Http\Controllers\API\AdminPusat\HierarchyController::class, 'getMataPelajaran']);
+                Route::get('/mata-pelajaran-stats/{mataPelajaran}/{kelas}', [App\Http\Controllers\API\AdminPusat\HierarchyController::class, 'getTemplateStats']);
+                Route::post('/clear-cache', [App\Http\Controllers\API\AdminPusat\HierarchyController::class, 'clearCache']);
+            });
+
+            // Template CRUD - Specific routes MUST come before apiResource
+            Route::post('/template-materi/{template}/activate', [App\Http\Controllers\API\AdminPusat\TemplateKurikulumController::class, 'activate']);
+            Route::post('/template-materi/{template}/deactivate', [App\Http\Controllers\API\AdminPusat\TemplateKurikulumController::class, 'deactivate']);
+            Route::post('/template-materi/{template}/duplicate', [App\Http\Controllers\API\AdminPusat\TemplateKurikulumController::class, 'duplicate']);
+            Route::get('/template-materi/by-mapel/{mataPelajaran}/{kelas}', [App\Http\Controllers\API\AdminPusat\TemplateKurikulumController::class, 'getByMataPelajaran']);
+            Route::apiResource('template-materi', App\Http\Controllers\API\AdminPusat\TemplateKurikulumController::class);
+
+            // Distribution Management
+            Route::prefix('distribution')->group(function () {
+                Route::get('/cabang', [App\Http\Controllers\API\AdminPusat\DistributionController::class, 'getAvailableCabang']);
+                Route::post('/template/{template}', [App\Http\Controllers\API\AdminPusat\DistributionController::class, 'distributeTemplate']);
+                Route::post('/bulk', [App\Http\Controllers\API\AdminPusat\DistributionController::class, 'bulkDistribute']);
+                Route::get('/history/{template}', [App\Http\Controllers\API\AdminPusat\DistributionController::class, 'getDistributionHistory']);
+                Route::get('/summary', [App\Http\Controllers\API\AdminPusat\DistributionController::class, 'getDistributionSummary']);
+                Route::delete('/cancel/{adoption}', [App\Http\Controllers\API\AdminPusat\DistributionController::class, 'cancelDistribution']);
+            });
+
+            // Monitoring & Analytics
+            Route::prefix('monitoring')->group(function () {
+                Route::get('/dashboard', [App\Http\Controllers\API\AdminPusat\MonitoringController::class, 'getDashboardStats']);
+                Route::get('/cabang-adoption', [App\Http\Controllers\API\AdminPusat\MonitoringController::class, 'getCabangAdoptionRates']);
+                Route::get('/template-performance', [App\Http\Controllers\API\AdminPusat\MonitoringController::class, 'getTemplatePerformance']);
+                Route::get('/adoption-trends', [App\Http\Controllers\API\AdminPusat\MonitoringController::class, 'getAdoptionTrends']);
+                Route::get('/cabang/{kacab}', [App\Http\Controllers\API\AdminPusat\MonitoringController::class, 'getCabangDetails']);
+                Route::get('/template/{template}/usage', [App\Http\Controllers\API\AdminPusat\MonitoringController::class, 'getTemplateUsageStats']);
+                Route::get('/export-report', [App\Http\Controllers\API\AdminPusat\MonitoringController::class, 'exportAdoptionReport']);
+            });
+        });
     });
 
-    Route::middleware('role:admin_pusat')->prefix('admin-pusat')->group(function () {
-    // Dashboard (tetap di AdminPusatController)
-        Route::get('dashboard', [App\Http\Controllers\API\AdminPusatController::class, 'dashboard']); 
-
-        // User Management + Dropdown (dipindah ke AdminPusatUserController)
-        Route::get('users', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'index']);
-        Route::get('users/{id}', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'show']);
-        Route::post('create-user', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'store']);
-        Route::put('users/{id}', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'update']);
-
-        // Dropdown berjenjang
-        Route::prefix('dropdowns')->group(function () {
-            Route::get('kacab', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'listKacab']);
-            Route::get('kacab/{id}/wilbin', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'listWilbinByKacab']);
-            Route::get('wilbin/{id}/shelter', [App\Http\Controllers\API\AdminPusat\AdminPusatUserController::class, 'listShelterByWilbin']);
-        });
-
-        Route::apiResource('kacab', App\Http\Controllers\API\AdminPusat\KacabController::class);
- Route::get('/tutor-honor-settings', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'index']);
-    Route::get('/tutor-honor-settings/active', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'getActiveSetting']);
-    Route::post('/tutor-honor-settings', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'store']);
-    Route::get('/tutor-honor-settings/{id}', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'show']);
-    Route::put('/tutor-honor-settings/{id}', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'update']);
-    Route::post('/tutor-honor-settings/{id}/set-active', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'setActive']);
-    Route::delete('/tutor-honor-settings/{id}', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'destroy']);
-    Route::post('/tutor-honor-settings/calculate-preview', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'calculatePreview']);
-    Route::get('/tutor-honor-settings-statistics', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'getStatistics']);
-        // Admin Pusat Template Management Routes
-        Route::prefix('template-kurikulum')->group(function () {
-            // Hierarchy & Navigation
-            Route::get('/struktur', [App\Http\Controllers\API\AdminPusat\HierarchyController::class, 'getStruktur']);
-            Route::get('/kelas/{jenjang}', [App\Http\Controllers\API\AdminPusat\HierarchyController::class, 'getKelas']);
-            Route::get('/mata-pelajaran/{kelas}', [App\Http\Controllers\API\AdminPusat\HierarchyController::class, 'getMataPelajaran']);
-            Route::get('/mata-pelajaran-stats/{mataPelajaran}/{kelas}', [App\Http\Controllers\API\AdminPusat\HierarchyController::class, 'getTemplateStats']);
-            Route::post('/clear-cache', [App\Http\Controllers\API\AdminPusat\HierarchyController::class, 'clearCache']);
-        });
-
-        // Template CRUD - Specific routes MUST come before apiResource
-        Route::post('/template-materi/{template}/activate', [App\Http\Controllers\API\AdminPusat\TemplateKurikulumController::class, 'activate']);
-        Route::post('/template-materi/{template}/deactivate', [App\Http\Controllers\API\AdminPusat\TemplateKurikulumController::class, 'deactivate']);
-        Route::post('/template-materi/{template}/duplicate', [App\Http\Controllers\API\AdminPusat\TemplateKurikulumController::class, 'duplicate']);
-        Route::get('/template-materi/by-mapel/{mataPelajaran}/{kelas}', [App\Http\Controllers\API\AdminPusat\TemplateKurikulumController::class, 'getByMataPelajaran']);
-        Route::apiResource('template-materi', App\Http\Controllers\API\AdminPusat\TemplateKurikulumController::class);
-
-        // Distribution Management
-        Route::prefix('distribution')->group(function () {
-            Route::get('/cabang', [App\Http\Controllers\API\AdminPusat\DistributionController::class, 'getAvailableCabang']);
-            Route::post('/template/{template}', [App\Http\Controllers\API\AdminPusat\DistributionController::class, 'distributeTemplate']);
-            Route::post('/bulk', [App\Http\Controllers\API\AdminPusat\DistributionController::class, 'bulkDistribute']);
-            Route::get('/history/{template}', [App\Http\Controllers\API\AdminPusat\DistributionController::class, 'getDistributionHistory']);
-            Route::get('/summary', [App\Http\Controllers\API\AdminPusat\DistributionController::class, 'getDistributionSummary']);
-            Route::delete('/cancel/{adoption}', [App\Http\Controllers\API\AdminPusat\DistributionController::class, 'cancelDistribution']);
-        });
-
-        // Monitoring & Analytics
-        Route::prefix('monitoring')->group(function () {
-            Route::get('/dashboard', [App\Http\Controllers\API\AdminPusat\MonitoringController::class, 'getDashboardStats']);
-            Route::get('/cabang-adoption', [App\Http\Controllers\API\AdminPusat\MonitoringController::class, 'getCabangAdoptionRates']);
-            Route::get('/template-performance', [App\Http\Controllers\API\AdminPusat\MonitoringController::class, 'getTemplatePerformance']);
-            Route::get('/adoption-trends', [App\Http\Controllers\API\AdminPusat\MonitoringController::class, 'getAdoptionTrends']);
-            Route::get('/cabang/{kacab}', [App\Http\Controllers\API\AdminPusat\MonitoringController::class, 'getCabangDetails']);
-            Route::get('/template/{template}/usage', [App\Http\Controllers\API\AdminPusat\MonitoringController::class, 'getTemplateUsageStats']);
-            Route::get('/export-report', [App\Http\Controllers\API\AdminPusat\MonitoringController::class, 'exportAdoptionReport']);
-        });
-    });
-    
 // REFACTORED: Admin Cabang routes with cleaner patterns
     Route::middleware('role:admin_cabang')->prefix('admin-cabang')->group(function () {
             // Dashboard & Profile

--- a/frontend/src/constants/endpoints.js
+++ b/frontend/src/constants/endpoints.js
@@ -374,8 +374,8 @@ export const MANAGEMENT_ENDPOINTS = {
   USERS: '/users',
   USER_DETAIL: (id) => `/users/${id}`,
   
-  KACAB: '/kacab',
-  KACAB_DETAIL: (id) => `/kacab/${id}`,
+  KACAB: '/admin-pusat/kacab',
+  KACAB_DETAIL: (id) => `/admin-pusat/kacab/${id}`,
   
   WILBIN: '/wilbin',
   WILBIN_DETAIL: (id) => `/wilbin/${id}`,

--- a/frontend/src/features/adminPusat/api/adminPusatApi.js
+++ b/frontend/src/features/adminPusat/api/adminPusatApi.js
@@ -105,11 +105,7 @@ export const adminPusatApi = {
    * @returns {Promise} - API response
    */
   createKacab: async (kacabData) => {
-    return await api.post(MANAGEMENT_ENDPOINTS.KACAB, kacabData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
+    return await api.post(MANAGEMENT_ENDPOINTS.KACAB, kacabData);
   },
 
   /**
@@ -119,11 +115,7 @@ export const adminPusatApi = {
    * @returns {Promise} - API response
    */
   updateKacab: async (kacabId, kacabData) => {
-    return await api.post(MANAGEMENT_ENDPOINTS.KACAB_DETAIL(kacabId), kacabData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
+    return await api.put(MANAGEMENT_ENDPOINTS.KACAB_DETAIL(kacabId), kacabData);
   },
 
   /**

--- a/frontend/src/features/adminPusat/screens/DataWilayahScreen.js
+++ b/frontend/src/features/adminPusat/screens/DataWilayahScreen.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Alert } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
 
 const menuItems = [
   {
@@ -27,6 +28,17 @@ const menuItems = [
 ];
 
 const DataWilayahScreen = () => {
+  const navigation = useNavigation();
+
+  const handlePress = (itemId) => {
+    if (itemId === 'kantor-cabang') {
+      navigation.navigate('KacabList');
+      return;
+    }
+
+    Alert.alert('Segera Hadir', 'Fitur ini akan tersedia pada pembaruan berikutnya.');
+  };
+
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.contentContainer}>
       <Text style={styles.title}>Data Wilayah</Text>
@@ -36,7 +48,12 @@ const DataWilayahScreen = () => {
 
       <View style={styles.menuList}>
         {menuItems.map((item) => (
-          <TouchableOpacity key={item.id} style={styles.menuCard} activeOpacity={0.8}>
+          <TouchableOpacity
+            key={item.id}
+            style={styles.menuCard}
+            activeOpacity={0.8}
+            onPress={() => handlePress(item.id)}
+          >
             <View style={[styles.iconContainer, { backgroundColor: item.color }]}>
               <Ionicons name={item.icon} size={28} color="#fff" />
             </View>

--- a/frontend/src/features/adminPusat/screens/kacab/KacabDetailScreen.js
+++ b/frontend/src/features/adminPusat/screens/kacab/KacabDetailScreen.js
@@ -1,0 +1,312 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  RefreshControl,
+  ActivityIndicator,
+  TouchableOpacity,
+  Alert,
+} from 'react-native';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
+import { adminPusatApi } from '../../api/adminPusatApi';
+
+const statusStyles = {
+  aktif: {
+    container: { backgroundColor: '#eafaf1' },
+    text: { color: '#27ae60' },
+  },
+  nonaktif: {
+    container: { backgroundColor: '#fdecea' },
+    text: { color: '#e74c3c' },
+  },
+};
+
+const formatDateTime = (value) => {
+  if (!value) {
+    return '-';
+  }
+
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return String(value);
+    }
+    return date.toLocaleString();
+  } catch (error) {
+    return String(value);
+  }
+};
+
+const DetailRow = ({ icon, label, value }) => (
+  <View style={styles.detailRow}>
+    <View style={styles.detailLabelWrapper}>
+      <Ionicons name={icon} size={18} color="#7f8c8d" style={styles.detailIcon} />
+      <Text style={styles.detailLabel}>{label}</Text>
+    </View>
+    <Text style={styles.detailValue}>{value ?? '-'}</Text>
+  </View>
+);
+
+const KacabDetailScreen = () => {
+  const navigation = useNavigation();
+  const route = useRoute();
+  const idKacab = route.params?.idKacab;
+
+  const [detail, setDetail] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+
+  const fetchDetail = useCallback(
+    async (options = {}) => {
+      const { silent = false } = options;
+
+      if (!idKacab) {
+        setError('ID kantor cabang tidak ditemukan.');
+        setLoading(false);
+        return;
+      }
+
+      try {
+        setError('');
+        if (!silent) {
+          setLoading(true);
+        }
+
+        const response = await adminPusatApi.getKacabDetail(idKacab);
+        const payload = response?.data ?? null;
+        const data = payload?.data ?? payload ?? null;
+        setDetail(data);
+      } catch (err) {
+        const message = err?.response?.data?.message || err?.message || 'Gagal memuat detail kantor cabang';
+        setError(String(message));
+      } finally {
+        if (!silent) {
+          setLoading(false);
+        }
+        setRefreshing(false);
+      }
+    },
+    [idKacab]
+  );
+
+  useEffect(() => {
+    fetchDetail();
+  }, [fetchDetail]);
+
+  const onRefresh = () => {
+    setRefreshing(true);
+    fetchDetail({ silent: true });
+  };
+
+  const goToEdit = () => {
+    if (!idKacab) {
+      Alert.alert('Tidak bisa mengedit', 'ID kantor cabang tidak ditemukan.');
+      return;
+    }
+    navigation.navigate('KacabForm', { mode: 'edit', idKacab });
+  };
+
+  const statusKey = String(detail?.status || '').toLowerCase();
+  const statusStyle = statusStyles[statusKey] || {
+    container: { backgroundColor: '#ecf0f1' },
+    text: { color: '#7f8c8d' },
+  };
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.contentContainer}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+    >
+      <View style={styles.headerCard}>
+        <View style={styles.headerContent}>
+          <View style={styles.headerIcon}>
+            <Ionicons name="business" size={26} color="#fff" />
+          </View>
+          <View style={{ flex: 1 }}>
+            <Text style={styles.headerTitle}>{detail?.nama_kacab || 'Kantor Cabang'}</Text>
+            <Text style={styles.headerSubtitle}>{detail?.alamat || 'Alamat belum tersedia'}</Text>
+          </View>
+          <View style={[styles.statusBadge, statusStyle.container]}>
+            <Text style={[styles.statusText, statusStyle.text]}>
+              {(detail?.status || 'UNKNOWN').toString().toUpperCase()}
+            </Text>
+          </View>
+        </View>
+        <TouchableOpacity style={styles.editButton} onPress={goToEdit}>
+          <Ionicons name="create-outline" size={18} color="#fff" />
+          <Text style={styles.editButtonText}>Edit</Text>
+        </TouchableOpacity>
+      </View>
+
+      {loading ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color="#3498db" />
+        </View>
+      ) : error ? (
+        <View style={styles.errorBox}>
+          <Ionicons name="alert-circle" size={20} color="#e74c3c" />
+          <Text style={styles.errorText}>{error}</Text>
+          <TouchableOpacity style={styles.retryButton} onPress={() => fetchDetail()}>
+            <Text style={styles.retryText}>Coba Lagi</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <View style={styles.detailCard}>
+          <Text style={styles.sectionTitle}>Informasi Kontak</Text>
+          <DetailRow icon="call-outline" label="Nomor Telepon" value={detail?.no_telp || detail?.no_telpon || '-'} />
+          <DetailRow icon="call" label="No. Telpon (Legacy)" value={detail?.no_telpon || detail?.no_telp || '-'} />
+          <DetailRow icon="mail-outline" label="Email" value={detail?.email || '-'} />
+
+          <Text style={styles.sectionTitle}>Informasi Wilayah</Text>
+          <DetailRow icon="flag-outline" label="Kode Provinsi" value={detail?.id_prov || '-'} />
+          <DetailRow icon="business-outline" label="Kode Kabupaten" value={detail?.id_kab || '-'} />
+          <DetailRow icon="map-outline" label="Kode Kecamatan" value={detail?.id_kec || '-'} />
+          <DetailRow icon="location-outline" label="Kode Kelurahan" value={detail?.id_kel || '-'} />
+
+          <Text style={styles.sectionTitle}>Status & Audit</Text>
+          <DetailRow icon="time-outline" label="Dibuat" value={formatDateTime(detail?.created_at)} />
+          <DetailRow icon="refresh" label="Terakhir Diperbarui" value={formatDateTime(detail?.updated_at)} />
+        </View>
+      )}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f6fa',
+  },
+  contentContainer: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  headerCard: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  headerContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  headerIcon: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: '#3498db',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#2c3e50',
+  },
+  headerSubtitle: {
+    marginTop: 4,
+    fontSize: 13,
+    color: '#7f8c8d',
+  },
+  statusBadge: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 18,
+  },
+  statusText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  editButton: {
+    marginTop: 16,
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    backgroundColor: '#2980b9',
+    borderRadius: 8,
+  },
+  editButtonText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  loadingContainer: {
+    marginTop: 60,
+    alignItems: 'center',
+  },
+  errorBox: {
+    backgroundColor: '#fdecea',
+    borderRadius: 12,
+    padding: 16,
+    alignItems: 'flex-start',
+    gap: 8,
+  },
+  errorText: {
+    color: '#c0392b',
+  },
+  retryButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    backgroundColor: '#e74c3c',
+    borderRadius: 8,
+  },
+  retryText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  detailCard: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    gap: 12,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  sectionTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#2c3e50',
+    marginTop: 8,
+  },
+  detailRow: {
+    marginTop: 8,
+  },
+  detailLabelWrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginBottom: 4,
+  },
+  detailIcon: {
+    width: 20,
+  },
+  detailLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#34495e',
+  },
+  detailValue: {
+    fontSize: 14,
+    color: '#2c3e50',
+    lineHeight: 20,
+  },
+});
+
+export default KacabDetailScreen;

--- a/frontend/src/features/adminPusat/screens/kacab/KacabFormScreen.js
+++ b/frontend/src/features/adminPusat/screens/kacab/KacabFormScreen.js
@@ -1,0 +1,439 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  ActivityIndicator,
+} from 'react-native';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
+import { adminPusatApi } from '../../api/adminPusatApi';
+
+const statusOptions = [
+  { key: 'aktif', label: 'Aktif' },
+  { key: 'nonaktif', label: 'Nonaktif' },
+];
+
+const initialForm = {
+  nama_kacab: '',
+  no_telp: '',
+  no_telpon: '',
+  alamat: '',
+  email: '',
+  status: 'aktif',
+  id_prov: '',
+  id_kab: '',
+  id_kec: '',
+  id_kel: '',
+};
+
+const KacabFormScreen = () => {
+  const navigation = useNavigation();
+  const route = useRoute();
+  const mode = route.params?.mode ?? 'create';
+  const idKacab = route.params?.idKacab ?? null;
+
+  const [form, setForm] = useState(initialForm);
+  const [loading, setLoading] = useState(mode === 'edit');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  const updateField = (key, value) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const fetchDetail = useCallback(async () => {
+    if (mode !== 'edit' || !idKacab) {
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError('');
+      const response = await adminPusatApi.getKacabDetail(idKacab);
+      const payload = response?.data ?? null;
+      const data = payload?.data ?? payload ?? {};
+
+      setForm({
+        nama_kacab: data?.nama_kacab ?? '',
+        no_telp: data?.no_telp ?? data?.no_telpon ?? '',
+        no_telpon: data?.no_telpon ?? data?.no_telp ?? '',
+        alamat: data?.alamat ?? '',
+        email: data?.email ?? '',
+        status: data?.status ?? 'aktif',
+        id_prov: data?.id_prov ?? '',
+        id_kab: data?.id_kab ?? '',
+        id_kec: data?.id_kec ?? '',
+        id_kel: data?.id_kel ?? '',
+      });
+    } catch (err) {
+      const message = err?.response?.data?.message || err?.message || 'Gagal memuat data kantor cabang';
+      setError(String(message));
+      Alert.alert('Error', String(message));
+    } finally {
+      setLoading(false);
+    }
+  }, [idKacab, mode]);
+
+  useEffect(() => {
+    fetchDetail();
+  }, [fetchDetail]);
+
+  const handleSubmit = async () => {
+    const nama = form.nama_kacab.trim();
+    const alamat = form.alamat.trim();
+    const phonePrimary = form.no_telp.trim();
+    const phoneLegacy = form.no_telpon.trim();
+
+    if (!nama) {
+      Alert.alert('Validasi', 'Nama kantor cabang wajib diisi.');
+      return;
+    }
+
+    if (!alamat) {
+      Alert.alert('Validasi', 'Alamat kantor cabang wajib diisi.');
+      return;
+    }
+
+    if (!phonePrimary && !phoneLegacy) {
+      Alert.alert('Validasi', 'Minimal salah satu nomor telepon harus diisi.');
+      return;
+    }
+
+    const payload = {
+      nama_kacab: nama,
+      alamat,
+      email: form.email.trim() || null,
+      status: form.status || 'aktif',
+      no_telp: phonePrimary || phoneLegacy,
+      no_telpon: phoneLegacy || phonePrimary,
+      id_prov: form.id_prov.trim() || null,
+      id_kab: form.id_kab.trim() || null,
+      id_kec: form.id_kec.trim() || null,
+      id_kel: form.id_kel.trim() || null,
+    };
+
+    try {
+      setSubmitting(true);
+      setError('');
+      if (mode === 'edit' && idKacab) {
+        await adminPusatApi.updateKacab(idKacab, payload);
+        Alert.alert('Berhasil', 'Kantor cabang berhasil diperbarui.', [
+          { text: 'OK', onPress: () => navigation.goBack() },
+        ]);
+      } else {
+        await adminPusatApi.createKacab(payload);
+        Alert.alert('Berhasil', 'Kantor cabang berhasil dibuat.', [
+          { text: 'OK', onPress: () => navigation.goBack() },
+        ]);
+      }
+    } catch (err) {
+      const message = err?.response?.data?.message || err?.message || 'Gagal menyimpan kantor cabang';
+      setError(String(message));
+      Alert.alert('Error', String(message));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.contentContainer}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.headerRow}>
+          <View>
+            <Text style={styles.title}>
+              {mode === 'edit' ? 'Edit Kantor Cabang' : 'Tambah Kantor Cabang'}
+            </Text>
+            <Text style={styles.subtitle}>
+              Isi informasi kantor cabang secara lengkap.
+            </Text>
+          </View>
+          <Ionicons name="business" size={28} color="#2980b9" />
+        </View>
+
+        {loading ? (
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator size="large" color="#3498db" />
+          </View>
+        ) : (
+          <View style={styles.formCard}>
+            {error ? <Text style={styles.errorText}>{error}</Text> : null}
+
+            <Text style={styles.sectionTitle}>Informasi Utama</Text>
+            <View style={styles.formGroup}>
+              <Text style={styles.label}>Nama Kantor Cabang *</Text>
+              <TextInput
+                style={styles.input}
+                value={form.nama_kacab}
+                onChangeText={(text) => updateField('nama_kacab', text)}
+                placeholder="Contoh: Kantor Cabang Jakarta"
+              />
+            </View>
+
+            <View style={styles.formGroup}>
+              <Text style={styles.label}>Alamat *</Text>
+              <TextInput
+                style={[styles.input, styles.multilineInput]}
+                value={form.alamat}
+                onChangeText={(text) => updateField('alamat', text)}
+                placeholder="Alamat lengkap kantor cabang"
+                multiline
+                numberOfLines={3}
+              />
+            </View>
+
+            <View style={styles.row}>
+              <View style={[styles.formGroup, styles.flexHalf]}>
+                <Text style={styles.label}>No. Telepon Utama *</Text>
+                <TextInput
+                  style={styles.input}
+                  value={form.no_telp}
+                  onChangeText={(text) => updateField('no_telp', text)}
+                  placeholder="Contoh: 021123456"
+                  keyboardType="phone-pad"
+                />
+              </View>
+              <View style={[styles.formGroup, styles.flexHalf]}>
+                <Text style={styles.label}>No. Telpon (Legacy)</Text>
+                <TextInput
+                  style={styles.input}
+                  value={form.no_telpon}
+                  onChangeText={(text) => updateField('no_telpon', text)}
+                  placeholder="Opsional"
+                  keyboardType="phone-pad"
+                />
+              </View>
+            </View>
+
+            <View style={styles.formGroup}>
+              <Text style={styles.label}>Email</Text>
+              <TextInput
+                style={styles.input}
+                value={form.email}
+                onChangeText={(text) => updateField('email', text)}
+                placeholder="email@kantorcabang.com"
+                keyboardType="email-address"
+                autoCapitalize="none"
+              />
+            </View>
+
+            <Text style={styles.sectionTitle}>Status</Text>
+            <View style={styles.statusRow}>
+              {statusOptions.map((option) => {
+                const active = form.status === option.key;
+                return (
+                  <TouchableOpacity
+                    key={option.key}
+                    style={[styles.statusPill, active && styles.statusPillActive]}
+                    onPress={() => updateField('status', option.key)}
+                  >
+                    <Text style={[styles.statusPillText, active && styles.statusPillTextActive]}>
+                      {option.label}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+
+            <Text style={styles.sectionTitle}>Kode Wilayah (Opsional)</Text>
+            <View style={styles.row}>
+              <View style={[styles.formGroup, styles.flexHalf]}>
+                <Text style={styles.label}>ID Provinsi</Text>
+                <TextInput
+                  style={styles.input}
+                  value={form.id_prov}
+                  onChangeText={(text) => updateField('id_prov', text)}
+                  placeholder="Contoh: 32"
+                  autoCapitalize="none"
+                />
+              </View>
+              <View style={[styles.formGroup, styles.flexHalf]}>
+                <Text style={styles.label}>ID Kabupaten</Text>
+                <TextInput
+                  style={styles.input}
+                  value={form.id_kab}
+                  onChangeText={(text) => updateField('id_kab', text)}
+                  placeholder="Contoh: 3201"
+                  autoCapitalize="none"
+                />
+              </View>
+            </View>
+            <View style={styles.row}>
+              <View style={[styles.formGroup, styles.flexHalf]}>
+                <Text style={styles.label}>ID Kecamatan</Text>
+                <TextInput
+                  style={styles.input}
+                  value={form.id_kec}
+                  onChangeText={(text) => updateField('id_kec', text)}
+                  placeholder="Contoh: 320101"
+                  autoCapitalize="none"
+                />
+              </View>
+              <View style={[styles.formGroup, styles.flexHalf]}>
+                <Text style={styles.label}>ID Kelurahan</Text>
+                <TextInput
+                  style={styles.input}
+                  value={form.id_kel}
+                  onChangeText={(text) => updateField('id_kel', text)}
+                  placeholder="Contoh: 3201011001"
+                  autoCapitalize="none"
+                />
+              </View>
+            </View>
+
+            <TouchableOpacity
+              style={[styles.submitButton, submitting && styles.submitButtonDisabled]}
+              onPress={handleSubmit}
+              disabled={submitting}
+            >
+              {submitting ? (
+                <ActivityIndicator color="#fff" />
+              ) : (
+                <Text style={styles.submitButtonText}>
+                  {mode === 'edit' ? 'Simpan Perubahan' : 'Simpan'}
+                </Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        )}
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f6fa',
+  },
+  scroll: {
+    flex: 1,
+  },
+  contentContainer: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: '#2c3e50',
+  },
+  subtitle: {
+    marginTop: 4,
+    color: '#7f8c8d',
+  },
+  loadingContainer: {
+    marginTop: 60,
+    alignItems: 'center',
+  },
+  formCard: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 6,
+    elevation: 2,
+    gap: 12,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#2c3e50',
+    marginTop: 8,
+  },
+  formGroup: {
+    marginTop: 12,
+  },
+  label: {
+    fontSize: 13,
+    color: '#34495e',
+    marginBottom: 6,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#dfe6e9',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: '#fff',
+    fontSize: 14,
+    color: '#2c3e50',
+  },
+  multilineInput: {
+    height: 90,
+    textAlignVertical: 'top',
+  },
+  row: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  flexHalf: {
+    flex: 1,
+  },
+  statusRow: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 8,
+  },
+  statusPill: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 24,
+    borderWidth: 1,
+    borderColor: '#dfe6e9',
+  },
+  statusPillActive: {
+    backgroundColor: '#eafaf1',
+    borderColor: '#27ae60',
+  },
+  statusPillText: {
+    fontSize: 13,
+    color: '#7f8c8d',
+  },
+  statusPillTextActive: {
+    color: '#27ae60',
+    fontWeight: '600',
+  },
+  submitButton: {
+    marginTop: 24,
+    backgroundColor: '#27ae60',
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  submitButtonDisabled: {
+    opacity: 0.7,
+  },
+  submitButtonText: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 16,
+  },
+  errorText: {
+    color: '#e74c3c',
+    marginBottom: 4,
+  },
+});
+
+export default KacabFormScreen;

--- a/frontend/src/features/adminPusat/screens/kacab/KacabListScreen.js
+++ b/frontend/src/features/adminPusat/screens/kacab/KacabListScreen.js
@@ -1,0 +1,418 @@
+import React, { useCallback, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+  RefreshControl,
+  ActivityIndicator,
+  Alert,
+} from 'react-native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
+import { adminPusatApi } from '../../api/adminPusatApi';
+
+const normalizeListResponse = (payload) => {
+  if (!payload) {
+    return { items: [], meta: null };
+  }
+
+  if (Array.isArray(payload)) {
+    return { items: payload, meta: null };
+  }
+
+  if (Array.isArray(payload.data)) {
+    return { items: payload.data, meta: payload.meta ?? null };
+  }
+
+  return { items: [], meta: payload.meta ?? null };
+};
+
+const statusStyles = {
+  aktif: {
+    container: { backgroundColor: '#eafaf1' },
+    text: { color: '#27ae60' },
+  },
+  nonaktif: {
+    container: { backgroundColor: '#fdecea' },
+    text: { color: '#e74c3c' },
+  },
+};
+
+const KacabListScreen = () => {
+  const navigation = useNavigation();
+  const [kacabList, setKacabList] = useState([]);
+  const [meta, setMeta] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [deletingId, setDeletingId] = useState(null);
+
+  const fetchKacab = useCallback(async (options = {}) => {
+    const { silent = false } = options;
+
+    try {
+      setError('');
+      if (!silent) {
+        setLoading(true);
+      }
+
+      const response = await adminPusatApi.getKacab();
+      const payload = response?.data ?? null;
+      const { items, meta: pagination } = normalizeListResponse(payload);
+
+      setKacabList(Array.isArray(items) ? items : []);
+      setMeta(pagination);
+    } catch (err) {
+      const message = err?.response?.data?.message || err?.message || 'Gagal memuat kantor cabang';
+      setError(String(message));
+    } finally {
+      if (!silent) {
+        setLoading(false);
+      }
+      setRefreshing(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      fetchKacab();
+    }, [fetchKacab])
+  );
+
+  const onRefresh = () => {
+    setRefreshing(true);
+    fetchKacab({ silent: true });
+  };
+
+  const goToCreate = () => {
+    navigation.navigate('KacabForm', { mode: 'create' });
+  };
+
+  const goToDetail = (item) => {
+    const id = item?.id_kacab;
+    if (!id) {
+      Alert.alert('Tidak bisa membuka detail', 'ID kantor cabang tidak ditemukan.');
+      return;
+    }
+    navigation.navigate('KacabDetail', { idKacab: id });
+  };
+
+  const goToEdit = (item) => {
+    const id = item?.id_kacab;
+    if (!id) {
+      Alert.alert('Tidak bisa mengedit', 'ID kantor cabang tidak ditemukan.');
+      return;
+    }
+    navigation.navigate('KacabForm', { mode: 'edit', idKacab: id });
+  };
+
+  const handleDelete = async (item) => {
+    const id = item?.id_kacab;
+    if (!id) {
+      Alert.alert('Tidak bisa menghapus', 'ID kantor cabang tidak ditemukan.');
+      return;
+    }
+
+    try {
+      setDeletingId(id);
+      await adminPusatApi.deleteKacab(id);
+      Alert.alert('Berhasil', 'Kantor cabang berhasil dihapus.');
+      await fetchKacab();
+    } catch (err) {
+      const message = err?.response?.data?.message || err?.message || 'Gagal menghapus kantor cabang';
+      Alert.alert('Error', String(message));
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const confirmDelete = (item) => {
+    Alert.alert(
+      'Hapus Kantor Cabang',
+      `Apakah Anda yakin ingin menghapus ${item?.nama_kacab || 'kantor cabang ini'}?`,
+      [
+        { text: 'Batal', style: 'cancel' },
+        { text: 'Hapus', style: 'destructive', onPress: () => handleDelete(item) },
+      ]
+    );
+  };
+
+  const renderItem = ({ item }) => {
+    const statusKey = String(item?.status || '').toLowerCase();
+    const statusStyle = statusStyles[statusKey] || {
+      container: { backgroundColor: '#ecf0f1' },
+      text: { color: '#7f8c8d' },
+    };
+
+    return (
+      <View style={styles.card}>
+        <TouchableOpacity
+          activeOpacity={0.85}
+          style={styles.cardHeader}
+          onPress={() => goToDetail(item)}
+        >
+          <View style={styles.avatar}>
+            <Ionicons name="business" size={20} color="#fff" />
+          </View>
+          <View style={{ flex: 1 }}>
+            <Text style={styles.nameText}>{item?.nama_kacab || '-'}</Text>
+            <Text style={styles.addressText} numberOfLines={2}>
+              {item?.alamat || 'Alamat belum tersedia'}
+            </Text>
+          </View>
+          <View style={[styles.statusBadge, statusStyle.container]}>
+            <Text style={[styles.statusText, statusStyle.text]}>
+              {(item?.status || 'unknown').toString().toUpperCase()}
+            </Text>
+          </View>
+        </TouchableOpacity>
+
+        <View style={styles.metaRow}>
+          <Ionicons name="call-outline" size={16} color="#7f8c8d" />
+          <Text style={styles.metaText}>
+            {item?.no_telp || item?.no_telpon || '-'}
+          </Text>
+        </View>
+
+        {item?.email ? (
+          <View style={styles.metaRow}>
+            <Ionicons name="mail-outline" size={16} color="#7f8c8d" />
+            <Text style={styles.metaText}>{item.email}</Text>
+          </View>
+        ) : null}
+
+        <View style={styles.actionsRow}>
+          <TouchableOpacity style={styles.actionButton} onPress={() => goToEdit(item)}>
+            <Ionicons name="create-outline" size={18} color="#2980b9" />
+            <Text style={[styles.actionText, { color: '#2980b9' }]}>Edit</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.actionButton} onPress={() => goToDetail(item)}>
+            <Ionicons name="eye-outline" size={18} color="#27ae60" />
+            <Text style={[styles.actionText, { color: '#27ae60' }]}>Detail</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.actionButton, styles.deleteButton]}
+            onPress={() => confirmDelete(item)}
+            disabled={deletingId === item?.id_kacab}
+          >
+            {deletingId === item?.id_kacab ? (
+              <ActivityIndicator size="small" color="#fff" />
+            ) : (
+              <>
+                <Ionicons name="trash-outline" size={18} color="#fff" />
+                <Text style={[styles.actionText, { color: '#fff' }]}>Hapus</Text>
+              </>
+            )}
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  };
+
+  const listEmptyComponent = () => {
+    if (loading) {
+      return null;
+    }
+
+    return (
+      <View style={styles.emptyContainer}>
+        <Ionicons name="folder-open" size={40} color="#bdc3c7" />
+        <Text style={styles.emptyText}>Belum ada data kantor cabang.</Text>
+      </View>
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.headerRow}>
+        <View>
+          <Text style={styles.title}>Kantor Cabang</Text>
+          <Text style={styles.subtitle}>
+            Total {meta?.total ?? kacabList.length} cabang terdaftar
+          </Text>
+        </View>
+        <TouchableOpacity style={styles.addButton} onPress={goToCreate}>
+          <Ionicons name="add" size={22} color="#fff" />
+          <Text style={styles.addButtonText}>Tambah</Text>
+        </TouchableOpacity>
+      </View>
+
+      {loading && !refreshing ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color="#3498db" />
+        </View>
+      ) : error ? (
+        <View style={styles.errorBox}>
+          <Text style={styles.errorText}>{error}</Text>
+          <TouchableOpacity style={styles.retryButton} onPress={() => fetchKacab()}>
+            <Text style={styles.retryText}>Coba Lagi</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <FlatList
+          data={kacabList}
+          keyExtractor={(item, index) => String(item?.id_kacab ?? index)}
+          renderItem={renderItem}
+          contentContainerStyle={{ paddingBottom: 24 }}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+          }
+          ListEmptyComponent={listEmptyComponent}
+        />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f6fa',
+    padding: 16,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: '#2c3e50',
+  },
+  subtitle: {
+    marginTop: 4,
+    fontSize: 14,
+    color: '#7f8c8d',
+  },
+  addButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#27ae60',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 10,
+  },
+  addButtonText: {
+    marginLeft: 6,
+    color: '#fff',
+    fontWeight: '600',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  errorBox: {
+    backgroundColor: '#fdecea',
+    padding: 16,
+    borderRadius: 10,
+  },
+  errorText: {
+    color: '#e74c3c',
+    fontWeight: '500',
+    marginBottom: 12,
+  },
+  retryButton: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    backgroundColor: '#e74c3c',
+    borderRadius: 8,
+  },
+  retryText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  avatar: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: '#3498db',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 12,
+  },
+  nameText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#2c3e50',
+    marginBottom: 4,
+  },
+  addressText: {
+    fontSize: 13,
+    color: '#7f8c8d',
+  },
+  statusBadge: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 20,
+    marginLeft: 12,
+  },
+  statusText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 6,
+    gap: 8,
+  },
+  metaText: {
+    fontSize: 13,
+    color: '#7f8c8d',
+  },
+  actionsRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 12,
+  },
+  actionButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: '#ecf0f1',
+  },
+  actionText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  deleteButton: {
+    backgroundColor: '#e74c3c',
+  },
+  emptyContainer: {
+    marginTop: 60,
+    alignItems: 'center',
+  },
+  emptyText: {
+    marginTop: 12,
+    fontSize: 14,
+    color: '#95a5a6',
+  },
+});
+
+export default KacabListScreen;

--- a/frontend/src/navigation/AdminPusatNavigator.js
+++ b/frontend/src/navigation/AdminPusatNavigator.js
@@ -8,6 +8,9 @@ import AdminPusatDashboardScreen from '../features/adminPusat/screens/AdminPusat
 import AdminPusatProfileScreen from '../features/adminPusat/screens/AdminPusatProfileScreen';
 import TutorHonorSettingsScreen from '../features/adminPusat/screens/TutorHonorSettingsScreen';
 import DataWilayahScreen from '../features/adminPusat/screens/DataWilayahScreen';
+import KacabListScreen from '../features/adminPusat/screens/kacab/KacabListScreen';
+import KacabDetailScreen from '../features/adminPusat/screens/kacab/KacabDetailScreen';
+import KacabFormScreen from '../features/adminPusat/screens/kacab/KacabFormScreen';
 
 // User Management Screens
 import UserManagementScreen from '../features/adminPusat/screens/user/UserManagementScreen';
@@ -45,6 +48,23 @@ const HomeStackNavigator = () => {
         name="DataWilayah"
         component={DataWilayahScreen}
         options={{ headerTitle: 'Data Wilayah' }}
+      />
+      <Stack.Screen
+        name="KacabList"
+        component={KacabListScreen}
+        options={{ headerTitle: 'Kantor Cabang' }}
+      />
+      <Stack.Screen
+        name="KacabDetail"
+        component={KacabDetailScreen}
+        options={{ headerTitle: 'Detail Kantor Cabang' }}
+      />
+      <Stack.Screen
+        name="KacabForm"
+        component={KacabFormScreen}
+        options={({ route }) => ({
+          headerTitle: route?.params?.mode === 'edit' ? 'Edit Kantor Cabang' : 'Tambah Kantor Cabang',
+        })}
       />
       <Stack.Screen
         name="TutorHonorSettings"


### PR DESCRIPTION
## Summary
- scope admin pusat API routes under an `admin-pusat.` name prefix to expose the new Kacab resource without route name collisions
- update the shared endpoint constants and API client so Kantor Cabang CRUD uses the `/admin-pusat/kacab` endpoints with JSON payloads
- add Kantor Cabang list, detail, and form screens reachable from Data Wilayah along with navigation wiring

## Testing
- Not run (manual testing recommended)


------
https://chatgpt.com/codex/tasks/task_e_68cecd7fa59c83239e7d253ba3f69bfb