### PR TITLE
Add Admin Pusat Wilbin management endpoints

### DIFF
--- a/backend/app/Http/Controllers/API/AdminPusat/WilbinController.php
+++ b/backend/app/Http/Controllers/API/AdminPusat/WilbinController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\API\AdminPusat;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Wilbin\StoreWilbinRequest;
+use App\Http\Requests\Wilbin\UpdateWilbinRequest;
+use App\Http\Resources\WilbinResource;
+use App\Models\Wilbin;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class WilbinController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): AnonymousResourceCollection
+    {
+        $wilbins = Wilbin::query()
+            ->with('kacab')
+            ->latest('id_wilbin')
+            ->paginate();
+
+        return WilbinResource::collection($wilbins);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(StoreWilbinRequest $request)
+    {
+        $wilbin = Wilbin::create($request->validated());
+
+        return (new WilbinResource($wilbin->load('kacab')))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Wilbin $wilbin): WilbinResource
+    {
+        $wilbin->loadMissing('kacab');
+
+        return new WilbinResource($wilbin);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(UpdateWilbinRequest $request, Wilbin $wilbin): WilbinResource
+    {
+        $wilbin->fill($request->validated());
+        $wilbin->save();
+
+        return new WilbinResource($wilbin->fresh()->loadMissing('kacab'));
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Wilbin $wilbin): JsonResponse
+    {
+        $wilbin->delete();
+
+        return response()->json([
+            'message' => 'Wilayah binaan berhasil dihapus.',
+        ]);
+    }
+}

--- a/backend/app/Http/Requests/Wilbin/StoreWilbinRequest.php
+++ b/backend/app/Http/Requests/Wilbin/StoreWilbinRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests\Wilbin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreWilbinRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'nama_wilbin' => ['required', 'string'],
+            'id_kacab' => ['required', 'exists:kacab,id_kacab'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/Wilbin/UpdateWilbinRequest.php
+++ b/backend/app/Http/Requests/Wilbin/UpdateWilbinRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests\Wilbin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateWilbinRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'nama_wilbin' => ['sometimes', 'required', 'string'],
+            'id_kacab' => ['sometimes', 'required', 'exists:kacab,id_kacab'],
+        ];
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -30,6 +30,7 @@ Route::middleware('auth:sanctum')->group(function () {
             });
 
             Route::apiResource('kacab', App\Http\Controllers\API\AdminPusat\KacabController::class);
+            Route::apiResource('wilbin', App\Http\Controllers\API\AdminPusat\WilbinController::class);
 
             Route::get('/tutor-honor-settings', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'index']);
             Route::get('/tutor-honor-settings/active', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'getActiveSetting']);


### PR DESCRIPTION
## Summary
- add form request classes to validate Wilbin create and update payloads
- implement Admin Pusat Wilbin controller with resource-based CRUD responses
- expose Wilbin API resource routes under the Admin Pusat route group

## Testing
- `php artisan test` *(fails: Could not open input file: artisan)*

------
https://chatgpt.com/codex/tasks/task_e_68cfed06979c832384f75dd79b7f052c