### PR TITLE
Add admin pusat wilbin endpoints and API methods

### DIFF
--- a/frontend/src/constants/endpoints.js
+++ b/frontend/src/constants/endpoints.js
@@ -7,6 +7,8 @@ export const AUTH_ENDPOINTS = {
 export const ADMIN_PUSAT_ENDPOINTS = {
   DASHBOARD: '/admin-pusat/dashboard',
   PROFILE: '/admin-pusat/profile',
+  WILBIN: '/admin-pusat/wilbin',
+  WILBIN_DETAIL: (id) => `/admin-pusat/wilbin/${id}`,
   ANAK: {
     LIST: '/admin-pusat/anak',
     DETAIL: (id) => `/admin-pusat/anak/${id}`,

--- a/frontend/src/features/adminPusat/api/adminPusatApi.js
+++ b/frontend/src/features/adminPusat/api/adminPusatApi.js
@@ -125,5 +125,55 @@ export const adminPusatApi = {
    */
   deleteKacab: async (kacabId) => {
     return await api.delete(MANAGEMENT_ENDPOINTS.KACAB_DETAIL(kacabId));
+  },
+
+  /**
+   * Get list of wilbin
+   * @param {Object} params - Query parameters
+   * @returns {Promise} - API response with wilbin data
+   */
+  getWilbin: async (params = {}) => {
+    return await api.get(ADMIN_PUSAT_ENDPOINTS.WILBIN, { params });
+  },
+
+  /**
+   * Get wilbin details
+   * @param {number|string} wilbinId - Wilbin ID
+   * @returns {Promise} - API response with wilbin details
+   */
+  getWilbinDetail: async (wilbinId) => {
+    return await api.get(ADMIN_PUSAT_ENDPOINTS.WILBIN_DETAIL(wilbinId));
+  },
+
+  /**
+   * Create new wilbin
+   * @param {Object} wilbinData - Wilbin data
+   * @param {number|string} wilbinData.id_kacab - Kacab ID associated with wilbin
+   * @param {string} wilbinData.nama_wilbin - Wilbin name
+   * @returns {Promise} - API response
+   */
+  createWilbin: async ({ id_kacab, nama_wilbin }) => {
+    return await api.post(ADMIN_PUSAT_ENDPOINTS.WILBIN, { id_kacab, nama_wilbin });
+  },
+
+  /**
+   * Update wilbin
+   * @param {number|string} wilbinId - Wilbin ID
+   * @param {Object} wilbinData - Wilbin data
+   * @param {number|string} wilbinData.id_kacab - Kacab ID associated with wilbin
+   * @param {string} wilbinData.nama_wilbin - Wilbin name
+   * @returns {Promise} - API response
+   */
+  updateWilbin: async (wilbinId, { id_kacab, nama_wilbin }) => {
+    return await api.put(ADMIN_PUSAT_ENDPOINTS.WILBIN_DETAIL(wilbinId), { id_kacab, nama_wilbin });
+  },
+
+  /**
+   * Delete wilbin
+   * @param {number|string} wilbinId - Wilbin ID
+   * @returns {Promise} - API response
+   */
+  deleteWilbin: async (wilbinId) => {
+    return await api.delete(ADMIN_PUSAT_ENDPOINTS.WILBIN_DETAIL(wilbinId));
   }
 };


### PR DESCRIPTION
## Summary
- add admin pusat wilbin endpoints to the shared constants
- expose admin pusat wilbin CRUD API helpers using the new routes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cff60329a083238e21e0360b5fab7f