### PR TITLE
feat: add admin pusat shelter resource endpoints

### DIFF
--- a/backend/app/Http/Controllers/API/AdminPusat/ShelterController.php
+++ b/backend/app/Http/Controllers/API/AdminPusat/ShelterController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\API\AdminPusat;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Shelter\StoreShelterRequest;
+use App\Http\Requests\Shelter\UpdateShelterRequest;
+use App\Http\Resources\ShelterResource;
+use App\Models\Shelter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class ShelterController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): AnonymousResourceCollection
+    {
+        $shelters = Shelter::query()
+            ->with(['wilbin.kacab'])
+            ->latest('id_shelter')
+            ->paginate();
+
+        return ShelterResource::collection($shelters);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(StoreShelterRequest $request)
+    {
+        $shelter = Shelter::create($request->validated());
+
+        return (new ShelterResource($shelter->load(['wilbin.kacab'])))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Shelter $shelter): ShelterResource
+    {
+        $shelter->loadMissing(['wilbin.kacab']);
+
+        return new ShelterResource($shelter);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(UpdateShelterRequest $request, Shelter $shelter): ShelterResource
+    {
+        $shelter->fill($request->validated());
+        $shelter->save();
+
+        return new ShelterResource($shelter->fresh()->loadMissing(['wilbin.kacab']));
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Shelter $shelter): JsonResponse
+    {
+        $shelter->delete();
+
+        return response()->json([
+            'message' => 'Shelter berhasil dihapus.',
+        ]);
+    }
+}

--- a/backend/app/Http/Requests/Shelter/StoreShelterRequest.php
+++ b/backend/app/Http/Requests/Shelter/StoreShelterRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\Shelter;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreShelterRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'nama_shelter' => ['required', 'string', 'max:255'],
+            'id_wilbin' => ['required', 'exists:wilbin,id_wilbin'],
+            'require_gps' => ['nullable', 'boolean'],
+            'latitude' => ['nullable', 'numeric', 'between:-90,90'],
+            'longitude' => ['nullable', 'numeric', 'between:-180,180'],
+            'max_distance_meters' => ['nullable', 'integer', 'min:0'],
+            'gps_accuracy_required' => ['nullable', 'integer', 'min:0'],
+            'location_name' => ['nullable', 'string', 'max:255'],
+            'gps_approval_status' => ['nullable', 'string', 'max:255'],
+            'gps_approval_data' => ['nullable', 'array'],
+            'gps_submitted_at' => ['nullable', 'date'],
+            'gps_approved_at' => ['nullable', 'date'],
+            'gps_approved_by' => ['nullable', 'exists:users,id_users'],
+            'gps_rejection_reason' => ['nullable', 'string'],
+            'gps_change_history' => ['nullable', 'array'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/Shelter/UpdateShelterRequest.php
+++ b/backend/app/Http/Requests/Shelter/UpdateShelterRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\Shelter;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateShelterRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'nama_shelter' => ['sometimes', 'required', 'string', 'max:255'],
+            'id_wilbin' => ['sometimes', 'required', 'exists:wilbin,id_wilbin'],
+            'require_gps' => ['sometimes', 'nullable', 'boolean'],
+            'latitude' => ['sometimes', 'nullable', 'numeric', 'between:-90,90'],
+            'longitude' => ['sometimes', 'nullable', 'numeric', 'between:-180,180'],
+            'max_distance_meters' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'gps_accuracy_required' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'location_name' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'gps_approval_status' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'gps_approval_data' => ['sometimes', 'nullable', 'array'],
+            'gps_submitted_at' => ['sometimes', 'nullable', 'date'],
+            'gps_approved_at' => ['sometimes', 'nullable', 'date'],
+            'gps_approved_by' => ['sometimes', 'nullable', 'exists:users,id_users'],
+            'gps_rejection_reason' => ['sometimes', 'nullable', 'string'],
+            'gps_change_history' => ['sometimes', 'nullable', 'array'],
+        ];
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -31,6 +31,7 @@ Route::middleware('auth:sanctum')->group(function () {
 
             Route::apiResource('kacab', App\Http\Controllers\API\AdminPusat\KacabController::class);
             Route::apiResource('wilbin', App\Http\Controllers\API\AdminPusat\WilbinController::class);
+            Route::apiResource('shelter', App\Http\Controllers\API\AdminPusat\ShelterController::class);
 
             Route::get('/tutor-honor-settings', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'index']);
             Route::get('/tutor-honor-settings/active', [App\Http\Controllers\API\AdminPusat\AdminPusatTutorHonorSettingsController::class, 'getActiveSetting']);


### PR DESCRIPTION
## Summary
- add an Admin Pusat ShelterController that loads wilbin relationships and returns resource collections
- create StoreShelterRequest and UpdateShelterRequest to validate shelter fields including GPS metadata
- register the shelter apiResource within the admin-pusat route group

## Testing
- ⚠️ php artisan test *(fails: Could not open input file: artisan)*

------
https://chatgpt.com/codex/tasks/task_e_68d0068df53c8323861e86684ef9ff9a