### PR TITLE
feat: add shelter endpoints and admin pusat api methods

### DIFF
--- a/frontend/src/constants/endpoints.js
+++ b/frontend/src/constants/endpoints.js
@@ -9,6 +9,13 @@ export const ADMIN_PUSAT_ENDPOINTS = {
   PROFILE: '/admin-pusat/profile',
   WILBIN: '/admin-pusat/wilbin',
   WILBIN_DETAIL: (id) => `/admin-pusat/wilbin/${id}`,
+  SHELTER: {
+    LIST: '/admin-pusat/shelter',
+    DETAIL: (id) => `/admin-pusat/shelter/${id}`,
+    DROPDOWN: {
+      BY_WILBIN: (wilbinId) => `/dropdowns/wilbin/${wilbinId}/shelter`
+    }
+  },
   ANAK: {
     LIST: '/admin-pusat/anak',
     DETAIL: (id) => `/admin-pusat/anak/${id}`,

--- a/frontend/src/features/adminPusat/api/adminPusatApi.js
+++ b/frontend/src/features/adminPusat/api/adminPusatApi.js
@@ -175,5 +175,60 @@ export const adminPusatApi = {
    */
   deleteWilbin: async (wilbinId) => {
     return await api.delete(ADMIN_PUSAT_ENDPOINTS.WILBIN_DETAIL(wilbinId));
+  },
+
+  /**
+   * Get list of shelters
+   * @param {Object} params - Query parameters
+   * @returns {Promise} - API response with shelter data
+   */
+  getShelter: async (params = {}) => {
+    return await api.get(ADMIN_PUSAT_ENDPOINTS.SHELTER.LIST, { params });
+  },
+
+  /**
+   * Get shelter details
+   * @param {number|string} shelterId - Shelter ID
+   * @returns {Promise} - API response with shelter details
+   */
+  getShelterDetail: async (shelterId) => {
+    return await api.get(ADMIN_PUSAT_ENDPOINTS.SHELTER.DETAIL(shelterId));
+  },
+
+  /**
+   * Create new shelter
+   * @param {Object} shelterData - Shelter data
+   * @returns {Promise} - API response
+   */
+  createShelter: async (shelterData) => {
+    return await api.post(ADMIN_PUSAT_ENDPOINTS.SHELTER.LIST, shelterData);
+  },
+
+  /**
+   * Update shelter
+   * @param {number|string} shelterId - Shelter ID
+   * @param {Object} shelterData - Shelter data
+   * @returns {Promise} - API response
+   */
+  updateShelter: async (shelterId, shelterData) => {
+    return await api.put(ADMIN_PUSAT_ENDPOINTS.SHELTER.DETAIL(shelterId), shelterData);
+  },
+
+  /**
+   * Delete shelter
+   * @param {number|string} shelterId - Shelter ID
+   * @returns {Promise} - API response
+   */
+  deleteShelter: async (shelterId) => {
+    return await api.delete(ADMIN_PUSAT_ENDPOINTS.SHELTER.DETAIL(shelterId));
+  },
+
+  /**
+   * Get shelter dropdown data by wilbin
+   * @param {number|string} wilbinId - Wilbin ID
+   * @returns {Promise} - API response with shelter dropdown data
+   */
+  getShelterDropdownByWilbin: async (wilbinId) => {
+    return await api.get(ADMIN_PUSAT_ENDPOINTS.SHELTER.DROPDOWN.BY_WILBIN(wilbinId));
   }
 };


### PR DESCRIPTION
## Summary
- add shelter list/detail/dropdown endpoints for admin pusat shelter management
- implement shelter CRUD helpers and wilbin dropdown loader in the admin pusat API service

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d008c92ee48323b2eab66450eaa455