### PR TITLE
Add shelter management screens for admin pusat

### DIFF
--- a/frontend/src/features/adminPusat/screens/DataWilayahScreen.js
+++ b/frontend/src/features/adminPusat/screens/DataWilayahScreen.js
@@ -41,6 +41,11 @@ const DataWilayahScreen = () => {
       return;
     }
 
+    if (itemId === 'shelter') {
+      navigation.navigate('ShelterList');
+      return;
+    }
+
     Alert.alert('Segera Hadir', 'Fitur ini akan tersedia pada pembaruan berikutnya.');
   };
 

--- a/frontend/src/features/adminPusat/screens/shelter/ShelterDetailScreen.js
+++ b/frontend/src/features/adminPusat/screens/shelter/ShelterDetailScreen.js
@@ -1,0 +1,300 @@
+import React, { useCallback, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  RefreshControl,
+  ActivityIndicator,
+  TouchableOpacity,
+  Alert,
+} from 'react-native';
+import { useFocusEffect, useNavigation, useRoute } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
+import { adminPusatApi } from '../../api/adminPusatApi';
+
+const formatDateTime = (value) => {
+  if (!value) {
+    return '-';
+  }
+
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return String(value);
+    }
+    return date.toLocaleString();
+  } catch (error) {
+    return String(value);
+  }
+};
+
+const DetailRow = ({ icon, label, value }) => (
+  <View style={styles.detailRow}>
+    <View style={styles.detailLabelWrapper}>
+      <Ionicons name={icon} size={18} color="#7f8c8d" style={styles.detailIcon} />
+      <Text style={styles.detailLabel}>{label}</Text>
+    </View>
+    <Text style={styles.detailValue}>{value ?? '-'}</Text>
+  </View>
+);
+
+const ShelterDetailScreen = () => {
+  const navigation = useNavigation();
+  const route = useRoute();
+  const idShelter = route.params?.idShelter;
+
+  const [detail, setDetail] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+
+  const fetchDetail = useCallback(
+    async (options = {}) => {
+      const { silent = false } = options;
+
+      if (!idShelter && idShelter !== 0) {
+        setError('ID shelter tidak ditemukan.');
+        setLoading(false);
+        return;
+      }
+
+      try {
+        setError('');
+        if (!silent) {
+          setLoading(true);
+        }
+
+        const response = await adminPusatApi.getShelterDetail(idShelter);
+        const payload = response?.data ?? null;
+        const data = payload?.data ?? payload ?? null;
+        setDetail(data);
+      } catch (err) {
+        const message =
+          err?.response?.data?.message ||
+          err?.message ||
+          'Gagal memuat detail shelter';
+        setError(String(message));
+      } finally {
+        if (!silent) {
+          setLoading(false);
+        }
+        setRefreshing(false);
+      }
+    },
+    [idShelter]
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      fetchDetail();
+
+      return () => {};
+    }, [fetchDetail])
+  );
+
+  const onRefresh = () => {
+    setRefreshing(true);
+    fetchDetail({ silent: true });
+  };
+
+  const goToEdit = () => {
+    if (!idShelter && idShelter !== 0) {
+      Alert.alert('Tidak bisa mengedit', 'ID shelter tidak ditemukan.');
+      return;
+    }
+    navigation.navigate('ShelterForm', { mode: 'edit', idShelter });
+  };
+
+  const wilbinName =
+    detail?.wilbin?.nama_wilbin ||
+    detail?.wilbin_name ||
+    detail?.nama_wilbin ||
+    'Wilayah binaan belum ditentukan';
+  const kacabName =
+    detail?.wilbin?.kacab?.nama_kacab ||
+    detail?.kacab?.nama_kacab ||
+    detail?.nama_kacab ||
+    'Kantor cabang belum ditentukan';
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.contentContainer}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+    >
+      <View style={styles.headerCard}>
+        <View style={styles.headerContent}>
+          <View style={styles.headerIcon}>
+            <Ionicons name="home" size={26} color="#fff" />
+          </View>
+          <View style={{ flex: 1 }}>
+            <Text style={styles.headerTitle}>{detail?.nama_shelter || 'Shelter'}</Text>
+            <Text style={styles.headerSubtitle}>{wilbinName}</Text>
+          </View>
+        </View>
+        <TouchableOpacity style={styles.editButton} onPress={goToEdit}>
+          <Ionicons name="create-outline" size={18} color="#fff" />
+          <Text style={styles.editButtonText}>Edit</Text>
+        </TouchableOpacity>
+      </View>
+
+      {loading ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color="#3498db" />
+        </View>
+      ) : error ? (
+        <View style={styles.errorBox}>
+          <Ionicons name="alert-circle" size={20} color="#e74c3c" />
+          <Text style={styles.errorText}>{error}</Text>
+          <TouchableOpacity style={styles.retryButton} onPress={() => fetchDetail()}>
+            <Text style={styles.retryText}>Coba Lagi</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <View style={styles.detailCard}>
+          <Text style={styles.sectionTitle}>Informasi Shelter</Text>
+          <DetailRow icon="home-outline" label="Nama Shelter" value={detail?.nama_shelter || '-'} />
+          <DetailRow icon="map-outline" label="Wilayah Binaan" value={wilbinName} />
+          <DetailRow icon="id-card-outline" label="ID Shelter" value={detail?.id_shelter ?? detail?.id ?? '-'} />
+          <DetailRow icon="location-outline" label="ID Wilbin" value={detail?.id_wilbin ?? '-'} />
+          <DetailRow icon="business-outline" label="Kantor Cabang" value={kacabName} />
+
+          <Text style={styles.sectionTitle}>Audit</Text>
+          <DetailRow icon="time-outline" label="Dibuat" value={formatDateTime(detail?.created_at)} />
+          <DetailRow icon="refresh" label="Terakhir Diperbarui" value={formatDateTime(detail?.updated_at)} />
+        </View>
+      )}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f6fa',
+  },
+  contentContainer: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  headerCard: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  headerContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  headerIcon: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: '#e67e22',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  headerTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: '#2c3e50',
+    marginBottom: 4,
+  },
+  headerSubtitle: {
+    fontSize: 14,
+    color: '#7f8c8d',
+  },
+  editButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#2980b9',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 8,
+    marginTop: 12,
+    alignSelf: 'flex-start',
+  },
+  editButtonText: {
+    marginLeft: 6,
+    color: '#fff',
+    fontWeight: '600',
+  },
+  loadingContainer: {
+    paddingVertical: 40,
+    alignItems: 'center',
+  },
+  errorBox: {
+    backgroundColor: '#fdecea',
+    borderRadius: 12,
+    padding: 16,
+    alignItems: 'flex-start',
+    gap: 8,
+  },
+  errorText: {
+    color: '#e74c3c',
+    fontWeight: '500',
+  },
+  retryButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    backgroundColor: '#e74c3c',
+    borderRadius: 8,
+  },
+  retryText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  detailCard: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    gap: 12,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#2c3e50',
+    marginBottom: 4,
+  },
+  detailRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 12,
+  },
+  detailLabelWrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    flex: 1,
+  },
+  detailIcon: {
+    width: 24,
+  },
+  detailLabel: {
+    fontSize: 14,
+    color: '#7f8c8d',
+    flexShrink: 1,
+  },
+  detailValue: {
+    fontSize: 14,
+    color: '#2c3e50',
+    flex: 1,
+    textAlign: 'right',
+  },
+});
+
+export default ShelterDetailScreen;

--- a/frontend/src/features/adminPusat/screens/shelter/ShelterFormScreen.js
+++ b/frontend/src/features/adminPusat/screens/shelter/ShelterFormScreen.js
@@ -1,0 +1,361 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  ActivityIndicator,
+} from 'react-native';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { Picker } from '@react-native-picker/picker';
+import { Ionicons } from '@expo/vector-icons';
+import { adminPusatApi } from '../../api/adminPusatApi';
+
+const normalizeListResponse = (payload) => {
+  if (!payload) {
+    return { items: [], meta: null };
+  }
+
+  if (Array.isArray(payload)) {
+    return { items: payload, meta: null };
+  }
+
+  if (Array.isArray(payload.data)) {
+    return { items: payload.data, meta: payload.meta ?? null };
+  }
+
+  return { items: [], meta: payload.meta ?? null };
+};
+
+const initialForm = {
+  nama_shelter: '',
+  id_wilbin: '',
+};
+
+const ShelterFormScreen = () => {
+  const navigation = useNavigation();
+  const route = useRoute();
+  const mode = route.params?.mode ?? 'create';
+  const idShelter = route.params?.idShelter ?? null;
+
+  const [form, setForm] = useState(initialForm);
+  const [wilbinOptions, setWilbinOptions] = useState([]);
+  const [loading, setLoading] = useState(mode === 'edit');
+  const [loadingWilbin, setLoadingWilbin] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [dropdownError, setDropdownError] = useState('');
+
+  const updateField = (key, value) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const loadWilbinOptions = useCallback(async () => {
+    try {
+      setDropdownError('');
+      setLoadingWilbin(true);
+      const response = await adminPusatApi.getWilbin({ per_page: 100 });
+      const payload = response?.data ?? null;
+      const { items } = normalizeListResponse(payload);
+      setWilbinOptions(Array.isArray(items) ? items : []);
+    } catch (err) {
+      const message =
+        err?.response?.data?.message ||
+        err?.message ||
+        'Gagal memuat daftar wilayah binaan';
+      setDropdownError(String(message));
+    } finally {
+      setLoadingWilbin(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadWilbinOptions();
+  }, [loadWilbinOptions]);
+
+  const fetchDetail = useCallback(async () => {
+    if (mode !== 'edit' || (!idShelter && idShelter !== 0)) {
+      setLoading(false);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError('');
+      const response = await adminPusatApi.getShelterDetail(idShelter);
+      const payload = response?.data ?? null;
+      const data = payload?.data ?? payload ?? {};
+      const wilbinId =
+        data?.id_wilbin ??
+        data?.wilbin_id ??
+        data?.wilbin?.id_wilbin ??
+        data?.wilbin?.id ??
+        null;
+      const parsedWilbinId =
+        wilbinId !== null && wilbinId !== undefined ? String(wilbinId) : '';
+
+      setForm({
+        nama_shelter: data?.nama_shelter ?? data?.nama ?? '',
+        id_wilbin: parsedWilbinId,
+      });
+    } catch (err) {
+      const message =
+        err?.response?.data?.message ||
+        err?.message ||
+        'Gagal memuat data shelter';
+      setError(String(message));
+      Alert.alert('Error', String(message));
+    } finally {
+      setLoading(false);
+    }
+  }, [idShelter, mode]);
+
+  useEffect(() => {
+    fetchDetail();
+  }, [fetchDetail]);
+
+  const handleSubmit = async () => {
+    const trimmedName = form.nama_shelter.trim();
+    if (!trimmedName) {
+      Alert.alert('Validasi', 'Nama shelter wajib diisi.');
+      return;
+    }
+
+    if (!form.id_wilbin) {
+      Alert.alert('Validasi', 'Pilih wilayah binaan terlebih dahulu.');
+      return;
+    }
+
+    const numericWilbinId = Number(form.id_wilbin);
+    const payload = {
+      nama_shelter: trimmedName,
+      id_wilbin: Number.isNaN(numericWilbinId) ? form.id_wilbin : numericWilbinId,
+    };
+
+    try {
+      setSubmitting(true);
+      setError('');
+      if (mode === 'edit' && (idShelter || idShelter === 0)) {
+        await adminPusatApi.updateShelter(idShelter, payload);
+        Alert.alert('Berhasil', 'Shelter berhasil diperbarui.', [
+          { text: 'OK', onPress: () => navigation.goBack() },
+        ]);
+      } else {
+        await adminPusatApi.createShelter(payload);
+        Alert.alert('Berhasil', 'Shelter berhasil dibuat.', [
+          { text: 'OK', onPress: () => navigation.goBack() },
+        ]);
+      }
+    } catch (err) {
+      const message =
+        err?.response?.data?.message ||
+        err?.message ||
+        'Gagal menyimpan shelter';
+      setError(String(message));
+      Alert.alert('Error', String(message));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.contentContainer}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.headerRow}>
+          <View>
+            <Text style={styles.title}>
+              {mode === 'edit' ? 'Edit Shelter' : 'Tambah Shelter'}
+            </Text>
+            <Text style={styles.subtitle}>
+              Isi informasi shelter secara lengkap.
+            </Text>
+          </View>
+          <Ionicons name="home" size={28} color="#e67e22" />
+        </View>
+
+        {loading ? (
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator size="large" color="#3498db" />
+          </View>
+        ) : (
+          <View style={styles.formCard}>
+            {error ? <Text style={styles.errorText}>{error}</Text> : null}
+
+            <Text style={styles.sectionTitle}>Informasi Shelter</Text>
+            <View style={styles.formGroup}>
+              <Text style={styles.label}>Nama Shelter *</Text>
+              <TextInput
+                style={styles.input}
+                value={form.nama_shelter}
+                onChangeText={(text) => updateField('nama_shelter', text)}
+                placeholder="Contoh: Shelter A"
+              />
+            </View>
+
+            <View style={styles.formGroup}>
+              <Text style={styles.label}>Wilayah Binaan *</Text>
+              <View style={styles.pickerWrapper}>
+                {loadingWilbin ? (
+                  <ActivityIndicator size="small" color="#3498db" />
+                ) : (
+                  <Picker
+                    selectedValue={form.id_wilbin}
+                    onValueChange={(value) => updateField('id_wilbin', value)}
+                  >
+                    <Picker.Item label="-- Pilih Wilayah Binaan --" value="" />
+                    {wilbinOptions.map((option) => {
+                      const optionId = option?.id_wilbin ?? option?.id;
+                      const optionLabel =
+                        option?.nama_wilbin || option?.nama || 'Tanpa nama';
+                      if (optionId === undefined || optionId === null) {
+                        return null;
+                      }
+                      return (
+                        <Picker.Item
+                          key={String(optionId)}
+                          label={optionLabel}
+                          value={String(optionId)}
+                        />
+                      );
+                    })}
+                  </Picker>
+                )}
+              </View>
+              {dropdownError ? <Text style={styles.helperError}>{dropdownError}</Text> : null}
+            </View>
+
+            <TouchableOpacity
+              style={[styles.submitButton, submitting && styles.submitButtonDisabled]}
+              onPress={handleSubmit}
+              disabled={submitting}
+            >
+              {submitting ? (
+                <ActivityIndicator size="small" color="#fff" />
+              ) : (
+                <>
+                  <Ionicons name="save" size={18} color="#fff" />
+                  <Text style={styles.submitButtonText}>Simpan</Text>
+                </>
+              )}
+            </TouchableOpacity>
+          </View>
+        )}
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f6fa',
+  },
+  scroll: {
+    flex: 1,
+  },
+  contentContainer: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: '#2c3e50',
+  },
+  subtitle: {
+    marginTop: 4,
+    fontSize: 14,
+    color: '#7f8c8d',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 40,
+  },
+  formCard: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  errorText: {
+    color: '#e74c3c',
+    fontWeight: '500',
+    marginBottom: 12,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#2c3e50',
+    marginBottom: 12,
+  },
+  formGroup: {
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 14,
+    color: '#34495e',
+    marginBottom: 8,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#dfe6e9',
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: Platform.select({ ios: 12, android: 8 }),
+    backgroundColor: '#fdfdfd',
+  },
+  pickerWrapper: {
+    borderWidth: 1,
+    borderColor: '#dfe6e9',
+    borderRadius: 10,
+    backgroundColor: '#fdfdfd',
+  },
+  helperError: {
+    marginTop: 6,
+    color: '#e74c3c',
+    fontSize: 12,
+  },
+  submitButton: {
+    marginTop: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingVertical: 12,
+    borderRadius: 10,
+    backgroundColor: '#27ae60',
+  },
+  submitButtonDisabled: {
+    opacity: 0.7,
+  },
+  submitButtonText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+});
+
+export default ShelterFormScreen;

--- a/frontend/src/features/adminPusat/screens/shelter/ShelterListScreen.js
+++ b/frontend/src/features/adminPusat/screens/shelter/ShelterListScreen.js
@@ -1,0 +1,517 @@
+import React, { useCallback, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+  RefreshControl,
+  ActivityIndicator,
+  Alert,
+} from 'react-native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
+import { adminPusatApi } from '../../api/adminPusatApi';
+
+const normalizeListResponse = (payload) => {
+  if (!payload) {
+    return { items: [], meta: null };
+  }
+
+  if (Array.isArray(payload)) {
+    return { items: payload, meta: null };
+  }
+
+  if (Array.isArray(payload.data)) {
+    return { items: payload.data, meta: payload.meta ?? null };
+  }
+
+  return { items: [], meta: payload.meta ?? null };
+};
+
+const ShelterListScreen = () => {
+  const navigation = useNavigation();
+  const [shelterList, setShelterList] = useState([]);
+  const [meta, setMeta] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [deletingId, setDeletingId] = useState(null);
+  const [page, setPage] = useState(1);
+  const [lastPage, setLastPage] = useState(1);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const resetPagination = useCallback((options = {}) => {
+    const { clearData = false } = options;
+
+    setPage(1);
+    setLastPage(1);
+    setLoadingMore(false);
+
+    if (clearData) {
+      setShelterList([]);
+      setMeta(null);
+    }
+  }, []);
+
+  const fetchShelter = useCallback(
+    async (options = {}) => {
+      const { silent = false, page: requestedPage = 1 } = options;
+
+      try {
+        if (requestedPage === 1) {
+          setError('');
+        }
+
+        if (requestedPage > 1) {
+          setLoadingMore(true);
+        } else if (!silent) {
+          setLoading(true);
+        }
+
+        const response = await adminPusatApi.getShelter({ page: requestedPage });
+        const payload = response?.data ?? null;
+        const { items, meta: pagination } = normalizeListResponse(payload);
+        const normalizedItems = Array.isArray(items) ? items : [];
+
+        setMeta((prevMeta) =>
+          pagination ?? (requestedPage > 1 ? prevMeta : null)
+        );
+
+        const derivedLastPageRaw =
+          pagination?.last_page ??
+          pagination?.lastPage ??
+          pagination?.total_pages ??
+          pagination?.totalPages ??
+          pagination?.pages ??
+          pagination?.pageCount ??
+          pagination?.page_count ??
+          pagination?.max_page ??
+          pagination?.maxPage ??
+          pagination?.last ??
+          null;
+        const derivedLastPage =
+          typeof derivedLastPageRaw === 'number'
+            ? derivedLastPageRaw
+            : Number(derivedLastPageRaw) || requestedPage;
+        setLastPage((prevLastPage) =>
+          derivedLastPage || (requestedPage > 1 ? prevLastPage : 1)
+        );
+
+        setShelterList((prev) =>
+          requestedPage > 1 ? [...prev, ...normalizedItems] : normalizedItems
+        );
+        setPage(requestedPage);
+      } catch (err) {
+        const message =
+          err?.response?.data?.message ||
+          err?.message ||
+          'Gagal memuat data shelter';
+        if (requestedPage > 1) {
+          Alert.alert('Error', String(message));
+        } else {
+          setError(String(message));
+        }
+      } finally {
+        if (requestedPage > 1) {
+          setLoadingMore(false);
+        } else {
+          setLoading(false);
+          setRefreshing(false);
+        }
+      }
+    },
+    []
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      resetPagination({ clearData: true });
+      fetchShelter({ page: 1 });
+    }, [fetchShelter, resetPagination])
+  );
+
+  const onRefresh = () => {
+    setRefreshing(true);
+    resetPagination();
+    fetchShelter({ page: 1, silent: true });
+  };
+
+  const handleLoadMore = useCallback(() => {
+    if (loadingMore || loading || refreshing || page >= lastPage) {
+      return;
+    }
+
+    const nextPage = page + 1;
+    fetchShelter({ page: nextPage, silent: true });
+  }, [fetchShelter, lastPage, loading, loadingMore, page, refreshing]);
+
+  const renderFooter = useCallback(() => {
+    if (loadingMore) {
+      return (
+        <View style={styles.footerLoading}>
+          <ActivityIndicator size="small" color="#3498db" />
+        </View>
+      );
+    }
+
+    if (!loading && page < lastPage) {
+      return (
+        <TouchableOpacity style={styles.loadMoreButton} onPress={handleLoadMore}>
+          <Text style={styles.loadMoreText}>Muat Lebih</Text>
+        </TouchableOpacity>
+      );
+    }
+
+    return null;
+  }, [handleLoadMore, lastPage, loading, loadingMore, page]);
+
+  const goToCreate = () => {
+    navigation.navigate('ShelterForm', { mode: 'create' });
+  };
+
+  const goToDetail = (item) => {
+    const id = item?.id_shelter ?? item?.id;
+    if (!id && id !== 0) {
+      Alert.alert('Tidak bisa membuka detail', 'ID shelter tidak ditemukan.');
+      return;
+    }
+    navigation.navigate('ShelterDetail', { idShelter: id });
+  };
+
+  const goToEdit = (item) => {
+    const id = item?.id_shelter ?? item?.id;
+    if (!id && id !== 0) {
+      Alert.alert('Tidak bisa mengedit', 'ID shelter tidak ditemukan.');
+      return;
+    }
+    navigation.navigate('ShelterForm', { mode: 'edit', idShelter: id });
+  };
+
+  const handleDelete = async (item) => {
+    const id = item?.id_shelter ?? item?.id;
+    if (!id && id !== 0) {
+      Alert.alert('Tidak bisa menghapus', 'ID shelter tidak ditemukan.');
+      return;
+    }
+
+    try {
+      setDeletingId(id);
+      await adminPusatApi.deleteShelter(id);
+      Alert.alert('Berhasil', 'Shelter berhasil dihapus.');
+      resetPagination({ clearData: true });
+      await fetchShelter({ page: 1 });
+    } catch (err) {
+      const message =
+        err?.response?.data?.message ||
+        err?.message ||
+        'Gagal menghapus shelter';
+      Alert.alert('Error', String(message));
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const confirmDelete = (item) => {
+    Alert.alert(
+      'Hapus Shelter',
+      `Apakah Anda yakin ingin menghapus ${item?.nama_shelter || 'shelter ini'}?`,
+      [
+        { text: 'Batal', style: 'cancel' },
+        { text: 'Hapus', style: 'destructive', onPress: () => handleDelete(item) },
+      ]
+    );
+  };
+
+  const renderItem = ({ item }) => {
+    const shelterId = item?.id_shelter ?? item?.id;
+    const shelterName = item?.nama_shelter || item?.nama || 'Shelter';
+    const wilbinName =
+      item?.wilbin?.nama_wilbin ||
+      item?.wilbin_name ||
+      item?.nama_wilbin ||
+      'Wilayah binaan belum ditentukan';
+    const kacabName =
+      item?.wilbin?.kacab?.nama_kacab ||
+      item?.kacab?.nama_kacab ||
+      item?.nama_kacab ||
+      null;
+
+    return (
+      <View style={styles.card}>
+        <TouchableOpacity
+          activeOpacity={0.85}
+          style={styles.cardHeader}
+          onPress={() => goToDetail(item)}
+        >
+          <View style={styles.avatar}>
+            <Ionicons name="home" size={20} color="#fff" />
+          </View>
+          <View style={{ flex: 1 }}>
+            <Text style={styles.nameText}>{shelterName}</Text>
+            <Text style={styles.subText} numberOfLines={2}>
+              {wilbinName}
+            </Text>
+            {kacabName ? (
+              <Text style={styles.subTextSecondary} numberOfLines={1}>
+                {kacabName}
+              </Text>
+            ) : null}
+          </View>
+        </TouchableOpacity>
+
+        <View style={styles.metaRow}>
+          <Ionicons name="id-card-outline" size={16} color="#7f8c8d" />
+          <Text style={styles.metaText}>ID Shelter: {shelterId ?? '-'}</Text>
+        </View>
+
+        <View style={styles.metaRow}>
+          <Ionicons name="map-outline" size={16} color="#7f8c8d" />
+          <Text style={styles.metaText}>ID Wilbin: {item?.id_wilbin ?? '-'}</Text>
+        </View>
+
+        <View style={styles.actionsRow}>
+          <TouchableOpacity style={styles.actionButton} onPress={() => goToEdit(item)}>
+            <Ionicons name="create-outline" size={18} color="#2980b9" />
+            <Text style={[styles.actionText, { color: '#2980b9' }]}>Edit</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.actionButton} onPress={() => goToDetail(item)}>
+            <Ionicons name="eye-outline" size={18} color="#27ae60" />
+            <Text style={[styles.actionText, { color: '#27ae60' }]}>Detail</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.actionButton, styles.deleteButton]}
+            onPress={() => confirmDelete(item)}
+            disabled={deletingId === shelterId}
+          >
+            {deletingId === shelterId ? (
+              <ActivityIndicator size="small" color="#fff" />
+            ) : (
+              <>
+                <Ionicons name="trash-outline" size={18} color="#fff" />
+                <Text style={[styles.actionText, { color: '#fff' }]}>Hapus</Text>
+              </>
+            )}
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  };
+
+  const listEmptyComponent = () => {
+    if (loading) {
+      return null;
+    }
+
+    return (
+      <View style={styles.emptyContainer}>
+        <Ionicons name="folder-open" size={40} color="#bdc3c7" />
+        <Text style={styles.emptyText}>Belum ada data shelter.</Text>
+      </View>
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.headerRow}>
+        <View>
+          <Text style={styles.title}>Shelter</Text>
+          <Text style={styles.subtitle}>
+            Total {meta?.total ?? shelterList.length} shelter terdaftar
+          </Text>
+        </View>
+        <TouchableOpacity style={styles.addButton} onPress={goToCreate}>
+          <Ionicons name="add" size={22} color="#fff" />
+          <Text style={styles.addButtonText}>Tambah</Text>
+        </TouchableOpacity>
+      </View>
+
+      {loading && !refreshing ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color="#3498db" />
+        </View>
+      ) : error ? (
+        <View style={styles.errorBox}>
+          <Text style={styles.errorText}>{error}</Text>
+          <TouchableOpacity style={styles.retryButton} onPress={() => fetchShelter()}>
+            <Text style={styles.retryText}>Coba Lagi</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <FlatList
+          data={shelterList}
+          keyExtractor={(item, index) => String(item?.id_shelter ?? item?.id ?? index)}
+          renderItem={renderItem}
+          contentContainerStyle={{ paddingBottom: 24 }}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+          ListEmptyComponent={listEmptyComponent}
+          onEndReached={handleLoadMore}
+          onEndReachedThreshold={0.2}
+          ListFooterComponent={renderFooter}
+        />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f6fa',
+    padding: 16,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: '#2c3e50',
+  },
+  subtitle: {
+    marginTop: 4,
+    fontSize: 14,
+    color: '#7f8c8d',
+  },
+  addButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#27ae60',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 10,
+  },
+  addButtonText: {
+    marginLeft: 6,
+    color: '#fff',
+    fontWeight: '600',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  errorBox: {
+    backgroundColor: '#fdecea',
+    padding: 16,
+    borderRadius: 10,
+  },
+  errorText: {
+    color: '#e74c3c',
+    fontWeight: '500',
+    marginBottom: 12,
+  },
+  retryButton: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    backgroundColor: '#e74c3c',
+    borderRadius: 8,
+  },
+  retryText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+    gap: 12,
+  },
+  avatar: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: '#e67e22',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  nameText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#2c3e50',
+    marginBottom: 4,
+  },
+  subText: {
+    fontSize: 13,
+    color: '#7f8c8d',
+  },
+  subTextSecondary: {
+    fontSize: 12,
+    color: '#95a5a6',
+    marginTop: 2,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 6,
+    gap: 8,
+  },
+  metaText: {
+    fontSize: 13,
+    color: '#7f8c8d',
+  },
+  actionsRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 12,
+  },
+  actionButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: '#ecf0f1',
+  },
+  actionText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  deleteButton: {
+    backgroundColor: '#e74c3c',
+  },
+  emptyContainer: {
+    marginTop: 60,
+    alignItems: 'center',
+  },
+  emptyText: {
+    marginTop: 12,
+    fontSize: 14,
+    color: '#95a5a6',
+  },
+  footerLoading: {
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  loadMoreButton: {
+    marginTop: 16,
+    alignSelf: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 8,
+    backgroundColor: '#3498db',
+  },
+  loadMoreText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+});
+
+export default ShelterListScreen;

--- a/frontend/src/navigation/AdminPusatNavigator.js
+++ b/frontend/src/navigation/AdminPusatNavigator.js
@@ -14,6 +14,9 @@ import KacabFormScreen from '../features/adminPusat/screens/kacab/KacabFormScree
 import WilbinListScreen from '../features/adminPusat/screens/wilbin/WilbinListScreen';
 import WilbinDetailScreen from '../features/adminPusat/screens/wilbin/WilbinDetailScreen';
 import WilbinFormScreen from '../features/adminPusat/screens/wilbin/WilbinFormScreen';
+import ShelterListScreen from '../features/adminPusat/screens/shelter/ShelterListScreen';
+import ShelterDetailScreen from '../features/adminPusat/screens/shelter/ShelterDetailScreen';
+import ShelterFormScreen from '../features/adminPusat/screens/shelter/ShelterFormScreen';
 
 // User Management Screens
 import UserManagementScreen from '../features/adminPusat/screens/user/UserManagementScreen';
@@ -84,6 +87,23 @@ const HomeStackNavigator = () => {
         component={WilbinFormScreen}
         options={({ route }) => ({
           headerTitle: route?.params?.mode === 'edit' ? 'Edit Wilayah Binaan' : 'Tambah Wilayah Binaan',
+        })}
+      />
+      <Stack.Screen
+        name="ShelterList"
+        component={ShelterListScreen}
+        options={{ headerTitle: 'Shelter' }}
+      />
+      <Stack.Screen
+        name="ShelterDetail"
+        component={ShelterDetailScreen}
+        options={{ headerTitle: 'Detail Shelter' }}
+      />
+      <Stack.Screen
+        name="ShelterForm"
+        component={ShelterFormScreen}
+        options={({ route }) => ({
+          headerTitle: route?.params?.mode === 'edit' ? 'Edit Shelter' : 'Tambah Shelter',
         })}
       />
       <Stack.Screen


### PR DESCRIPTION
## Summary
- add shelter list, detail, and form screens that reuse the adminPusatApi shelter endpoints and provide wilbin selection
- hook the new shelter screens into the data wilayah menu and admin pusat navigator

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d00a86f1408323bb971368a5366c39