### PR TITLE
Disable admin template access during maintenance

### DIFF
--- a/frontend/src/features/adminPusat/screens/AdminPusatDashboardScreen.js
+++ b/frontend/src/features/adminPusat/screens/AdminPusatDashboardScreen.js
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   RefreshControl,
   Image,
+  Alert,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
@@ -56,7 +57,11 @@ const AdminPusatDashboardScreen = () => {
   };
 
   // Navigation handlers
-  const navigateToTemplates = () => navigation.navigate('Template');
+  const navigateToTemplates = () =>
+    Alert.alert(
+      'Maintenance',
+      'Fitur ini sedang dalam perbaikan / maintenance.'
+    );
   const navigateToProfile = () => navigation.navigate('ProfileTab');
   const navigateToTutorHonorSettings = () => navigation.navigate('TutorHonorSettings');
   const navigateToUserManagement = () => navigation.navigate('UserManagement');
@@ -157,7 +162,7 @@ const AdminPusatDashboardScreen = () => {
               <Ionicons name="library" size={24} color="#fff" />
             </View>
             <Text style={styles.quickAccessText}>Template Kurikulum</Text>
-            <Text style={styles.quickAccessSubtext}>Kelola template dan distribusi</Text>
+            <Text style={styles.quickAccessSubtext}>Fitur ini sedang dalam perbaikan / maintenance</Text>
           </TouchableOpacity>
           
           <TouchableOpacity

--- a/frontend/src/navigation/AdminPusatNavigator.js
+++ b/frontend/src/navigation/AdminPusatNavigator.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Alert } from 'react-native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createStackNavigator } from '@react-navigation/stack';
 import { Ionicons } from '@expo/vector-icons';
@@ -232,10 +233,19 @@ const AdminPusatNavigator = () => {
         component={HomeStackNavigator} 
         options={{ tabBarLabel: 'Home' }}
       />
-      <Tab.Screen 
-        name="Template" 
-        component={TemplateStackNavigator} 
+      <Tab.Screen
+        name="Template"
+        component={TemplateStackNavigator}
         options={{ tabBarLabel: 'Template' }}
+        listeners={() => ({
+          tabPress: (e) => {
+            e.preventDefault();
+            Alert.alert(
+              'Maintenance',
+              'Fitur ini sedang dalam perbaikan / maintenance.'
+            );
+          },
+        })}
       />
       <Tab.Screen 
         name="ProfileTab" 


### PR DESCRIPTION
## Summary
- show a maintenance alert from the dashboard quick access button instead of navigating to the template tab
- prevent the Template tab from opening by intercepting its tab press and showing the same maintenance alert

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0ac40a3d08323bc02453284e0ac62