### PR TITLE
Normalize target arrays for mata pelajaran

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Foundation\Application;
+
+$app = new Application(
+    $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__)
+);
+
+$app->singleton(
+    Illuminate\Contracts\Http\Kernel::class,
+    App\Http\Kernel::class
+);
+
+$app->singleton(
+    Illuminate\Contracts\Console\Kernel::class,
+    App\Console\Kernel::class
+);
+
+$app->singleton(
+    Illuminate\Contracts\Debug\ExceptionHandler::class,
+    App\Exceptions\Handler::class
+);
+
+return $app;

--- a/backend/database/migrations/2025_09_20_000001_normalize_targets_on_mata_pelajaran_table.php
+++ b/backend/database/migrations/2025_09_20_000001_normalize_targets_on_mata_pelajaran_table.php
@@ -1,0 +1,82 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Collection;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('mata_pelajaran')
+            ->select('id_mata_pelajaran', 'target_jenjang', 'target_kelas')
+            ->orderBy('id_mata_pelajaran')
+            ->chunkById(100, function ($records) {
+                foreach ($records as $record) {
+                    $updates = [];
+
+                    $normalizedJenjang = $this->normalizeTargetValue($record->target_jenjang);
+                    if ($normalizedJenjang !== null) {
+                        $updates['target_jenjang'] = json_encode($normalizedJenjang);
+                    } elseif ($record->target_jenjang !== null) {
+                        $updates['target_jenjang'] = null;
+                    }
+
+                    $normalizedKelas = $this->normalizeTargetValue($record->target_kelas);
+                    if ($normalizedKelas !== null) {
+                        $updates['target_kelas'] = json_encode($normalizedKelas);
+                    } elseif ($record->target_kelas !== null) {
+                        $updates['target_kelas'] = null;
+                    }
+
+                    if (!empty($updates)) {
+                        DB::table('mata_pelajaran')
+                            ->where('id_mata_pelajaran', $record->id_mata_pelajaran)
+                            ->update($updates);
+                    }
+                }
+            }, 'id_mata_pelajaran');
+    }
+
+    public function down(): void
+    {
+        // No rollback action required for data normalization.
+    }
+
+    private function normalizeTargetValue($value): ?array
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if ($value instanceof Collection) {
+            $value = $value->toArray();
+        }
+
+        if (is_string($value)) {
+            $decoded = json_decode($value, true);
+
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $value = $decoded;
+            }
+        }
+
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_array($value)) {
+            $value = [$value];
+        }
+
+        $value = array_values(array_filter($value, function ($item) {
+            return $item !== null && $item !== '';
+        }));
+
+        if (empty($value)) {
+            return [];
+        }
+
+        return array_map('intval', $value);
+    }
+};

--- a/backend/tests/CreatesApplication.php
+++ b/backend/tests/CreatesApplication.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/backend/tests/Feature/MataPelajaranEndpointTest.php
+++ b/backend/tests/Feature/MataPelajaranEndpointTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AdminCabang;
+use App\Models\Jenjang;
+use App\Models\Kacab;
+use App\Models\MataPelajaran;
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class MataPelajaranEndpointTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['app.key' => 'base64:'.base64_encode(random_bytes(32))]);
+        config(['database.default' => 'sqlite']);
+        config(['database.connections.sqlite.database' => ':memory:']);
+
+        DB::purge('sqlite');
+        DB::reconnect('sqlite');
+
+        $this->createSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropAllTables();
+        parent::tearDown();
+    }
+
+    public function test_endpoint_returns_mata_pelajaran_for_target_assignments(): void
+    {
+        $user = User::create([
+            'username' => 'admin_cabang',
+            'email' => 'admin@example.com',
+            'password' => 'secret',
+            'level' => 'admin_cabang',
+            'status' => 'active',
+        ]);
+
+        $kacab = Kacab::create([
+            'nama_kacab' => 'Cabang A',
+            'status' => 'aktif',
+        ]);
+
+        AdminCabang::create([
+            'user_id' => $user->id_users,
+            'id_kacab' => $kacab->id_kacab,
+            'nama_lengkap' => 'Admin Cabang',
+        ]);
+
+        $jenjang = Jenjang::create([
+            'nama_jenjang' => 'SMP',
+            'kode_jenjang' => 'SMP',
+            'urutan' => 1,
+            'deskripsi' => 'Sekolah Menengah Pertama',
+            'is_active' => true,
+        ]);
+
+        MataPelajaran::create([
+            'nama_mata_pelajaran' => 'Matematika',
+            'kode_mata_pelajaran' => 'MTK',
+            'kategori' => 'wajib',
+            'deskripsi' => 'Belajar angka',
+            'status' => 'active',
+            'id_kacab' => $kacab->id_kacab,
+            'id_jenjang' => null,
+            'is_global' => false,
+            'target_jenjang' => [$jenjang->id_jenjang],
+            'target_kelas' => [101],
+        ]);
+
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->getJson('/api/admin-cabang/kurikulum/mata-pelajaran?jenjang='.$jenjang->id_jenjang.'&kelas=101');
+
+        $response->assertOk()
+            ->assertJson([
+                'success' => true,
+            ])
+            ->assertJsonPath('data.0.nama_mata_pelajaran', 'Matematika');
+    }
+
+    private function createSchema(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->bigIncrements('id_users');
+            $table->string('username')->nullable();
+            $table->string('email')->nullable();
+            $table->string('password')->nullable();
+            $table->string('level')->nullable();
+            $table->string('status')->nullable();
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        Schema::create('kacab', function (Blueprint $table) {
+            $table->bigIncrements('id_kacab');
+            $table->string('nama_kacab')->nullable();
+            $table->string('status')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('admin_cabang', function (Blueprint $table) {
+            $table->bigIncrements('id_admin_cabang');
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('id_kacab');
+            $table->string('nama_lengkap')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('jenjang', function (Blueprint $table) {
+            $table->bigIncrements('id_jenjang');
+            $table->string('nama_jenjang');
+            $table->string('kode_jenjang')->nullable();
+            $table->integer('urutan')->default(0);
+            $table->text('deskripsi')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+
+        Schema::create('mata_pelajaran', function (Blueprint $table) {
+            $table->bigIncrements('id_mata_pelajaran');
+            $table->string('nama_mata_pelajaran');
+            $table->string('kode_mata_pelajaran')->unique();
+            $table->string('kategori');
+            $table->text('deskripsi')->nullable();
+            $table->string('status')->default('active');
+            $table->unsignedBigInteger('id_kacab')->nullable();
+            $table->unsignedBigInteger('id_jenjang')->nullable();
+            $table->boolean('is_global')->default(false);
+            $table->json('target_jenjang')->nullable();
+            $table->json('target_kelas')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('materi', function (Blueprint $table) {
+            $table->bigIncrements('id_materi');
+            $table->unsignedBigInteger('id_mata_pelajaran')->nullable();
+            $table->unsignedBigInteger('id_kelas')->nullable();
+            $table->unsignedBigInteger('id_kacab')->nullable();
+            $table->string('nama_materi')->nullable();
+            $table->timestamps();
+        });
+    }
+}

--- a/backend/tests/TestCase.php
+++ b/backend/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    use CreatesApplication;
+}


### PR DESCRIPTION
## Summary
- normalize target_jenjang and target_kelas inputs before creating or updating custom mata pelajaran
- add a data normalization migration that converts stored JSON strings into integer arrays for existing mata_pelajaran records
- bootstrap the Laravel testing harness and add a feature test covering the curriculum mata pelajaran listing filtered by target arrays

## Testing
- `composer install` *(fails: curl error 56, CONNECT tunnel failed with 403 while reaching repo.packagist.org)*
- `./vendor/bin/phpunit` *(fails: vendor/bin/phpunit not found because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d0bac4bf6883238783e28d00460b47