### PR TITLE
Normalize mata pelajaran targets stored as null

### DIFF
--- a/backend/app/Http/Controllers/API/AdminCabang/KurikulumController.php
+++ b/backend/app/Http/Controllers/API/AdminCabang/KurikulumController.php
@@ -289,6 +289,7 @@ class KurikulumController extends Controller
                 $query->where(function($q) use ($jenjangId) {
                     $q->where('id_jenjang', $jenjangId)
                       ->orWhereNull('id_jenjang')
+                      ->orWhereJsonLength('target_jenjang', 0)
                       ->orWhereJsonContains('target_jenjang', $jenjangId);
                 });
             }
@@ -296,7 +297,8 @@ class KurikulumController extends Controller
             if ($kelasId !== null) {
                 $query->where(function($q) use ($kelasId) {
                     $q->whereJsonContains('target_kelas', $kelasId)
-                      ->orWhereNull('target_kelas'); // Not specific to any class
+                      ->orWhereNull('target_kelas') // Not specific to any class
+                      ->orWhereJsonLength('target_kelas', 0);
                 });
             }
 

--- a/backend/app/Http/Controllers/API/AdminCabang/MasterDataController.php
+++ b/backend/app/Http/Controllers/API/AdminCabang/MasterDataController.php
@@ -55,7 +55,7 @@ class MasterDataController extends Controller
         }));
 
         if (empty($value)) {
-            return [];
+            return null;
         }
 
         return array_map('intval', $value);

--- a/backend/database/migrations/2025_09_20_000001_normalize_targets_on_mata_pelajaran_table.php
+++ b/backend/database/migrations/2025_09_20_000001_normalize_targets_on_mata_pelajaran_table.php
@@ -74,7 +74,7 @@ return new class extends Migration
         }));
 
         if (empty($value)) {
-            return [];
+            return null;
         }
 
         return array_map('intval', $value);

--- a/backend/database/migrations/2025_09_20_000002_set_empty_targets_to_null_in_mata_pelajaran_table.php
+++ b/backend/database/migrations/2025_09_20_000002_set_empty_targets_to_null_in_mata_pelajaran_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('mata_pelajaran')
+            ->whereNotNull('target_jenjang')
+            ->where(function ($query) {
+                $query->where('target_jenjang', '[]')
+                      ->orWhereJsonLength('target_jenjang', 0);
+            })
+            ->update(['target_jenjang' => null]);
+
+        DB::table('mata_pelajaran')
+            ->whereNotNull('target_kelas')
+            ->where(function ($query) {
+                $query->where('target_kelas', '[]')
+                      ->orWhereJsonLength('target_kelas', 0);
+            })
+            ->update(['target_kelas' => null]);
+    }
+
+    public function down(): void
+    {
+        // No rollback needed because original intent cannot be reliably restored.
+    }
+};


### PR DESCRIPTION
## Summary
- update target normalization helpers to return null when no explicit values remain
- expand mata pelajaran filtering to include records with empty JSON arrays for jenjang and kelas
- add a data migration that rewrites empty JSON target arrays to null in the mata_pelajaran table

## Testing
- php -l backend/app/Http/Controllers/API/AdminCabang/MasterDataController.php
- php -l backend/app/Http/Controllers/API/AdminCabang/KurikulumController.php
- php -l backend/database/migrations/2025_09_20_000001_normalize_targets_on_mata_pelajaran_table.php
- php -l backend/database/migrations/2025_09_20_000002_set_empty_targets_to_null_in_mata_pelajaran_table.php

------
https://chatgpt.com/codex/tasks/task_e_68d0c21281208323b7de6fa5f5bb72e1