### PR TITLE
Add status override support for GPS approvals

### DIFF
--- a/frontend/src/features/adminCabang/screens/GpsApprovalScreen.js
+++ b/frontend/src/features/adminCabang/screens/GpsApprovalScreen.js
@@ -36,7 +36,10 @@ const GpsApprovalScreen = ({ navigation }) => {
   ];
 
   // Load GPS approval requests
-  const loadGpsRequests = useCallback(async (page = 1, isRefresh = false) => {
+  const loadGpsRequests = useCallback(async (page = 1, isRefresh = false, overrides = {}) => {
+    const { statusOverride } = overrides;
+    const effectiveStatus = statusOverride ?? selectedStatus;
+
     try {
       if (page === 1) {
         isRefresh ? setRefreshing(true) : setLoading(true);
@@ -48,7 +51,7 @@ const GpsApprovalScreen = ({ navigation }) => {
       const params = {
         page,
         per_page: pagination.per_page,
-        status: selectedStatus,
+        status: effectiveStatus,
         search: searchQuery.trim() || undefined,
         sort_by: 'gps_submitted_at',
         sort_order: 'desc'
@@ -94,14 +97,14 @@ const GpsApprovalScreen = ({ navigation }) => {
   );
 
   // Refresh data
-  const handleRefresh = () => {
-    loadGpsRequests(1, true);
+  const handleRefresh = (overrides) => {
+    loadGpsRequests(1, true, overrides);
   };
 
   // Load more data
-  const handleLoadMore = () => {
+  const handleLoadMore = (overrides) => {
     if (!loadingMore && pagination.current_page < pagination.last_page) {
-      loadGpsRequests(pagination.current_page + 1);
+      loadGpsRequests(pagination.current_page + 1, false, overrides);
     }
   };
 
@@ -122,7 +125,7 @@ const GpsApprovalScreen = ({ navigation }) => {
   // Status filter change
   const handleStatusChange = (status) => {
     setSelectedStatus(status);
-    loadGpsRequests(1);
+    loadGpsRequests(1, false, { statusOverride: status });
   };
 
   // Navigate to detail


### PR DESCRIPTION
## Summary
- allow the GPS approval loader to accept an optional status override and apply it to API params
- ensure refresh, pagination, and status tab switching pass along overrides so data loads with the expected status

## Testing
- Not run (react-native environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d80da7bbc883238a08ed86635e0f8d