### PR TITLE
Ensure GPS detection state resets correctly

### DIFF
--- a/frontend/src/features/adminShelter/screens/ShelterGpsSettingScreen.js
+++ b/frontend/src/features/adminShelter/screens/ShelterGpsSettingScreen.js
@@ -89,7 +89,13 @@ const ShelterGpsSettingScreen = ({ navigation }) => {
   };
 
   const handleDetectCurrentLocation = () => {
+    setIsDetectingLocation(true);
     setShowGpsModal(true);
+  };
+
+  const handleCloseGpsModal = () => {
+    setIsDetectingLocation(false);
+    setShowGpsModal(false);
   };
 
   const handleLocationSuccess = (locationData) => {
@@ -98,13 +104,13 @@ const ShelterGpsSettingScreen = ({ navigation }) => {
       latitude: locationData.latitude.toString(),
       longitude: locationData.longitude.toString()
     }));
-    setShowGpsModal(false);
+    handleCloseGpsModal();
     Alert.alert('Berhasil', 'Lokasi saat ini berhasil terdeteksi');
   };
 
 
   const handleLocationError = (error) => {
-    setShowGpsModal(false);
+    handleCloseGpsModal();
     Alert.alert('Error GPS', error);
   };
 
@@ -442,7 +448,7 @@ const ShelterGpsSettingScreen = ({ navigation }) => {
       {/* GPS Permission Modal */}
       <GpsPermissionModal
         visible={showGpsModal}
-        onClose={() => setShowGpsModal(false)}
+        onClose={handleCloseGpsModal}
         onLocationSuccess={handleLocationSuccess}
         onLocationError={handleLocationError}
         title="Deteksi Lokasi Shelter"


### PR DESCRIPTION
## Summary
- set the detecting state when the GPS detection flow starts
- reset the detecting state when the modal closes after success, error, or manual dismissal

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d80fe6f558832390c67ca2270dd60a