### PR TITLE
Add navigation from report screens to detail views

### DIFF
--- a/frontend/src/features/adminShelter/screens/reports/LaporanAnakBinaanScreen.js
+++ b/frontend/src/features/adminShelter/screens/reports/LaporanAnakBinaanScreen.js
@@ -14,6 +14,7 @@ import { Ionicons } from '@expo/vector-icons';
 import * as FileSystem from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
 import * as MediaLibrary from 'expo-media-library';
+import { useNavigation } from '@react-navigation/native';
 
 import LoadingSpinner from '../../../../common/components/LoadingSpinner';
 import ErrorMessage from '../../../../common/components/ErrorMessage';
@@ -55,6 +56,7 @@ import {
 
 const LaporanAnakBinaanScreen = () => {
   const dispatch = useDispatch();
+  const navigation = useNavigation();
   const [refreshing, setRefreshing] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
   const [searchText, setSearchText] = useState('');
@@ -232,8 +234,10 @@ const LaporanAnakBinaanScreen = () => {
 
   // Handle child item press
   const handleChildPress = (child) => {
-    console.log('Child pressed:', child.full_name);
-    // TODO: Navigate to child detail
+    navigation.navigate('AnakDetail', {
+      childId: child.id_anak,
+      filters: { ...filters, search: searchText },
+    });
   };
 
   // Handle PDF export

--- a/frontend/src/features/adminShelter/screens/reports/LaporanRaportAnakScreen.js
+++ b/frontend/src/features/adminShelter/screens/reports/LaporanRaportAnakScreen.js
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
 
 import LoadingSpinner from '../../../../common/components/LoadingSpinner';
 import ErrorMessage from '../../../../common/components/ErrorMessage';
@@ -45,6 +46,7 @@ import {
 
 const LaporanRaportAnakScreen = () => {
   const dispatch = useDispatch();
+  const navigation = useNavigation();
   const [refreshing, setRefreshing] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
   const [searchText, setSearchText] = useState('');
@@ -167,8 +169,10 @@ const LaporanRaportAnakScreen = () => {
 
   // Handle child item press
   const handleChildPress = (child) => {
-    console.log('Child pressed:', child.full_name);
-    // TODO: Navigate to child detail
+    navigation.navigate('RaportChildDetail', {
+      childId: child.id_anak,
+      filters: { ...filters, search: searchText },
+    });
   };
 
   // Handle card expand/collapse

--- a/frontend/src/features/adminShelter/screens/reports/LaporanTutorScreen.js
+++ b/frontend/src/features/adminShelter/screens/reports/LaporanTutorScreen.js
@@ -15,6 +15,7 @@ import { Ionicons } from '@expo/vector-icons';
 import * as FileSystem from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
 import * as MediaLibrary from 'expo-media-library';
+import { useNavigation } from '@react-navigation/native';
 
 import LoadingSpinner from '../../../../common/components/LoadingSpinner';
 import ErrorMessage from '../../../../common/components/ErrorMessage';
@@ -56,6 +57,7 @@ import {
 
 const LaporanTutorScreen = () => {
   const dispatch = useDispatch();
+  const navigation = useNavigation();
   const [refreshing, setRefreshing] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
   const [searchText, setSearchText] = useState('');
@@ -238,7 +240,10 @@ const LaporanTutorScreen = () => {
   };
 
   const handleTutorPress = (tutor) => {
-    console.log('Tutor pressed:', tutor.nama);
+    navigation.navigate('TutorDetail', {
+      tutorId: tutor.id_tutor,
+      filters: { ...filters, search: searchText },
+    });
   };
 
   const handleCardToggle = (tutorId) => {


### PR DESCRIPTION
## Summary
- wire report child, anak binaan, and tutor cards to navigate to their respective detail screens
- pass the active report filters when navigating so detail views can refresh with the same context

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8cc75b3e48323939c435bcb95c0a2