### PR TITLE
Remove PDF export flows from reports

### DIFF
--- a/frontend/src/features/adminShelter/redux/cpbLaporanSlice.js
+++ b/frontend/src/features/adminShelter/redux/cpbLaporanSlice.js
@@ -3,8 +3,7 @@ import {
   fetchCpbReport,
   fetchCpbByStatus,
   initializeCpbLaporanPage,
-  exportCpbData,
-  exportCpbPdf
+  exportCpbData
 } from './cpbLaporanThunks';
 
 const initialState = {
@@ -21,22 +20,18 @@ const initialState = {
   
   // Export data
   exportData: null,
-  pdfBlob: null,
-  pdfFilename: null,
-  
+
   // Loading states
   loading: false,
   childrenLoading: false,
   initializingPage: false,
   exportLoading: false,
-  pdfExportLoading: false,
-  
+
   // Error states
   error: null,
   childrenError: null,
   initializeError: null,
   exportError: null,
-  pdfExportError: null,
   
   // UI state
   filters: {
@@ -70,11 +65,6 @@ const cpbLaporanSlice = createSlice({
       state.exportData = null;
       state.exportError = null;
     },
-    clearPdfData: (state) => {
-      state.pdfBlob = null;
-      state.pdfFilename = null;
-      state.pdfExportError = null;
-    },
     clearError: (state) => {
       state.error = null;
     },
@@ -87,15 +77,11 @@ const cpbLaporanSlice = createSlice({
     clearExportError: (state) => {
       state.exportError = null;
     },
-    clearPdfExportError: (state) => {
-      state.pdfExportError = null;
-    },
     clearAllErrors: (state) => {
       state.error = null;
       state.childrenError = null;
       state.initializeError = null;
       state.exportError = null;
-      state.pdfExportError = null;
     }
   },
   extraReducers: (builder) => {
@@ -158,22 +144,6 @@ const cpbLaporanSlice = createSlice({
       .addCase(exportCpbData.rejected, (state, action) => {
         state.exportLoading = false;
         state.exportError = action.payload;
-      })
-      
-      // Export CPB PDF
-      .addCase(exportCpbPdf.pending, (state) => {
-        state.pdfExportLoading = true;
-        state.pdfExportError = null;
-      })
-      .addCase(exportCpbPdf.fulfilled, (state, action) => {
-        state.pdfExportLoading = false;
-        state.pdfBlob = action.payload.blob;
-        state.pdfFilename = action.payload.filename;
-        state.pdfExportError = null;
-      })
-      .addCase(exportCpbPdf.rejected, (state, action) => {
-        state.pdfExportLoading = false;
-        state.pdfExportError = action.payload;
       });
   }
 });
@@ -185,12 +155,10 @@ export const {
   setActiveTab,
   clearChildren,
   clearExportData,
-  clearPdfData,
   clearError,
   clearChildrenError,
   clearInitializeError,
   clearExportError,
-  clearPdfExportError,
   clearAllErrors
 } = cpbLaporanSlice.actions;
 
@@ -202,18 +170,14 @@ export const selectCpbCurrentStatus = (state) => state.cpbLaporan.currentStatus;
 export const selectCpbFilters = (state) => state.cpbLaporan.filters;
 export const selectCpbActiveTab = (state) => state.cpbLaporan.activeTab;
 export const selectCpbExportData = (state) => state.cpbLaporan.exportData;
-export const selectCpbPdfBlob = (state) => state.cpbLaporan.pdfBlob;
-export const selectCpbPdfFilename = (state) => state.cpbLaporan.pdfFilename;
 export const selectCpbLoading = (state) => state.cpbLaporan.loading;
 export const selectCpbChildrenLoading = (state) => state.cpbLaporan.childrenLoading;
 export const selectCpbInitializingPage = (state) => state.cpbLaporan.initializingPage;
 export const selectCpbExportLoading = (state) => state.cpbLaporan.exportLoading;
-export const selectCpbPdfExportLoading = (state) => state.cpbLaporan.pdfExportLoading;
 export const selectCpbError = (state) => state.cpbLaporan.error;
 export const selectCpbChildrenError = (state) => state.cpbLaporan.childrenError;
 export const selectCpbInitializeError = (state) => state.cpbLaporan.initializeError;
 export const selectCpbExportError = (state) => state.cpbLaporan.exportError;
-export const selectCpbPdfExportError = (state) => state.cpbLaporan.pdfExportError;
 
 // Derived selectors
 export const selectCpbHasActiveFilters = (state) => {

--- a/frontend/src/features/adminShelter/redux/cpbLaporanThunks.js
+++ b/frontend/src/features/adminShelter/redux/cpbLaporanThunks.js
@@ -55,35 +55,6 @@ export const exportCpbData = createAsyncThunk(
   }
 );
 
-// Export CPB data as PDF
-export const exportCpbPdf = createAsyncThunk(
-  'cpbLaporan/exportCpbPdf',
-  async ({ status } = {}, { rejectWithValue }) => {
-    try {
-      const params = { format: 'pdf' };
-      if (status) params.status = status;
-      
-      const response = await cpbLaporanApi.exportCpbPdf(params);
-      
-      // Handle blob response for PDF
-      if (response.data instanceof Blob) {
-        return {
-          blob: response.data,
-          filename: response.headers['content-disposition']?.match(/filename="([^"]+)"/)?.[1] || 
-                   `laporan-cpb-${status ? status.toLowerCase() + '-' : ''}${new Date().toISOString().split('T')[0]}.pdf`
-        };
-      }
-      
-      return response.data;
-    } catch (error) {
-      const message = error.response?.data?.message || 
-        error.message || 
-        'Failed to export CPB PDF';
-      return rejectWithValue(message);
-    }
-  }
-);
-
 // Initialize CPB laporan page data
 export const initializeCpbLaporanPage = createAsyncThunk(
   'cpbLaporan/initializeCpbLaporanPage',

--- a/frontend/src/features/adminShelter/redux/laporanSlice.js
+++ b/frontend/src/features/adminShelter/redux/laporanSlice.js
@@ -5,8 +5,7 @@ import {
   fetchJenisKegiatanOptions,
   fetchAvailableYears,
   initializeLaporanPage,
-  updateFiltersAndRefreshAll,
-  exportLaporanAnakPdf
+  updateFiltersAndRefreshAll
 } from './laporanThunks';
 
 const initialState = {
@@ -24,23 +23,17 @@ const initialState = {
     filter: null
   },
   
-  // PDF export data
-  pdfBlob: null,
-  pdfFilename: null,
-  
   loading: false,
   childDetailLoading: false,
   filterOptionsLoading: false,
   initializingPage: false,
   refreshingAll: false,
-  pdfExportLoading: false,
-  
+
   error: null,
   childDetailError: null,
   filterOptionsError: null,
   initializeError: null,
   refreshAllError: null,
-  pdfExportError: null,
   
   filters: {
     start_date: null,
@@ -115,11 +108,6 @@ const laporanSlice = createSlice({
       };
       state.childDetailError = null;
     },
-    clearPdfData: (state) => {
-      state.pdfBlob = null;
-      state.pdfFilename = null;
-      state.pdfExportError = null;
-    },
     clearError: (state) => {
       state.error = null;
     },
@@ -135,16 +123,12 @@ const laporanSlice = createSlice({
     clearRefreshAllError: (state) => {
       state.refreshAllError = null;
     },
-    clearPdfExportError: (state) => {
-      state.pdfExportError = null;
-    },
     clearAllErrors: (state) => {
       state.error = null;
       state.childDetailError = null;
       state.filterOptionsError = null;
       state.initializeError = null;
       state.refreshAllError = null;
-      state.pdfExportError = null;
     }
   },
   extraReducers: (builder) => {
@@ -255,22 +239,6 @@ const laporanSlice = createSlice({
       .addCase(fetchAvailableYears.rejected, (state, action) => {
         state.filterOptionsLoading = false;
         state.filterOptionsError = action.payload;
-      })
-      
-      // Export PDF
-      .addCase(exportLaporanAnakPdf.pending, (state) => {
-        state.pdfExportLoading = true;
-        state.pdfExportError = null;
-      })
-      .addCase(exportLaporanAnakPdf.fulfilled, (state, action) => {
-        state.pdfExportLoading = false;
-        state.pdfBlob = action.payload.blob;
-        state.pdfFilename = action.payload.filename;
-        state.pdfExportError = null;
-      })
-      .addCase(exportLaporanAnakPdf.rejected, (state, action) => {
-        state.pdfExportLoading = false;
-        state.pdfExportError = action.payload;
       });
   }
 });
@@ -288,13 +256,11 @@ export const {
   expandAllCards,
   collapseAllCards,
   clearChildDetail,
-  clearPdfData,
   clearError,
   clearChildDetailError,
   clearFilterOptionsError,
   clearInitializeError,
   clearRefreshAllError,
-  clearPdfExportError,
   clearAllErrors
 } = laporanSlice.actions;
 
@@ -312,15 +278,11 @@ export const selectChildDetailLoading = (state) => state.laporan.childDetailLoad
 export const selectFilterOptionsLoading = (state) => state.laporan.filterOptionsLoading;
 export const selectInitializingPage = (state) => state.laporan.initializingPage;
 export const selectRefreshingAll = (state) => state.laporan.refreshingAll;
-export const selectPdfExportLoading = (state) => state.laporan.pdfExportLoading;
 export const selectError = (state) => state.laporan.error;
 export const selectChildDetailError = (state) => state.laporan.childDetailError;
 export const selectFilterOptionsError = (state) => state.laporan.filterOptionsError;
 export const selectInitializeError = (state) => state.laporan.initializeError;
 export const selectRefreshAllError = (state) => state.laporan.refreshAllError;
-export const selectPdfExportError = (state) => state.laporan.pdfExportError;
-export const selectPdfBlob = (state) => state.laporan.pdfBlob;
-export const selectPdfFilename = (state) => state.laporan.pdfFilename;
 
 // Derived selectors
 export const selectHasActiveFilters = (state) => {

--- a/frontend/src/features/adminShelter/redux/laporanThunks.js
+++ b/frontend/src/features/adminShelter/redux/laporanThunks.js
@@ -134,37 +134,6 @@ export const updateFiltersAndRefreshAll = createAsyncThunk(
   }
 );
 
-// Export PDF functionality
-export const exportLaporanAnakPdf = createAsyncThunk(
-  'laporan/exportLaporanAnakPdf',
-  async ({ start_date, end_date, jenisKegiatan, search } = {}, { rejectWithValue }) => {
-    try {
-      const params = {};
-      if (start_date) params.start_date = start_date;
-      if (end_date) params.end_date = end_date;
-      if (jenisKegiatan) params.jenisKegiatan = jenisKegiatan;
-      if (search) params.search = search;
-      
-      const response = await laporanAnakApi.exportLaporanAnakPdf(params);
-      
-      if (response.data instanceof Blob) {
-        return {
-          blob: response.data,
-          filename: response.headers['content-disposition']?.match(/filename="([^"]+)"/)?.[1] || 
-                   `laporan-anak-binaan-${new Date().toISOString().split('T')[0]}.pdf`
-        };
-      }
-      
-      return response.data;
-    } catch (error) {
-      const message = error.response?.data?.message || 
-        error.message || 
-        'Failed to export PDF';
-      return rejectWithValue(message);
-    }
-  }
-);
-
 // Refresh laporan with current filters
 export const refreshLaporanWithFilters = createAsyncThunk(
   'laporan/refreshLaporanWithFilters',

--- a/frontend/src/features/adminShelter/redux/tutorLaporanSlice.js
+++ b/frontend/src/features/adminShelter/redux/tutorLaporanSlice.js
@@ -6,8 +6,7 @@ import {
   fetchTutorAvailableYears,
   initializeTutorLaporanPage,
   updateTutorFiltersAndRefreshAll,
-  exportTutorData,
-  exportTutorPdf
+  exportTutorData
 } from './tutorLaporanThunks';
 
 const initialState = {
@@ -29,24 +28,20 @@ const initialState = {
   
   // Export data
   exportData: null,
-  pdfBlob: null,
-  pdfFilename: null,
-  
+
   loading: false,
   tutorDetailLoading: false,
   filterOptionsLoading: false,
   initializingPage: false,
   refreshingAll: false,
   exportLoading: false,
-  pdfExportLoading: false,
-  
+
   error: null,
   tutorDetailError: null,
   filterOptionsError: null,
   initializeError: null,
   refreshAllError: null,
   exportError: null,
-  pdfExportError: null,
   
   filters: {
     start_date: null,
@@ -122,11 +117,6 @@ const tutorLaporanSlice = createSlice({
       state.exportData = null;
       state.exportError = null;
     },
-    clearPdfData: (state) => {
-      state.pdfBlob = null;
-      state.pdfFilename = null;
-      state.pdfExportError = null;
-    },
     clearError: (state) => {
       state.error = null;
     },
@@ -145,9 +135,6 @@ const tutorLaporanSlice = createSlice({
     clearExportError: (state) => {
       state.exportError = null;
     },
-    clearPdfExportError: (state) => {
-      state.pdfExportError = null;
-    },
     clearAllErrors: (state) => {
       state.error = null;
       state.tutorDetailError = null;
@@ -155,7 +142,6 @@ const tutorLaporanSlice = createSlice({
       state.initializeError = null;
       state.refreshAllError = null;
       state.exportError = null;
-      state.pdfExportError = null;
     }
   },
   extraReducers: (builder) => {
@@ -277,22 +263,6 @@ const tutorLaporanSlice = createSlice({
       .addCase(exportTutorData.rejected, (state, action) => {
         state.exportLoading = false;
         state.exportError = action.payload;
-      })
-      
-      // Export PDF
-      .addCase(exportTutorPdf.pending, (state) => {
-        state.pdfExportLoading = true;
-        state.pdfExportError = null;
-      })
-      .addCase(exportTutorPdf.fulfilled, (state, action) => {
-        state.pdfExportLoading = false;
-        state.pdfBlob = action.payload.blob;
-        state.pdfFilename = action.payload.filename;
-        state.pdfExportError = null;
-      })
-      .addCase(exportTutorPdf.rejected, (state, action) => {
-        state.pdfExportLoading = false;
-        state.pdfExportError = action.payload;
       });
   }
 });
@@ -310,14 +280,12 @@ export const {
   collapseAllCards,
   clearTutorDetail,
   clearExportData,
-  clearPdfData,
   clearError,
   clearTutorDetailError,
   clearFilterOptionsError,
   clearInitializeError,
   clearRefreshAllError,
   clearExportError,
-  clearPdfExportError,
   clearAllErrors
 } = tutorLaporanSlice.actions;
 
@@ -332,22 +300,18 @@ export const selectTutorFilters = (state) => state.tutorLaporan.filters;
 export const selectTutorExpandedCards = (state) => state.tutorLaporan.expandedCards;
 export const selectTutorDetail = (state) => state.tutorLaporan.tutorDetail;
 export const selectTutorExportData = (state) => state.tutorLaporan.exportData;
-export const selectTutorPdfBlob = (state) => state.tutorLaporan.pdfBlob;
-export const selectTutorPdfFilename = (state) => state.tutorLaporan.pdfFilename;
 export const selectTutorLoading = (state) => state.tutorLaporan.loading;
 export const selectTutorDetailLoading = (state) => state.tutorLaporan.tutorDetailLoading;
 export const selectTutorFilterOptionsLoading = (state) => state.tutorLaporan.filterOptionsLoading;
 export const selectTutorInitializingPage = (state) => state.tutorLaporan.initializingPage;
 export const selectTutorRefreshingAll = (state) => state.tutorLaporan.refreshingAll;
 export const selectTutorExportLoading = (state) => state.tutorLaporan.exportLoading;
-export const selectTutorPdfExportLoading = (state) => state.tutorLaporan.pdfExportLoading;
 export const selectTutorError = (state) => state.tutorLaporan.error;
 export const selectTutorDetailError = (state) => state.tutorLaporan.tutorDetailError;
 export const selectTutorFilterOptionsError = (state) => state.tutorLaporan.filterOptionsError;
 export const selectTutorInitializeError = (state) => state.tutorLaporan.initializeError;
 export const selectTutorRefreshAllError = (state) => state.tutorLaporan.refreshAllError;
 export const selectTutorExportError = (state) => state.tutorLaporan.exportError;
-export const selectTutorPdfExportError = (state) => state.tutorLaporan.pdfExportError;
 
 export const selectIsTutorCardExpanded = (state, tutorId) => 
   state.tutorLaporan.expandedCards.includes(tutorId);

--- a/frontend/src/features/adminShelter/redux/tutorLaporanThunks.js
+++ b/frontend/src/features/adminShelter/redux/tutorLaporanThunks.js
@@ -63,37 +63,6 @@ export const exportTutorData = createAsyncThunk(
   }
 );
 
-export const exportTutorPdf = createAsyncThunk(
-  'tutorLaporan/exportTutorPdf',
-  async ({ start_date, end_date, jenisKegiatan, search } = {}, { rejectWithValue }) => {
-    try {
-      const params = {};
-      if (start_date) params.start_date = start_date;
-      if (end_date) params.end_date = end_date;
-      if (jenisKegiatan) params.jenis_kegiatan = jenisKegiatan;
-      if (search) params.search = search;
-      
-      const response = await tutorLaporanApi.exportTutorPdf(params);
-      
-      // Handle blob response for PDF
-      if (response.data instanceof Blob) {
-        return {
-          blob: response.data,
-          filename: response.headers['content-disposition']?.match(/filename="([^"]+)"/)?.[1] || 
-                   `laporan-tutor-${new Date().toISOString().split('T')[0]}.pdf`
-        };
-      }
-      
-      return response.data;
-    } catch (error) {
-      const message = error.response?.data?.message || 
-        error.message || 
-        'Failed to export tutor PDF';
-      return rejectWithValue(message);
-    }
-  }
-);
-
 export const fetchTutorJenisKegiatanOptions = createAsyncThunk(
   'tutorLaporan/fetchTutorJenisKegiatanOptions',
   async (_, { rejectWithValue }) => {


### PR DESCRIPTION
## Summary
- remove Expo file sharing and PDF handlers from the child, tutor, and CPB report screens
- strip PDF export state, selectors, and async thunks from the laporan, tutorLaporan, and cpbLaporan Redux modules
- leave the existing data loading, filtering, and pagination logic untouched so the reports still render normally

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8cd0d7fe48323b1eab006b4f8b1bd