### PR TITLE
Wrap icon touchables in CPB report

### DIFF
--- a/frontend/src/features/adminShelter/screens/reports/CPBReportScreen.js
+++ b/frontend/src/features/adminShelter/screens/reports/CPBReportScreen.js
@@ -139,11 +139,13 @@ const CPBReportScreen = () => {
           editable={!childrenLoading}
         />
         {searchText ? (
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.clearSearchButton}
             onPress={handleClearSearch}
           >
-            <Ionicons name="close-circle" size={20} color="#666" />
+            <Text>
+              <Ionicons name="close-circle" size={20} color="#666" />
+            </Text>
           </TouchableOpacity>
         ) : null}
         
@@ -166,12 +168,14 @@ const CPBReportScreen = () => {
 
       {/* Clear Search */}
       {filters.search && (
-        <TouchableOpacity 
+        <TouchableOpacity
           style={styles.clearFiltersButton}
           onPress={handleClearSearch}
           disabled={childrenLoading}
         >
-          <Ionicons name="close-circle" size={16} color="#9b59b6" />
+          <Text>
+            <Ionicons name="close-circle" size={16} color="#9b59b6" />
+          </Text>
           <Text style={styles.clearFiltersText}>Hapus Pencarian</Text>
         </TouchableOpacity>
       )}


### PR DESCRIPTION
## Summary
- wrap CPB report screen touchable icons in Text to avoid rendering bare glyph strings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d50e284c8323ad45b30577b531e2