### PR TITLE
Add missing shelter report screens to management navigator

### DIFF
--- a/frontend/src/navigation/AdminShelterNavigator.js
+++ b/frontend/src/navigation/AdminShelterNavigator.js
@@ -178,6 +178,9 @@ const ManagementStackNavigator = () => (
     <ManagementStack.Screen name="LaporanKegiatanMain" component={LaporanKegiatanMainScreen} options={{ headerTitle: 'Laporan Kegiatan' }} />
     <ManagementStack.Screen name="LaporanAnakBinaan" component={LaporanAnakBinaanScreen} options={{ headerTitle: 'Laporan Anak Binaan' }} />
     <ManagementStack.Screen name="LaporanRaportAnak" component={LaporanRaportAnakScreen} options={{ headerTitle: 'Laporan Raport Anak' }} />
+    <ManagementStack.Screen name="LaporanHistoriAnak" component={LaporanHistoriAnakScreen} options={{ headerTitle: 'Laporan Histori Anak' }} />
+    <ManagementStack.Screen name="LaporanAktivitas" component={LaporanAktivitasScreen} options={{ headerTitle: 'Laporan Aktivitas' }} />
+    <ManagementStack.Screen name="LaporanSuratAnak" component={LaporanSuratAnakScreen} options={{ headerTitle: 'Laporan Surat Anak' }} />
     <ManagementStack.Screen name="ShelterReport" component={ShelterReportScreen} options={{ headerTitle: 'Shelter Report' }} />
     <ManagementStack.Screen name="CPBReport" component={CPBReportScreen} options={{ headerTitle: 'CPB Report' }} />
     <ManagementStack.Screen name="RaportGenerate" component={RaportGenerateScreen} options={{ headerTitle: 'Generate Raport' }} />


### PR DESCRIPTION
## Summary
- add the missing management stack routes for shelter reports so that each card has a matching screen

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d8d64269908323aa76e5f2fcd6d7a3