### PR TITLE
Ensure semester actions use fallback IDs

### DIFF
--- a/frontend/src/features/adminCabang/api/kurikulumApi.js
+++ b/frontend/src/features/adminCabang/api/kurikulumApi.js
@@ -335,7 +335,7 @@ export const kurikulumApi = createApi({
         const data = result?.data;
         if (Array.isArray(data)) {
           return [
-            ...data.map(({ id_semester }) => ({ type: 'Semester', id: id_semester })),
+            ...data.map(({ id_semester, id }) => ({ type: 'Semester', id: id_semester ?? id })),
             { type: 'Semester', id: 'LIST' },
           ];
         }

--- a/frontend/src/features/adminCabang/screens/kurikulum/SemesterFormScreen.js
+++ b/frontend/src/features/adminCabang/screens/kurikulum/SemesterFormScreen.js
@@ -170,8 +170,15 @@ const SemesterFormScreen = () => {
 
     try {
       if (isEditMode) {
+        const semesterId = semesterParam?.id_semester ?? semesterParam?.id;
+
+        if (!semesterId) {
+          Alert.alert('Error', 'ID semester tidak ditemukan');
+          return;
+        }
+
         await updateSemester({
-          id: semesterParam.id_semester,
+          id: semesterId,
           ...payload,
         }).unwrap();
         Alert.alert('Berhasil', 'Semester berhasil diupdate');

--- a/frontend/src/features/adminCabang/screens/kurikulum/SemesterManagementScreen.js
+++ b/frontend/src/features/adminCabang/screens/kurikulum/SemesterManagementScreen.js
@@ -21,6 +21,10 @@ import SemesterListSection from './components/SemesterListSection';
  * Semester Management Screen - API Integrated
  * CRUD interface for semester management
  */
+const resolveSemesterId = (semester) => (
+  semester?.id_semester ?? semester?.id ?? null
+);
+
 const SemesterManagementScreen = ({ navigation }) => {
   const { selectedKurikulumId, selectedKurikulum } = useSelector(state => state?.kurikulum || {});
   const activeKurikulumId = selectedKurikulumId
@@ -74,6 +78,13 @@ const SemesterManagementScreen = ({ navigation }) => {
   };
 
   const handleDeleteSemester = async (semester) => {
+    const semesterId = resolveSemesterId(semester);
+
+    if (!semesterId) {
+      Alert.alert('Error', 'ID semester tidak ditemukan');
+      return;
+    }
+
     Alert.alert(
       'Hapus Semester',
       `Apakah Anda yakin ingin menghapus semester "${semester.nama_semester}"?`,
@@ -84,7 +95,7 @@ const SemesterManagementScreen = ({ navigation }) => {
           style: 'destructive',
           onPress: async () => {
             try {
-              await deleteSemester(semester.id_semester).unwrap();
+              await deleteSemester(semesterId).unwrap();
               Alert.alert('Berhasil', 'Semester berhasil dihapus');
             } catch (error) {
               Alert.alert('Error', error?.data?.message || 'Gagal menghapus semester');
@@ -96,6 +107,13 @@ const SemesterManagementScreen = ({ navigation }) => {
   };
 
   const handleSetActive = async (semester) => {
+    const semesterId = resolveSemesterId(semester);
+
+    if (!semesterId) {
+      Alert.alert('Error', 'ID semester tidak ditemukan');
+      return;
+    }
+
     Alert.alert(
       'Aktifkan Semester',
       `Aktifkan semester "${semester.nama_semester}"? Semester aktif lainnya akan dinonaktifkan.`,
@@ -105,7 +123,7 @@ const SemesterManagementScreen = ({ navigation }) => {
           text: 'Aktifkan',
           onPress: async () => {
             try {
-              await setActiveSemester(semester.id_semester).unwrap();
+              await setActiveSemester(semesterId).unwrap();
               Alert.alert('Berhasil', 'Semester berhasil diaktifkan');
             } catch (error) {
               Alert.alert('Error', error?.data?.message || 'Gagal mengaktifkan semester');

--- a/frontend/src/features/adminCabang/screens/kurikulum/components/SemesterListSection.js
+++ b/frontend/src/features/adminCabang/screens/kurikulum/components/SemesterListSection.js
@@ -48,6 +48,10 @@ const formatDate = (dateString) => {
   });
 };
 
+const resolveSemesterId = (semester) => (
+  semester?.id_semester ?? semester?.id ?? null
+);
+
 const SemesterListSection = ({
   tabs,
   selectedTab,
@@ -86,72 +90,77 @@ const SemesterListSection = ({
           />
         }
       >
-        {data.map((semester) => (
-          <View key={semester.id_semester} style={styles.semesterCard}>
-            <View style={styles.cardHeader}>
-              <View style={styles.cardTitle}>
-                <Text style={styles.semesterName}>{semester.nama_semester}</Text>
-                <View
-                  style={[
-                    styles.statusBadge,
-                    { backgroundColor: getStatusColor(semester.status) }
-                  ]}
-                >
-                  <Text style={styles.statusText}>
-                    {getStatusText(semester.status)}
+        {data.map((semester, index) => {
+          const semesterId = resolveSemesterId(semester);
+          const key = semesterId ? semesterId.toString() : `semester-${index}`;
+
+          return (
+            <View key={key} style={styles.semesterCard}>
+              <View style={styles.cardHeader}>
+                <View style={styles.cardTitle}>
+                  <Text style={styles.semesterName}>{semester.nama_semester}</Text>
+                  <View
+                    style={[
+                      styles.statusBadge,
+                      { backgroundColor: getStatusColor(semester.status) }
+                    ]}
+                  >
+                    <Text style={styles.statusText}>
+                      {getStatusText(semester.status)}
+                    </Text>
+                  </View>
+                </View>
+              </View>
+
+              <View style={styles.cardContent}>
+                <View style={styles.infoRow}>
+                  <Ionicons name="calendar-outline" size={14} color="#6c757d" />
+                  <Text style={styles.infoText}>
+                    {formatDate(semester.tanggal_mulai)} - {formatDate(semester.tanggal_selesai)}
+                  </Text>
+                </View>
+                <View style={styles.infoRow}>
+                  <Ionicons name="school-outline" size={14} color="#6c757d" />
+                  <Text style={styles.infoText}>
+                    Tahun Ajaran {semester.tahun_ajaran}
+                  </Text>
+                </View>
+                <View style={styles.infoRow}>
+                  <Ionicons name="time-outline" size={14} color="#6c757d" />
+                  <Text style={styles.infoText}>
+                    Periode {semester.periode === 'ganjil' ? 'Ganjil' : 'Genap'}
                   </Text>
                 </View>
               </View>
-            </View>
 
-            <View style={styles.cardContent}>
-              <View style={styles.infoRow}>
-                <Ionicons name="calendar-outline" size={14} color="#6c757d" />
-                <Text style={styles.infoText}>
-                  {formatDate(semester.tanggal_mulai)} - {formatDate(semester.tanggal_selesai)}
-                </Text>
-              </View>
-              <View style={styles.infoRow}>
-                <Ionicons name="school-outline" size={14} color="#6c757d" />
-                <Text style={styles.infoText}>
-                  Tahun Ajaran {semester.tahun_ajaran}
-                </Text>
-              </View>
-              <View style={styles.infoRow}>
-                <Ionicons name="time-outline" size={14} color="#6c757d" />
-                <Text style={styles.infoText}>
-                  Periode {semester.periode === 'ganjil' ? 'Ganjil' : 'Genap'}
-                </Text>
-              </View>
-            </View>
-
-            <View style={styles.cardActions}>
-              {semester.status === 'draft' && (
+              <View style={styles.cardActions}>
+                {semester.status === 'draft' && (
+                  <TouchableOpacity
+                    style={[styles.actionButton, styles.activateButton]}
+                    onPress={() => onSetActive(semester)}
+                  >
+                    <Ionicons name="play-circle" size={16} color="#28a745" />
+                    <Text style={[styles.actionText, { color: '#28a745' }]}>Aktifkan</Text>
+                  </TouchableOpacity>
+                )}
                 <TouchableOpacity
-                  style={[styles.actionButton, styles.activateButton]}
-                  onPress={() => onSetActive(semester)}
+                  style={styles.actionButton}
+                  onPress={() => onEdit(semester)}
                 >
-                  <Ionicons name="play-circle" size={16} color="#28a745" />
-                  <Text style={[styles.actionText, { color: '#28a745' }]}>Aktifkan</Text>
+                  <Ionicons name="pencil" size={16} color="#007bff" />
+                  <Text style={styles.actionText}>Edit</Text>
                 </TouchableOpacity>
-              )}
-              <TouchableOpacity
-                style={styles.actionButton}
-                onPress={() => onEdit(semester)}
-              >
-                <Ionicons name="pencil" size={16} color="#007bff" />
-                <Text style={styles.actionText}>Edit</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[styles.actionButton, styles.deleteButton]}
-                onPress={() => onDelete(semester)}
-              >
-                <Ionicons name="trash" size={16} color="#dc3545" />
-                <Text style={[styles.actionText, styles.deleteText]}>Hapus</Text>
-              </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.actionButton, styles.deleteButton]}
+                  onPress={() => onDelete(semester)}
+                >
+                  <Ionicons name="trash" size={16} color="#dc3545" />
+                  <Text style={[styles.actionText, styles.deleteText]}>Hapus</Text>
+                </TouchableOpacity>
+              </View>
             </View>
-          </View>
-        ))}
+          );
+        })}
 
         {data.length === 0 && (
           <View style={styles.emptyState}>


### PR DESCRIPTION
## Summary
- add reusable helpers to resolve semester IDs when only `id` is provided
- update CRUD handlers to use the fallback ID for update, delete, and activate operations
- align list rendering and cache tagging with the same fallback logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d90874465883239fe4932450352a0a