### PR TITLE
feat(admin-cabang): add reports home and navigation

### DIFF
--- a/frontend/src/constants/endpoints.js
+++ b/frontend/src/constants/endpoints.js
@@ -149,6 +149,11 @@ export const ADMIN_CABANG_ENDPOINTS = {
     SHELTERS_BY_WILBIN: (wilbinId) => `/admin-cabang/donatur-shelters/${wilbinId}`,
     STATS: '/admin-cabang/donatur-stats'
   },
+  REPORTS: {
+    SUMMARY: '/admin-cabang/reports/summary',
+    CHILDREN: '/admin-cabang/reports/children',
+    TUTORS: '/admin-cabang/reports/tutors',
+  },
   KURIKULUM: {
     LIST: '/admin-cabang/kurikulum',
     DETAIL: (id) => `/admin-cabang/kurikulum/${id}`,

--- a/frontend/src/features/adminCabang/api/adminCabangReportsApi.js
+++ b/frontend/src/features/adminCabang/api/adminCabangReportsApi.js
@@ -1,0 +1,10 @@
+import api from '../../../api/axiosConfig';
+import { ADMIN_CABANG_ENDPOINTS } from '../../../constants/endpoints';
+
+const { REPORTS } = ADMIN_CABANG_ENDPOINTS;
+
+export const adminCabangReportsApi = {
+  async getSummary(params) {
+    return api.get(REPORTS.SUMMARY, { params });
+  },
+};

--- a/frontend/src/features/adminCabang/components/reports/ReportQuickLinkTile.js
+++ b/frontend/src/features/adminCabang/components/reports/ReportQuickLinkTile.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import { TouchableOpacity, View, Text, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+const ReportQuickLinkTile = ({
+  title,
+  description,
+  icon = 'document-text',
+  color = '#3498db',
+  onPress,
+  disabled = false,
+}) => (
+  <TouchableOpacity
+    style={[styles.card, disabled && styles.cardDisabled]}
+    onPress={onPress}
+    activeOpacity={0.85}
+    disabled={disabled}
+  >
+    <View style={[styles.iconContainer, { backgroundColor: color }]}> 
+      <Ionicons name={icon} size={22} color="#fff" />
+    </View>
+    <View style={styles.textContainer}>
+      <Text style={styles.titleText} numberOfLines={2}>
+        {title}
+      </Text>
+      {description && (
+        <Text style={styles.descriptionText} numberOfLines={3}>
+          {description}
+        </Text>
+      )}
+    </View>
+    <Ionicons name="chevron-forward" size={18} color="#b2bec3" />
+  </TouchableOpacity>
+);
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#ffffff',
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    borderRadius: 12,
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: '#f0f0f0',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.08,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  cardDisabled: {
+    opacity: 0.6,
+  },
+  iconContainer: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 14,
+  },
+  textContainer: {
+    flex: 1,
+    marginRight: 8,
+  },
+  titleText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#2d3436',
+  },
+  descriptionText: {
+    fontSize: 13,
+    color: '#636e72',
+    marginTop: 4,
+  },
+});
+
+export default ReportQuickLinkTile;

--- a/frontend/src/features/adminCabang/components/reports/ReportSummaryCard.js
+++ b/frontend/src/features/adminCabang/components/reports/ReportSummaryCard.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+const ReportSummaryCard = ({
+  icon = 'stats-chart',
+  label,
+  value,
+  description,
+  color = '#2ecc71',
+  accessory,
+}) => {
+  const formattedValue = typeof value === 'number'
+    ? value.toLocaleString('id-ID')
+    : value;
+
+  return (
+    <View style={styles.card}>
+      <View style={[styles.iconContainer, { backgroundColor: color }]}>
+        <Ionicons name={icon} size={22} color="#fff" />
+      </View>
+      <View style={styles.textContainer}>
+        <Text style={styles.valueText} numberOfLines={1}>
+          {formattedValue ?? '-'}
+        </Text>
+        {label && (
+          <Text style={styles.labelText} numberOfLines={2}>
+            {label}
+          </Text>
+        )}
+        {description && (
+          <Text style={styles.descriptionText} numberOfLines={2}>
+            {description}
+          </Text>
+        )}
+      </View>
+      {accessory}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#ffffff',
+    paddingVertical: 16,
+    paddingHorizontal: 14,
+    borderRadius: 12,
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: '#f0f0f0',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.08,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  iconContainer: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 14,
+  },
+  textContainer: {
+    flex: 1,
+  },
+  valueText: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#2d3436',
+  },
+  labelText: {
+    fontSize: 14,
+    color: '#636e72',
+    marginTop: 4,
+  },
+  descriptionText: {
+    fontSize: 12,
+    color: '#95a5a6',
+    marginTop: 2,
+  },
+});
+
+export default ReportSummaryCard;

--- a/frontend/src/features/adminCabang/screens/reports/AdminCabangChildrenReportScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/AdminCabangChildrenReportScreen.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+const AdminCabangChildrenReportScreen = () => (
+  <View style={styles.container}>
+    <Text style={styles.title}>Laporan Anak Binaan</Text>
+    <Text style={styles.description}>
+      Modul laporan anak binaan akan segera hadir. Pantau pembaruan berikutnya untuk fitur ini.
+    </Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f6fa',
+    padding: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#2d3436',
+    marginBottom: 12,
+    textAlign: 'center',
+  },
+  description: {
+    fontSize: 14,
+    color: '#636e72',
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+});
+
+export default AdminCabangChildrenReportScreen;

--- a/frontend/src/features/adminCabang/screens/reports/AdminCabangReportHomeScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/AdminCabangReportHomeScreen.js
@@ -1,0 +1,312 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ScrollView,
+  StyleSheet,
+  View,
+  Text,
+  RefreshControl,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+
+import LoadingSpinner from '../../../../common/components/LoadingSpinner';
+import ErrorMessage from '../../../../common/components/ErrorMessage';
+import ReportSummaryCard from '../../components/reports/ReportSummaryCard';
+import ReportQuickLinkTile from '../../components/reports/ReportQuickLinkTile';
+import { adminCabangReportsApi } from '../../api/adminCabangReportsApi';
+
+const DEFAULT_LINKS = [
+  {
+    key: 'children',
+    title: 'Laporan Anak Binaan',
+    description: 'Pantau perkembangan dan kebutuhan anak binaan di cabang Anda.',
+    icon: 'school',
+    color: '#2980b9',
+    route: 'AdminCabangChildrenReport',
+  },
+  {
+    key: 'tutors',
+    title: 'Laporan Tutor',
+    description: 'Tinjau performa dan aktivitas tutor shelter di wilayah Anda.',
+    icon: 'people-circle',
+    color: '#9b59b6',
+    route: 'AdminCabangTutorReport',
+  },
+];
+
+const DEFAULT_SUMMARY = [
+  {
+    key: 'childrenTotal',
+    label: 'Total Anak Binaan',
+    value: 0,
+    icon: 'people',
+    color: '#27ae60',
+    description: 'Jumlah keseluruhan anak binaan aktif.',
+  },
+  {
+    key: 'shelterTotal',
+    label: 'Total Shelter',
+    value: 0,
+    icon: 'home',
+    color: '#e67e22',
+    description: 'Jumlah shelter aktif di cabang Anda.',
+  },
+  {
+    key: 'tutorTotal',
+    label: 'Total Tutor',
+    value: 0,
+    icon: 'person',
+    color: '#8e44ad',
+    description: 'Tutor aktif yang terdaftar dalam cabang.',
+  },
+];
+
+const AdminCabangReportHomeScreen = () => {
+  const navigation = useNavigation();
+  const [summaryCards, setSummaryCards] = useState(DEFAULT_SUMMARY);
+  const [quickLinks, setQuickLinks] = useState(DEFAULT_LINKS);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState(null);
+
+  const routeMap = useMemo(
+    () => ({
+      children: 'AdminCabangChildrenReport',
+      tutors: 'AdminCabangTutorReport',
+    }),
+    []
+  );
+
+  const parseSummaryCards = useCallback((payload) => {
+    if (!payload) return DEFAULT_SUMMARY;
+
+    if (Array.isArray(payload) && payload.length > 0) {
+      return payload.map((item, index) => ({
+        key: item.key || `${item.label || 'summary'}-${index}`,
+        label: item.label || item.title || 'Ringkasan',
+        value: item.value ?? item.total ?? 0,
+        icon: item.icon || 'stats-chart',
+        color: item.color || '#2ecc71',
+        description: item.description || item.subtitle || null,
+      }));
+    }
+
+    const cards = [];
+    if (payload.children) {
+      cards.push({
+        key: 'children',
+        label: payload.children.label || 'Total Anak Binaan',
+        value: payload.children.total ?? payload.children.value ?? 0,
+        icon: payload.children.icon || 'people',
+        color: payload.children.color || '#27ae60',
+        description: payload.children.description || payload.children.active_text,
+      });
+    } else if (payload.total_children || payload.children_total) {
+      cards.push({
+        key: 'children',
+        label: 'Total Anak Binaan',
+        value: payload.total_children ?? payload.children_total ?? 0,
+        icon: 'people',
+        color: '#27ae60',
+        description: payload.active_children
+          ? `${payload.active_children.toLocaleString('id-ID')} aktif`
+          : undefined,
+      });
+    }
+
+    if (payload.shelters) {
+      cards.push({
+        key: 'shelters',
+        label: payload.shelters.label || 'Total Shelter',
+        value: payload.shelters.total ?? payload.shelters.value ?? 0,
+        icon: payload.shelters.icon || 'home',
+        color: payload.shelters.color || '#e67e22',
+        description: payload.shelters.description || null,
+      });
+    } else if (payload.total_shelter || payload.shelter_total) {
+      cards.push({
+        key: 'shelters',
+        label: 'Total Shelter',
+        value: payload.total_shelter ?? payload.shelter_total ?? 0,
+        icon: 'home',
+        color: '#e67e22',
+        description: null,
+      });
+    }
+
+    if (payload.tutors) {
+      cards.push({
+        key: 'tutors',
+        label: payload.tutors.label || 'Total Tutor',
+        value: payload.tutors.total ?? payload.tutors.value ?? 0,
+        icon: payload.tutors.icon || 'people-circle',
+        color: payload.tutors.color || '#8e44ad',
+        description: payload.tutors.description || null,
+      });
+    } else if (payload.total_tutors || payload.tutor_total) {
+      cards.push({
+        key: 'tutors',
+        label: 'Total Tutor',
+        value: payload.total_tutors ?? payload.tutor_total ?? 0,
+        icon: 'people-circle',
+        color: '#8e44ad',
+        description: null,
+      });
+    }
+
+    if (payload.attendance_rate || payload.average_attendance) {
+      cards.push({
+        key: 'attendance',
+        label: 'Rata-rata Kehadiran',
+        value: `${Math.round((payload.attendance_rate ?? payload.average_attendance) * 100) / 100}%`,
+        icon: 'calendar',
+        color: '#16a085',
+        description: 'Rerata kehadiran seluruh kegiatan.',
+      });
+    }
+
+    return cards.length > 0 ? cards : DEFAULT_SUMMARY;
+  }, []);
+
+  const parseQuickLinks = useCallback((payload) => {
+    if (!payload || !Array.isArray(payload) || payload.length === 0) {
+      return DEFAULT_LINKS;
+    }
+
+    return payload.map((link, index) => {
+      const key = link.key || `link-${index}`;
+      return {
+        key,
+        title: link.title || link.label || 'Laporan',
+        description: link.description || link.subtitle || '',
+        icon: link.icon || 'document-text',
+        color: link.color || '#3498db',
+        route: link.route || routeMap[key] || 'AdminCabangReportHome',
+        params: link.params || {},
+        disabled: link.disabled || false,
+      };
+    });
+  }, [routeMap]);
+
+  const fetchSummary = useCallback(async ({ showLoading = false } = {}) => {
+    if (showLoading) {
+      setLoading(true);
+    }
+
+    try {
+      setError(null);
+      const response = await adminCabangReportsApi.getSummary();
+      const responseData = response?.data?.data || response?.data || {};
+      setSummaryCards(parseSummaryCards(responseData.summary || responseData.cards || responseData));
+      setQuickLinks(parseQuickLinks(responseData.quick_links || responseData.links || []));
+    } catch (err) {
+      console.error('Failed to fetch report summary:', err);
+      setError('Gagal memuat ringkasan laporan. Silakan coba lagi.');
+      setSummaryCards(DEFAULT_SUMMARY);
+      setQuickLinks(DEFAULT_LINKS);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [parseQuickLinks, parseSummaryCards]);
+
+  useEffect(() => {
+    fetchSummary({ showLoading: true });
+  }, [fetchSummary]);
+
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    fetchSummary();
+  }, [fetchSummary]);
+
+  const handleLinkPress = useCallback((link) => {
+    if (!link.route) return;
+    navigation.navigate(link.route, link.params);
+  }, [navigation]);
+
+  if (loading && !refreshing) {
+    return <LoadingSpinner fullScreen message="Memuat laporan..." />;
+  }
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.contentContainer}
+      refreshControl={(
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+      )}
+    >
+      <View style={styles.header}>
+        <Text style={styles.title}>Laporan Cabang</Text>
+        <Text style={styles.subtitle}>
+          Ringkasan metrik utama dan pintasan menuju laporan terperinci.
+        </Text>
+      </View>
+
+      {error && (
+        <View style={styles.errorContainer}>
+          <ErrorMessage message={error} onRetry={() => fetchSummary({ showLoading: true })} />
+        </View>
+      )}
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Ringkasan</Text>
+        {summaryCards.map((card) => (
+          <ReportSummaryCard key={card.key} {...card} />
+        ))}
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Laporan Detail</Text>
+        {quickLinks.map((link) => (
+          <ReportQuickLinkTile
+            key={link.key}
+            title={link.title}
+            description={link.description}
+            icon={link.icon}
+            color={link.color}
+            onPress={() => handleLinkPress(link)}
+            disabled={link.disabled}
+          />
+        ))}
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f6fa',
+  },
+  contentContainer: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  header: {
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#2d3436',
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '#636e72',
+    marginTop: 6,
+  },
+  section: {
+    marginTop: 20,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#2d3436',
+    marginBottom: 12,
+  },
+  errorContainer: {
+    marginBottom: 16,
+  },
+});
+
+export default AdminCabangReportHomeScreen;

--- a/frontend/src/features/adminCabang/screens/reports/AdminCabangTutorReportScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/AdminCabangTutorReportScreen.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+const AdminCabangTutorReportScreen = () => (
+  <View style={styles.container}>
+    <Text style={styles.title}>Laporan Tutor</Text>
+    <Text style={styles.description}>
+      Modul laporan tutor akan tersedia segera untuk membantu Anda memonitor performa tutor.
+    </Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f6fa',
+    padding: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#2d3436',
+    marginBottom: 12,
+    textAlign: 'center',
+  },
+  description: {
+    fontSize: 14,
+    color: '#636e72',
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+});
+
+export default AdminCabangTutorReportScreen;

--- a/frontend/src/navigation/AdminCabangNavigator.js
+++ b/frontend/src/navigation/AdminCabangNavigator.js
@@ -20,6 +20,9 @@ import GpsApprovalDetailScreen from '../features/adminCabang/screens/GpsApproval
 import AdminCabangUserManagementScreen from '../features/adminCabang/screens/user/UserManagementScreen';
 import AdminCabangUserFormScreen from '../features/adminCabang/screens/user/UserFormScreen';
 import AdminCabangUserDetailScreen from '../features/adminCabang/screens/user/UserDetailScreen';
+import AdminCabangReportHomeScreen from '../features/adminCabang/screens/reports/AdminCabangReportHomeScreen';
+import AdminCabangChildrenReportScreen from '../features/adminCabang/screens/reports/AdminCabangChildrenReportScreen';
+import AdminCabangTutorReportScreen from '../features/adminCabang/screens/reports/AdminCabangTutorReportScreen';
 
 // Kurikulum screens
 import KurikulumHomeScreen from '../features/adminCabang/screens/kurikulum/KurikulumHomeScreen';
@@ -39,6 +42,7 @@ import MasterDataScreen from '../features/adminCabang/screens/kurikulum/MasterDa
 const Tab = createBottomTabNavigator();
 const DashboardStack = createStackNavigator();
 const KurikulumStack = createStackNavigator();
+const ReportsStack = createStackNavigator();
 const ProfileStack = createStackNavigator();
 
 // Dashboard Stack Navigator
@@ -192,6 +196,27 @@ const KurikulumStackNavigator = () => (
   </KurikulumStack.Navigator>
 );
 
+// Reports Stack Navigator
+const ReportsStackNavigator = () => (
+  <ReportsStack.Navigator>
+    <ReportsStack.Screen
+      name="AdminCabangReportHome"
+      component={AdminCabangReportHomeScreen}
+      options={{ headerTitle: 'Laporan' }}
+    />
+    <ReportsStack.Screen
+      name="AdminCabangChildrenReport"
+      component={AdminCabangChildrenReportScreen}
+      options={{ headerTitle: 'Laporan Anak Binaan' }}
+    />
+    <ReportsStack.Screen
+      name="AdminCabangTutorReport"
+      component={AdminCabangTutorReportScreen}
+      options={{ headerTitle: 'Laporan Tutor' }}
+    />
+  </ReportsStack.Navigator>
+);
+
 // Profile Stack Navigator
 const ProfileStackNavigator = () => (
   <ProfileStack.Navigator>
@@ -210,6 +235,7 @@ const AdminCabangNavigator = () => (
         let iconName;
         if (route.name === 'Home') iconName = focused ? 'grid' : 'grid-outline';
         else if (route.name === 'Kurikulum') iconName = focused ? 'library' : 'library-outline';
+        else if (route.name === 'Reports') iconName = focused ? 'stats-chart' : 'stats-chart-outline';
         else if (route.name === 'Profile') iconName = focused ? 'person-circle' : 'person-circle-outline';
         return <Ionicons name={iconName} size={size} color={color} />;
       },
@@ -227,6 +253,11 @@ const AdminCabangNavigator = () => (
       name="Kurikulum"
       component={KurikulumStackNavigator}
       options={{ tabBarLabel: 'Kurikulum' }}
+    />
+    <Tab.Screen
+      name="Reports"
+      component={ReportsStackNavigator}
+      options={{ tabBarLabel: 'Laporan' }}
     />
     <Tab.Screen
       name="Profile"


### PR DESCRIPTION
## Summary
- add admin cabang reports stack with home, children, and tutor placeholders
- create reusable report summary and quick link components and wire summary API
- expose admin cabang reports endpoints and hook up new tab in navigator

## Testing
- CI=1 npm start

------
https://chatgpt.com/codex/tasks/task_e_68d913a5f87083239713f8aeba2ef6ce