### PR TITLE
Update admin cabang laporan endpoints

### DIFF
--- a/frontend/src/constants/endpoints.js
+++ b/frontend/src/constants/endpoints.js
@@ -150,10 +150,10 @@ export const ADMIN_CABANG_ENDPOINTS = {
     STATS: '/admin-cabang/donatur-stats'
   },
   REPORTS: {
-    SUMMARY: '/admin-cabang/reports/summary',
+    SUMMARY: '/admin-cabang/laporan/summary',
     ANAK: {
-      LIST: '/admin-cabang/reports/anak',
-      DETAIL: (childId) => `/admin-cabang/reports/anak/${childId}`,
+      LIST: '/admin-cabang/laporan/anak-binaan',
+      DETAIL: (childId) => `/admin-cabang/laporan/anak-binaan/child/${childId}`,
       FILTERS: {
         JENIS_KEGIATAN: '/admin-cabang/reports/anak/filter-options/jenis-kegiatan',
         WILAYAH_BINAAN: '/admin-cabang/reports/anak/filter-options/wilayah-binaan',

--- a/frontend/src/features/adminCabang/api/adminCabangReportApi.js
+++ b/frontend/src/features/adminCabang/api/adminCabangReportApi.js
@@ -3,22 +3,22 @@ import { ADMIN_CABANG_ENDPOINTS } from '../../../constants/endpoints';
 
 const {
   REPORTS: {
-    SUMMARY,
-    ANAK: { LIST, DETAIL, FILTERS }
+    SUMMARY: SUMMARY_ENDPOINT,
+    ANAK: { LIST: LIST_ENDPOINT, DETAIL: DETAIL_ENDPOINT, FILTERS }
   }
 } = ADMIN_CABANG_ENDPOINTS;
 
 export const adminCabangReportApi = {
   async getSummary(params = {}) {
-    return api.get(SUMMARY, { params });
+    return api.get(SUMMARY_ENDPOINT, { params });
   },
 
   async getLaporanAnakBinaan(params = {}) {
-    return api.get(LIST, { params });
+    return api.get(LIST_ENDPOINT, { params });
   },
 
   async getChildDetailReport(childId, params = {}) {
-    return api.get(DETAIL(childId), { params });
+    return api.get(DETAIL_ENDPOINT(childId), { params });
   },
 
   async getJenisKegiatanOptions() {


### PR DESCRIPTION
## Summary
- point Admin Cabang report summary and child endpoints to the new `/admin-cabang/laporan` routes
- update the Admin Cabang report API wrapper to consume the renamed endpoint constants

## Testing
- npm test -- --watchAll=false *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68d919dfb3348323b986f73f66c6f9f1