### PR TITLE
Populate cabang child report filters from list response

### DIFF
--- a/frontend/src/features/adminCabang/api/adminCabangReportApi.js
+++ b/frontend/src/features/adminCabang/api/adminCabangReportApi.js
@@ -21,14 +21,6 @@ export const adminCabangReportApi = {
     return api.get(DETAIL_ENDPOINT(childId), { params });
   },
 
-  async getJenisKegiatanOptions() {
-    return api.get(FILTERS.JENIS_KEGIATAN);
-  },
-
-  async getWilayahBinaanOptions() {
-    return api.get(FILTERS.WILAYAH_BINAAN);
-  },
-
   async getShelterOptionsByWilayah(wilbinId) {
     return api.get(FILTERS.SHELTER_BY_WILAYAH(wilbinId));
   }

--- a/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
@@ -123,9 +123,20 @@ const AdminCabangChildReportScreen = () => {
   };
 
   const handleWilayahFetch = (wilayahId) => {
-    if (wilayahId) {
-      dispatch(fetchShelterOptionsByWilayah(wilayahId));
+    if (!wilayahId) {
+      return;
     }
+
+    const existingOptions =
+      filterOptions.sheltersByWilayah?.[wilayahId] ||
+      filterOptions.sheltersByWilayah?.[String(wilayahId)];
+
+    if (Array.isArray(existingOptions)) {
+      // Data for this wilayah has already been loaded from the initial payload.
+      return;
+    }
+
+    dispatch(fetchShelterOptionsByWilayah(wilayahId));
   };
 
   const listHeader = (


### PR DESCRIPTION
## Summary
- remove the extra jenis/wilbin filter API calls and rely on the list response payload
- normalize filter_options to read available_activity_types, wilbins, and shelters for the dropdowns
- guard shelter lookups so the modal uses the pre-fetched options without redundant requests

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d91b6747a0832384be413e644d9b9c