### PR TITLE
Improve admin quick actions grid responsiveness

### DIFF
--- a/frontend/src/features/adminCabang/components/reports/ReportQuickActionTile.js
+++ b/frontend/src/features/adminCabang/components/reports/ReportQuickActionTile.js
@@ -38,13 +38,14 @@ const ReportQuickActionTile = ({
 
 const styles = StyleSheet.create({
   card: {
-    width: '48%',
+    flexBasis: '48%',
+    minWidth: 160,
+    flexGrow: 1,
     backgroundColor: '#ffffff',
     borderRadius: 12,
     paddingVertical: 16,
     paddingHorizontal: 12,
-    marginHorizontal: 6,
-    marginBottom: 12,
+    marginBottom: 0,
     alignItems: 'flex-start',
     justifyContent: 'flex-start',
     borderWidth: 1,

--- a/frontend/src/features/adminCabang/screens/reports/AdminCabangReportHomeScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/AdminCabangReportHomeScreen.js
@@ -389,7 +389,9 @@ const styles = StyleSheet.create({
   quickActionsGrid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    marginHorizontal: -6,
+    justifyContent: 'space-between',
+    rowGap: 12,
+    columnGap: 12,
   },
 });
 


### PR DESCRIPTION
## Summary
- update the admin cabang report quick actions grid spacing to avoid negative margins and distribute tiles evenly
- make quick action tiles responsive so they can grow and stack in a single column on narrow layouts

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d93f621cfc8323b958a14482d3988f