### PR TITLE
Remove quick action heading from admin cabang report home

### DIFF
--- a/frontend/src/features/adminCabang/screens/reports/AdminCabangReportHomeScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/AdminCabangReportHomeScreen.js
@@ -317,7 +317,6 @@ const AdminCabangReportHomeScreen = () => {
       </View>
 
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Aksi Cepat</Text>
         <View style={styles.quickActionsGrid}>
           {quickActions.map((action) => (
             <ReportQuickActionTile
@@ -390,6 +389,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     justifyContent: 'space-between',
+    marginTop: 12,
     rowGap: 12,
     columnGap: 12,
   },


### PR DESCRIPTION
## Summary
- remove the "Aksi Cepat" heading from the quick actions section on the admin cabang report home screen
- add spacing to the quick action grid to keep layout balance after the heading removal

## Testing
- npm run web *(fails: expo CLI cannot fetch dependencies in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d94028c71c8323b303abb25443c033