### PR TITLE
Handle object wilayah names in child report list

### DIFF
--- a/frontend/src/features/adminCabang/components/reports/ChildReportListItem.js
+++ b/frontend/src/features/adminCabang/components/reports/ChildReportListItem.js
@@ -4,6 +4,32 @@ import { Ionicons } from '@expo/vector-icons';
 
 const DEFAULT_PHOTO = require('../../../../assets/images/logo.png');
 
+const normalizeToDisplayString = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'object') {
+    const nestedValue = value?.name ?? value?.wilbin ?? null;
+
+    if (typeof nestedValue === 'string') {
+      return nestedValue;
+    }
+
+    try {
+      return JSON.stringify(value);
+    } catch (error) {
+      return '';
+    }
+  }
+
+  return String(value);
+};
+
 const ChildReportListItem = ({ child, onPress }) => {
   const {
     displayName,
@@ -23,7 +49,11 @@ const ChildReportListItem = ({ child, onPress }) => {
       displayName: child.full_name || child.name || child.nama || 'Anak Binaan',
       nickname: child.nick_name || child.nickname || null,
       shelterName: child.shelter_name || child.shelter || child.nama_shelter || null,
-      wilayahName: child.wilayah_name || child.wilbin_name || child.nama_wilayah || null,
+      wilayahName:
+        normalizeToDisplayString(child.wilayah_name) ??
+        normalizeToDisplayString(child.wilbin_name) ??
+        normalizeToDisplayString(child.nama_wilayah) ??
+        null,
       attendancePercentage: percentage !== null ? `${percentage}%` : null,
       attendanceSummary: (totalAttended !== undefined && totalActivities !== undefined)
         ? `${totalAttended}/${totalActivities} aktivitas`


### PR DESCRIPTION
## Summary
- add a helper to normalize non-string wilayah values into safe display strings
- use the normalizer when deriving wilayah names in child report list items to avoid rendering objects

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d940fb01d08323a058c0c2ade6a4b4