### PR TITLE
Add attendance ratio details to child summary card

### DIFF
--- a/frontend/src/features/adminCabang/components/reports/ChildReportSummary.js
+++ b/frontend/src/features/adminCabang/components/reports/ChildReportSummary.js
@@ -13,6 +13,12 @@ const ChildReportSummary = ({ summary }) => {
       total_children: summary.total_children ?? summary.children_total ?? summary.totalAnak ?? summary.total ?? 0,
       average_attendance: summary.average_attendance ?? summary.attendance_rate ?? summary.average ?? 0,
       total_activities: summary.total_activities ?? summary.activities_total ?? summary.totalActivities ?? 0,
+      total_attended:
+        summary.total_attended ??
+        summary.attended_count ??
+        summary.totalAttended ??
+        summary.attendedCount ??
+        null,
       total_wilayah: summary.total_wilayah ?? summary.wilayah_total ?? summary.totalWilayah ?? null,
       total_shelters: summary.total_shelters ?? summary.shelter_total ?? summary.totalShelter ?? null,
       active_programs: summary.active_programs ?? summary.programs_active ?? null,

--- a/frontend/src/features/adminShelter/components/ChildSummaryCard.js
+++ b/frontend/src/features/adminShelter/components/ChildSummaryCard.js
@@ -9,6 +9,14 @@ import { formatPercentage } from '../utils/reportUtils';
 const ChildSummaryCard = ({ summary }) => {
   if (!summary) return null;
 
+  const totalAttended = summary.total_attended;
+  const totalActivities = summary.total_activities;
+  const hasAttendanceDetails =
+    totalAttended !== undefined &&
+    totalAttended !== null &&
+    totalActivities !== undefined &&
+    totalActivities !== null;
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Ringkasan</Text>
@@ -21,7 +29,15 @@ const ChildSummaryCard = ({ summary }) => {
           <Text style={[styles.value, { color: '#9b59b6' }]}>
             {formatPercentage(summary.average_attendance)}%
           </Text>
-          <Text style={styles.label}>Rata-rata</Text>
+          <Text style={styles.label}>Rata-rata Kehadiran</Text>
+          {hasAttendanceDetails && (
+            <>
+              <Text style={styles.helperText}>= total hadir ÷ total aktivitas</Text>
+              <Text style={styles.helperRatio}>
+                {`${totalAttended}/${totalActivities}`}
+              </Text>
+            </>
+          )}
         </View>
         <View style={styles.item}>
           <Text style={styles.value}>{summary.total_activities}</Text>
@@ -65,6 +81,18 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: '#666',
     marginTop: 4
+  },
+  helperText: {
+    fontSize: 10,
+    color: '#888',
+    marginTop: 4,
+    textAlign: 'center'
+  },
+  helperRatio: {
+    fontSize: 10,
+    color: '#888',
+    marginTop: 2,
+    textAlign: 'center'
   }
 });
 


### PR DESCRIPTION
## Summary
- pass total attendance data through the admin cabang child report summary
- show attendance ratio details and helper text in the child summary card when data is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9f20b01648323bcb96507150e34e9