### PR TITLE
Fix child summary average attendance fallback

### DIFF
--- a/frontend/src/features/adminShelter/components/ChildSummaryCard.js
+++ b/frontend/src/features/adminShelter/components/ChildSummaryCard.js
@@ -12,13 +12,22 @@ import {
 const ChildSummaryCard = ({ summary }) => {
   if (!summary) return null;
 
+  const totalChildren = summary.total_children;
   const totalAttended = summary.total_attended;
   const totalActivities = summary.total_activities;
+  const numericTotalChildren = Number(totalChildren);
+  const numericTotalAttended = Number(totalAttended);
+  const numericTotalActivities = Number(totalActivities);
   const hasAttendanceDetails =
+    totalChildren !== undefined &&
+    totalChildren !== null &&
     totalAttended !== undefined &&
     totalAttended !== null &&
     totalActivities !== undefined &&
-    totalActivities !== null;
+    totalActivities !== null &&
+    !Number.isNaN(numericTotalChildren) &&
+    !Number.isNaN(numericTotalAttended) &&
+    !Number.isNaN(numericTotalActivities);
 
   const normalizePercentageValue = (value) => {
     if (value === null || value === undefined) return null;
@@ -47,12 +56,18 @@ const ChildSummaryCard = ({ summary }) => {
     return normalizePercentageValue(summary[key]);
   }, null);
 
+  const totalPotentialAttendance = hasAttendanceDetails
+    ? numericTotalChildren * numericTotalActivities
+    : 0;
+
   const shouldUseFallback =
-    explicitAverage === null && hasAttendanceDetails && totalActivities > 0;
+    explicitAverage === null &&
+    hasAttendanceDetails &&
+    totalPotentialAttendance > 0;
 
   const derivedAverage = shouldUseFallback
     ? normalizePercentageValue(
-        calculateAttendancePercentage(totalAttended, totalActivities)
+        calculateAttendancePercentage(numericTotalAttended, totalPotentialAttendance)
       )
     : explicitAverage;
 
@@ -71,9 +86,11 @@ const ChildSummaryCard = ({ summary }) => {
           <Text style={styles.label}>Rata-rata Kehadiran</Text>
           {shouldUseFallback && (
             <>
-              <Text style={styles.helperText}>= total hadir ÷ total aktivitas</Text>
+              <Text style={styles.helperText}>
+                = total hadir ÷ (total anak × total aktivitas)
+              </Text>
               <Text style={styles.helperRatio}>
-                {`${totalAttended}/${totalActivities}`}
+                {`${totalAttended}/${totalPotentialAttendance}`}
               </Text>
             </>
           )}


### PR DESCRIPTION
## Summary
- prefer explicit average attendance values provided by the summary payload when rendering the child summary card
- update the fallback average calculation to divide actual attendance by the total potential attendance (total children × total activities) and adjust the helper copy

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9fe7e5f0c83238934ccd683d2830f