### PR TITLE
Remove attendance trend chart from Admin Cabang child detail screen

### DIFF
--- a/frontend/src/features/adminCabang/screens/reports/AdminCabangChildDetailScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/AdminCabangChildDetailScreen.js
@@ -14,7 +14,6 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import LoadingSpinner from '../../../../common/components/LoadingSpinner';
 import ErrorMessage from '../../../../common/components/ErrorMessage';
 import ReportSummaryCard from '../../components/reports/ReportSummaryCard';
-import ChildAttendanceTrendChart from '../../components/reports/ChildAttendanceTrendChart';
 import {
   calculateAttendancePercentage,
   formatPercentage,
@@ -210,8 +209,6 @@ const AdminCabangChildDetailScreen = () => {
 
   const detail = useSelector(selectReportAnakDetail);
   const [refreshing, setRefreshing] = useState(false);
-  const shouldShowChart =
-    detail.monthlyData != null || (!detail.loading && !detail.error);
 
   useEffect(() => {
     if (childName) {
@@ -563,10 +560,6 @@ const AdminCabangChildDetailScreen = () => {
           ))}
         </View>
       )}
-
-      {shouldShowChart ? (
-        <ChildAttendanceTrendChart monthlyData={detail.monthlyData} type="line" />
-      ) : null}
 
       <View style={styles.activitiesSection}>
         <Text style={styles.sectionTitle}>Aktivitas Terakhir</Text>


### PR DESCRIPTION
## Summary
- remove the `ChildAttendanceTrendChart` import from the child detail screen
- delete the conditional chart rendering logic so the remaining sections render as before

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da48c22fec8323bc80ee44093601d9