### PR TITLE
Rename Admin Shelter profile stack screen

### DIFF
--- a/frontend/src/navigation/AdminShelterNavigator.js
+++ b/frontend/src/navigation/AdminShelterNavigator.js
@@ -156,10 +156,10 @@ const HomeStackNavigator = () => (
 
 const ProfileStackNavigator = () => (
   <ProfileStack.Navigator>
-    <ProfileStack.Screen 
-      name="Profile" 
-      component={AdminShelterProfileScreen} 
-      options={{ headerTitle: 'Profil Admin Shelter' }} 
+    <ProfileStack.Screen
+      name="AdminShelterProfile"
+      component={AdminShelterProfileScreen}
+      options={{ headerTitle: 'Profil Admin Shelter' }}
     />
     <ProfileStack.Screen 
       name="ShelterGpsSetting" 


### PR DESCRIPTION
## Summary
- rename the Admin Shelter profile stack screen to AdminShelterProfile to avoid name collisions with the tab route

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68da9b6aafd883239e2ddb290cadb26c