### PR TITLE
Add corrective migration for GPS approval defaults

### DIFF
--- a/backend/database/migrations/2025_09_22_000000_update_gps_approval_status_default.php
+++ b/backend/database/migrations/2025_09_22_000000_update_gps_approval_status_default.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Update the default value for gps_approval_status to "approved"
+        if (Schema::hasColumn('shelter', 'gps_approval_status')) {
+            DB::statement(
+                "ALTER TABLE `shelter` MODIFY `gps_approval_status` VARCHAR(255) NOT NULL DEFAULT 'approved'"
+            );
+        }
+
+        // Backfill existing rows where the approval data is missing
+        DB::table('shelter')
+            ->whereNull('gps_approval_data')
+            ->update([
+                'gps_approval_status' => 'approved',
+                'gps_submitted_at' => null,
+                'gps_approved_at' => null,
+                'gps_approved_by' => null,
+                'gps_rejection_reason' => null,
+                'gps_approval_data' => null,
+            ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('shelter', 'gps_approval_status')) {
+            DB::statement(
+                "ALTER TABLE `shelter` MODIFY `gps_approval_status` VARCHAR(255) NOT NULL DEFAULT 'pending'"
+            );
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration that sets the shelter.gps_approval_status default to approved
- backfill shelters lacking approval data to approved and clear GPS approval metadata
- restore the previous pending default when rolling back

## Testing
- not run (database connection unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dab1184bcc8323a20a3baec4d925bb