### PR TITLE
Add Admin Shelter settings screen and update navigation

### DIFF
--- a/frontend/src/features/adminShelter/screens/AdminShelterProfileScreen.js
+++ b/frontend/src/features/adminShelter/screens/AdminShelterProfileScreen.js
@@ -209,9 +209,9 @@ const AdminShelterProfileScreen = () => {
         )}
 
         <View style={styles.settingsContainer}>
-          {[
+          {[ 
             { icon: 'location-outline', text: 'GPS Setting Shelter', route: 'ShelterGpsSetting', color: '#3498db' },
-            { icon: 'settings-outline', text: 'Setting', route: 'Settings', color: '#e74c3c' },
+            { icon: 'settings-outline', text: 'Pengaturan', route: 'AdminShelterSettings', color: '#8e44ad' },
             { icon: 'log-out-outline', text: 'Keluar', onPress: handleLogout, color: '#e74c3c' }
           ].map((item, index) => (
             <TouchableOpacity

--- a/frontend/src/features/adminShelter/screens/AdminShelterSettingsScreen.js
+++ b/frontend/src/features/adminShelter/screens/AdminShelterSettingsScreen.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const AdminShelterSettingsScreen = () => (
+  <View style={styles.container}>
+    <Text style={styles.title}>Pengaturan</Text>
+    <Text style={styles.description}>
+      Fitur pengaturan akan segera hadir. Silakan kembali ke halaman profil untuk melanjutkan.
+    </Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 24,
+    backgroundColor: '#fff',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '700',
+    marginBottom: 12,
+    color: '#2c3e50',
+    textAlign: 'center',
+  },
+  description: {
+    fontSize: 16,
+    color: '#7f8c8d',
+    lineHeight: 22,
+    textAlign: 'center',
+  },
+});
+
+export default AdminShelterSettingsScreen;

--- a/frontend/src/navigation/AdminShelterNavigator.js
+++ b/frontend/src/navigation/AdminShelterNavigator.js
@@ -6,6 +6,7 @@ import { Ionicons } from '@expo/vector-icons';
 // Core screens
 import AdminShelterDashboardScreen from '../features/adminShelter/screens/AdminShelterDashboardScreen';
 import AdminShelterProfileScreen from '../features/adminShelter/screens/AdminShelterProfileScreen';
+import AdminShelterSettingsScreen from '../features/adminShelter/screens/AdminShelterSettingsScreen';
 import ShelterGpsSettingScreen from '../features/adminShelter/screens/ShelterGpsSettingScreen';
 
 // Primary feature screens  
@@ -161,10 +162,15 @@ const ProfileStackNavigator = () => (
       component={AdminShelterProfileScreen}
       options={{ headerTitle: 'Profil Admin Shelter' }}
     />
-    <ProfileStack.Screen 
-      name="ShelterGpsSetting" 
-      component={ShelterGpsSettingScreen} 
-      options={{ headerTitle: 'Setting GPS Shelter' }} 
+    <ProfileStack.Screen
+      name="ShelterGpsSetting"
+      component={ShelterGpsSettingScreen}
+      options={{ headerTitle: 'Setting GPS Shelter' }}
+    />
+    <ProfileStack.Screen
+      name="AdminShelterSettings"
+      component={AdminShelterSettingsScreen}
+      options={{ headerTitle: 'Pengaturan' }}
     />
   </ProfileStack.Navigator>
 );


### PR DESCRIPTION
## Summary
- add a placeholder Admin Shelter settings screen so the profile shortcut has a valid target
- register the new settings screen in the Admin Shelter profile stack navigator
- update the profile quick actions to navigate to the dedicated Admin Shelter settings route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dab202a3888323852be68a33abd62f