### PR TITLE
Improve error logging for shelter GPS config load

### DIFF
--- a/frontend/src/features/adminShelter/screens/ShelterGpsSettingScreen.js
+++ b/frontend/src/features/adminShelter/screens/ShelterGpsSettingScreen.js
@@ -67,7 +67,19 @@ const ShelterGpsSettingScreen = ({ navigation }) => {
         });
       }
     } catch (error) {
-      console.error('Error loading GPS config:', error);
+      console.error(
+        'Error loading GPS config:',
+        error.response?.status,
+        error.response?.data,
+        error.message,
+        error
+      );
+
+      const backendMessage =
+        error.response?.data?.message ||
+        error.response?.data?.error ||
+        (typeof error.response?.data === 'string' ? error.response?.data : null);
+      setError(backendMessage || 'Gagal memuat konfigurasi GPS');
       // Fallback to profile data if API fails
       if (profile?.shelter) {
         const requireGps = profile.shelter.require_gps;


### PR DESCRIPTION
## Summary
- expand GPS config load failure logging to include HTTP status, response body, and message
- surface backend error messages to users when the initial GPS config fetch fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab408fe988323be290fe6af4f6563