### PR TITLE
Improve admin shelter navigation naming and GPS error logging

### DIFF
--- a/frontend/src/features/adminShelter/screens/ShelterGpsSettingScreen.js
+++ b/frontend/src/features/adminShelter/screens/ShelterGpsSettingScreen.js
@@ -12,6 +12,21 @@ import { useAuth } from '../../../common/hooks/useAuth';
 import { adminShelterApi } from '../api/adminShelterApi';
 import GpsPermissionModal from '../../../common/components/GpsPermissionModal';
 
+const logAxiosError = (context, err) => {
+  const status = err.response?.status;
+  const data = err.response?.data;
+  const headers = err.response?.headers;
+
+  console.error(
+    `${context} (status: ${status ?? 'unknown'}, message: ${err.message})`,
+    {
+      data,
+      headers,
+      stack: err.stack
+    }
+  );
+};
+
 const ShelterGpsSettingScreen = ({ navigation }) => {
   const { profile, refreshUser } = useAuth();
   
@@ -67,19 +82,15 @@ const ShelterGpsSettingScreen = ({ navigation }) => {
         });
       }
     } catch (error) {
-      console.error(
-        'Error loading GPS config:',
-        error.response?.status,
-        error.response?.data,
-        error.message,
-        error
-      );
+      logAxiosError('Error loading GPS config', error);
 
       const backendMessage =
         error.response?.data?.message ||
         error.response?.data?.error ||
         (typeof error.response?.data === 'string' ? error.response?.data : null);
-      setError(backendMessage || 'Gagal memuat konfigurasi GPS');
+      const status = error.response?.status;
+      const fallbackMessage = backendMessage || 'Gagal memuat konfigurasi GPS';
+      setError(status ? `${fallbackMessage} (HTTP ${status})` : fallbackMessage);
       // Fallback to profile data if API fails
       if (profile?.shelter) {
         const requireGps = profile.shelter.require_gps;
@@ -205,19 +216,16 @@ const ShelterGpsSettingScreen = ({ navigation }) => {
       ]);
       
     } catch (err) {
-      console.error(
-        'Error updating GPS config:',
-        err.response?.status,
-        err.response?.data,
-        err
-      );
+      logAxiosError('Error updating GPS config', err);
 
       const backendMessage =
         err.response?.data?.message ||
         err.response?.data?.error ||
         (typeof err.response?.data === 'string' ? err.response?.data : null);
+      const status = err.response?.status;
+      const fallbackMessage = backendMessage || 'Gagal menyimpan GPS setting';
 
-      setError(backendMessage || 'Gagal menyimpan GPS setting');
+      setError(status ? `${fallbackMessage} (HTTP ${status})` : fallbackMessage);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/navigation/AdminShelterNavigator.js
+++ b/frontend/src/navigation/AdminShelterNavigator.js
@@ -158,7 +158,7 @@ const HomeStackNavigator = () => (
 const ProfileStackNavigator = () => (
   <ProfileStack.Navigator>
     <ProfileStack.Screen
-      name="AdminShelterProfile"
+      name="ProfileHome"
       component={AdminShelterProfileScreen}
       options={{ headerTitle: 'Profil Admin Shelter' }}
     />
@@ -249,7 +249,7 @@ const AdminShelterNavigator = () => (
           iconName = focused ? 'home' : 'home-outline';
         } else if (route.name === 'Management') {
           iconName = focused ? 'settings' : 'settings-outline';
-        } else if (route.name === 'Profile') {
+        } else if (route.name === 'ProfileTab') {
           iconName = focused ? 'person' : 'person-outline';
         }
         return <Ionicons name={iconName} size={size} color={color} />;
@@ -269,8 +269,8 @@ const AdminShelterNavigator = () => (
       component={ManagementStackNavigator}
       options={{ tabBarLabel: 'Management' }}
     />
-    <Tab.Screen 
-      name="Profile" 
+    <Tab.Screen
+      name="ProfileTab"
       component={ProfileStackNavigator}
       options={{ tabBarLabel: 'Profile' }}
     />


### PR DESCRIPTION
## Summary
- rename the admin shelter profile tab route so the nested stack screen uses a unique name and clears the duplicate-name warning
- add a reusable Axios logging helper for the GPS screen and include HTTP status codes in the displayed error message to aid debugging

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68da9ad14b6083238cfedbff493764b5