### PR TITLE
Fix image picker media type options

### DIFF
--- a/frontend/src/common/components/Anak/PrestasiForm.js
+++ b/frontend/src/common/components/Anak/PrestasiForm.js
@@ -97,7 +97,7 @@ const PrestasiForm = ({
 
       // Launch image picker
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaType.Images,
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
         allowsEditing: true,
         aspect: [4, 3],
         quality: 0.7,

--- a/frontend/src/common/components/Anak/RaportForm.js
+++ b/frontend/src/common/components/Anak/RaportForm.js
@@ -111,7 +111,7 @@ const RaportForm = ({
 
       // Launch image picker
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaType.Images,
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
         allowsMultipleSelection: true,
         quality: 0.7,
         aspect: [4, 3],

--- a/frontend/src/common/components/Anak/RiwayatForm.js
+++ b/frontend/src/common/components/Anak/RiwayatForm.js
@@ -86,7 +86,7 @@ const RiwayatForm = ({
 
       // Launch image picker
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaType.Images,
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
         allowsEditing: true,
         aspect: [4, 3],
         quality: 0.7,


### PR DESCRIPTION
## Summary
- update child-related forms to use ImagePicker.MediaTypeOptions.Images when opening the image library

## Testing
- not run (not applicable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68db4b4d21088323add583c3e63521cc