### PR TITLE
Fix ImagePicker media type options in donor screens

### DIFF
--- a/frontend/src/features/donatur/screen/DonaturProfileScreen.js
+++ b/frontend/src/features/donatur/screen/DonaturProfileScreen.js
@@ -51,7 +51,7 @@ const DonaturProfileScreen = () => {
       }
 
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaType.Images,
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
         allowsEditing: true, aspect: [1, 1], quality: 0.7,
       });
 

--- a/frontend/src/features/donatur/screen/SuratFormScreen.js
+++ b/frontend/src/features/donatur/screen/SuratFormScreen.js
@@ -63,7 +63,7 @@ const SuratFormScreen = () => {
   const openPicker = async () => {
     try {
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaType.Images,
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
         allowsEditing: true,
         aspect: [4, 3],
         quality: 0.8,


### PR DESCRIPTION
## Summary
- update donor letter attachment screen to use ImagePicker.MediaTypeOptions.Images
- update donor profile image picker to use ImagePicker.MediaTypeOptions.Images

## Testing
- not run (requires Expo runtime)


------
https://chatgpt.com/codex/tasks/task_e_68db4d615a4c8323b513e4e8d3bd3a18