### PR TITLE
Fix image picker media type import

### DIFF
--- a/frontend/src/features/adminShelter/components/keluargaForm/KeluargaFormStepChild.js
+++ b/frontend/src/features/adminShelter/components/keluargaForm/KeluargaFormStepChild.js
@@ -10,6 +10,7 @@ import { Picker } from '@react-native-picker/picker';
 import { Ionicons } from '@expo/vector-icons';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import * as ImagePicker from 'expo-image-picker';
+import { MediaTypeOptions } from 'expo-image-picker';
 
 import TextInput from '../../../../common/components/TextInput';
 import Button from '../../../../common/components/Button';
@@ -93,7 +94,7 @@ const KeluargaFormStepChild = ({
       }
       
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: MediaTypeOptions.Images,
         allowsEditing: true,
         aspect: [1, 1],
         quality: 0.8,


### PR DESCRIPTION
## Summary
- import MediaTypeOptions from expo-image-picker and update the image library launch configuration to use it

## Testing
- Not run (Expo environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db5ae5ff24832395798c515602e517