### PR TITLE
Fix expo image picker media type usage

### DIFF
--- a/frontend/src/common/components/Anak/PrestasiForm.js
+++ b/frontend/src/common/components/Anak/PrestasiForm.js
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
+import { MediaTypeOptions } from 'expo-image-picker';
 import DateTimePicker from '@react-native-community/datetimepicker';
 
 // Import components
@@ -97,7 +98,7 @@ const PrestasiForm = ({
 
       // Launch image picker
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: MediaTypeOptions.Images,
         allowsEditing: true,
         aspect: [4, 3],
         quality: 0.7,

--- a/frontend/src/common/components/Anak/RaportForm.js
+++ b/frontend/src/common/components/Anak/RaportForm.js
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
+import { MediaTypeOptions } from 'expo-image-picker';
 import DateTimePicker from '@react-native-community/datetimepicker';
 
 // Import components
@@ -111,7 +112,7 @@ const RaportForm = ({
 
       // Launch image picker
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: MediaTypeOptions.Images,
         allowsMultipleSelection: true,
         quality: 0.7,
         aspect: [4, 3],

--- a/frontend/src/common/components/Anak/RiwayatForm.js
+++ b/frontend/src/common/components/Anak/RiwayatForm.js
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
+import { MediaTypeOptions } from 'expo-image-picker';
 import DateTimePicker from '@react-native-community/datetimepicker';
 
 // Import components
@@ -86,7 +87,7 @@ const RiwayatForm = ({
 
       // Launch image picker
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: MediaTypeOptions.Images,
         allowsEditing: true,
         aspect: [4, 3],
         quality: 0.7,


### PR DESCRIPTION
## Summary
- import `MediaTypeOptions` from `expo-image-picker` across the Anak forms
- update the image picker configuration to reference the shared `MediaTypeOptions.Images`

## Testing
- not run (React Native environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68db5c951b0083239120687cb2df83ec