### PR TITLE
Fix image picker media type imports

### DIFF
--- a/frontend/src/features/adminCabang/screens/AdminCabangDonaturFormScreen.js
+++ b/frontend/src/features/adminCabang/screens/AdminCabangDonaturFormScreen.js
@@ -15,6 +15,7 @@ import {
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
+import { MediaTypeOptions } from 'expo-image-picker';
 import TextInput from '../../../common/components/TextInput';
 import Button from '../../../common/components/Button';
 import LoadingSpinner from '../../../common/components/LoadingSpinner';
@@ -229,7 +230,7 @@ const AdminCabangDonaturFormScreen = () => {
     }
 
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: MediaTypeOptions?.Images ?? MediaTypeOptions.All,
       allowsEditing: true,
       aspect: [1, 1],
       quality: 0.8,

--- a/frontend/src/features/adminCabang/screens/AdminCabangProfileScreen.js
+++ b/frontend/src/features/adminCabang/screens/AdminCabangProfileScreen.js
@@ -5,6 +5,7 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
+import { MediaTypeOptions } from 'expo-image-picker';
 
 import Button from '../../../common/components/Button';
 import TextInput from '../../../common/components/TextInput';
@@ -49,7 +50,7 @@ const AdminCabangProfileScreen = () => {
       }
 
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: MediaTypeOptions?.Images ?? MediaTypeOptions.All,
         allowsEditing: true, aspect: [1, 1], quality: 0.7,
       });
 

--- a/frontend/src/features/adminPusat/screens/AdminPusatProfileScreen.js
+++ b/frontend/src/features/adminPusat/screens/AdminPusatProfileScreen.js
@@ -11,6 +11,7 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
+import { MediaTypeOptions } from 'expo-image-picker';
 
 // Import components
 import Button from '../../../common/components/Button';
@@ -67,7 +68,7 @@ const AdminPusatProfileScreen = () => {
 
       // Launch image picker
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: MediaTypeOptions?.Images ?? MediaTypeOptions.All,
         allowsEditing: true,
         aspect: [1, 1],
         quality: 0.7,

--- a/frontend/src/features/donatur/screen/DonaturProfileScreen.js
+++ b/frontend/src/features/donatur/screen/DonaturProfileScreen.js
@@ -5,6 +5,7 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
+import { MediaTypeOptions } from 'expo-image-picker';
 
 import Button from '../../../common/components/Button';
 import TextInput from '../../../common/components/TextInput';
@@ -51,7 +52,7 @@ const DonaturProfileScreen = () => {
       }
 
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: MediaTypeOptions?.Images ?? MediaTypeOptions.All,
         allowsEditing: true, aspect: [1, 1], quality: 0.7,
       });
 

--- a/frontend/src/features/donatur/screen/SuratFormScreen.js
+++ b/frontend/src/features/donatur/screen/SuratFormScreen.js
@@ -13,6 +13,7 @@ import {
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
+import { MediaTypeOptions } from 'expo-image-picker';
 import TextInput from '../../../common/components/TextInput';
 import Button from '../../../common/components/Button';
 import LoadingSpinner from '../../../common/components/LoadingSpinner';
@@ -63,7 +64,7 @@ const SuratFormScreen = () => {
   const openPicker = async () => {
     try {
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: MediaTypeOptions?.Images ?? MediaTypeOptions.All,
         allowsEditing: true,
         aspect: [4, 3],
         quality: 0.8,


### PR DESCRIPTION
## Summary
- import MediaTypeOptions from expo-image-picker on profile and form screens
- update image picker configuration to use MediaTypeOptions.Images fallback to All to avoid undefined references

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db603236488323ac3bb7a920b8cd98