### PR TITLE
Clear active kurikulum when list has no active entries

### DIFF
--- a/frontend/src/features/adminCabang/screens/kurikulum/SelectKurikulumScreen.js
+++ b/frontend/src/features/adminCabang/screens/kurikulum/SelectKurikulumScreen.js
@@ -18,6 +18,7 @@ import { useGetKurikulumListQuery, useSetKurikulumActiveMutation } from '../../a
 import {
   setSelectedKurikulum,
   setActiveKurikulum,
+  clearActiveKurikulum,
   selectActiveKurikulum,
   selectActiveKurikulumId,
   selectSelectedKurikulum,
@@ -124,12 +125,14 @@ const SelectKurikulumScreen = ({ navigation }) => {
 
   React.useEffect(() => {
     if (!Array.isArray(kurikulumList) || kurikulumList.length === 0) {
+      dispatch(clearActiveKurikulum());
       return;
     }
 
     const activeFromList = kurikulumList.find((item) => item?.is_active);
 
     if (!activeFromList) {
+      dispatch(clearActiveKurikulum());
       return;
     }
 


### PR DESCRIPTION
## Summary
- dispatch `clearActiveKurikulum` when the kurikulum list is empty or has no active entry so the banner goes away
- import the new action in the kurikulum selection screen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db859cb9088323869ed21a14114db8