### PR TITLE
Fix kurikulum card stat mappings

### DIFF
--- a/frontend/src/features/adminShelter/components/KurikulumSelectionCard.js
+++ b/frontend/src/features/adminShelter/components/KurikulumSelectionCard.js
@@ -39,13 +39,13 @@ const KurikulumSelectionCard = ({ kurikulum, onSelect, isSelected }) => {
         <View style={styles.statItem}>
           <Ionicons name="book-outline" size={16} color="#7f8c8d" />
           <Text style={styles.statText}>
-            {kurikulum.kurikulum_materi_count || 0} Mata Pelajaran
+            {kurikulum.mata_pelajaran_count || 0} Mata Pelajaran
           </Text>
         </View>
         <View style={styles.statItem}>
           <Ionicons name="document-text-outline" size={16} color="#7f8c8d" />
           <Text style={styles.statText}>
-            {kurikulum.mata_pelajaran_count || 0} Materi
+            {kurikulum.kurikulum_materi_count || 0} Materi
           </Text>
         </View>
       </View>


### PR DESCRIPTION
## Summary
- ensure the Kurikulum selection card displays subject counts using `mata_pelajaran_count`
- ensure the card displays materi totals using `kurikulum_materi_count`

## Testing
- node - <<'NODE'
const kurikulum = { nama_kurikulum: 'Test', mata_pelajaran_count: 3, kurikulum_materi_count: 7 };
const mataPelajaranText = `${kurikulum.mata_pelajaran_count || 0} Mata Pelajaran`;
const materiText = `${kurikulum.kurikulum_materi_count || 0} Materi`;
console.log(mataPelajaranText);
console.log(materiText);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68db861502d88323beead4e60363c5c7