### PR TITLE
Clarify admin shelter kurikulum routes comment

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -291,7 +291,7 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::get('/activity-reports/by-activity/{id_aktivitas}', [App\Http\Controllers\API\AdminShelter\ActivityReportController::class, 'getByActivity']);
         Route::delete('/activity-reports/{id}', [App\Http\Controllers\API\AdminShelter\ActivityReportController::class, 'destroy']);
 
-        // Kurikulum read endpoints
+        // Kurikulum read endpoints (index, detail, preview, dropdown)
         Route::get('/kurikulum', [App\Http\Controllers\API\AdminShelter\AdminShelterKurikulumController::class, 'index']);
         Route::get('/kurikulum/{id}', [App\Http\Controllers\API\AdminShelter\AdminShelterKurikulumController::class, 'show']);
         Route::get('/kurikulum/{id}/preview', [App\Http\Controllers\API\AdminShelter\AdminShelterKurikulumController::class, 'getPreview']);


### PR DESCRIPTION
## Summary
- clarify the admin shelter kurikulum route comment to enumerate the index, detail, preview, and dropdown endpoints

## Testing
- php artisan route:list | grep admin-shelter/kurikulum *(fails: Could not open input file: artisan)*

------
https://chatgpt.com/codex/tasks/task_e_68dbde8b420c832387df15e5a07fb53a