### PR TITLE
Add admin shelter kurikulum routes

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -204,6 +204,13 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/profile', [App\Http\Controllers\API\AdminShelterController::class, 'getProfile']);
     Route::post('/profile', [App\Http\Controllers\API\AdminShelterController::class, 'updateProfile']);
     
+        Route::controller(App\Http\Controllers\API\AdminShelter\AdminShelterKurikulumController::class)->group(function () {
+            Route::get('/kurikulum', 'index');
+            Route::get('/kurikulum/{id}', 'show');
+            Route::get('/kurikulum/{id}/preview', 'getPreview');
+            Route::get('/kurikulum-dropdown', 'getForDropdown');
+        });
+
         Route::get('/anak', [App\Http\Controllers\API\AdminShelter\AdminShelterAnakController::class, 'index']);
         Route::post('/anak', [App\Http\Controllers\API\AdminShelter\AdminShelterAnakController::class, 'store']);
         Route::get('/anak/{id}', [App\Http\Controllers\API\AdminShelter\AdminShelterAnakController::class, 'show']);


### PR DESCRIPTION
## Summary
- register admin shelter kurikulum endpoints for listing, detail, preview, and dropdown data

## Testing
- `php artisan route:list | grep admin-shelter/kurikulum` *(fails: Could not open input file: artisan)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe7a5bcf48323be9f97acbf72cbff