### PR TITLE
Sync active kurikulum selection across semester screens

### DIFF
--- a/frontend/src/features/adminCabang/redux/kurikulumSlice.js
+++ b/frontend/src/features/adminCabang/redux/kurikulumSlice.js
@@ -1,5 +1,12 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+const resolveKurikulumId = (kurikulum) => (
+  kurikulum?.id_kurikulum
+  ?? kurikulum?.kurikulum_id
+  ?? kurikulum?.id
+  ?? null
+);
+
 /**
  * Kurikulum slice for Admin Cabang
  * Manages kurikulum hierarchy navigation state and structure data
@@ -56,13 +63,34 @@ const kurikulumSlice = createSlice({
 
     setActiveKurikulum: (state, action) => {
       const payload = action.payload || null;
+      const resolvedActiveId = resolveKurikulumId(payload);
+      const previousActiveId = state.activeKurikulumId
+        ?? resolveKurikulumId(state.activeKurikulum);
+      const selectedId = state.selectedKurikulumId
+        ?? resolveKurikulumId(state.selectedKurikulum);
+
       state.activeKurikulum = payload;
-      state.activeKurikulumId = payload?.id_kurikulum ?? payload?.kurikulum_id ?? payload?.id ?? null;
+      state.activeKurikulumId = resolvedActiveId;
+
+      if (!selectedId || (previousActiveId && selectedId === previousActiveId)) {
+        state.selectedKurikulum = payload;
+        state.selectedKurikulumId = resolvedActiveId;
+      }
     },
 
     clearActiveKurikulum: (state) => {
+      const previousActiveId = state.activeKurikulumId
+        ?? resolveKurikulumId(state.activeKurikulum);
+      const selectedId = state.selectedKurikulumId
+        ?? resolveKurikulumId(state.selectedKurikulum);
+
       state.activeKurikulum = null;
       state.activeKurikulumId = null;
+
+      if (!selectedId || (previousActiveId && selectedId === previousActiveId)) {
+        state.selectedKurikulum = null;
+        state.selectedKurikulumId = null;
+      }
     },
 
     clearSelectedKurikulum: (state) => {
@@ -247,13 +275,6 @@ export const selectKurikulumLoading = (state) => state.kurikulum.loading;
 export const selectKurikulumError = (state) => state.kurikulum.error;
 
 // Combined selectors
-const resolveKurikulumId = (kurikulum) => (
-  kurikulum?.id_kurikulum
-  ?? kurikulum?.kurikulum_id
-  ?? kurikulum?.id
-  ?? null
-);
-
 export const selectEffectiveKurikulum = (state) => (
   state.kurikulum.selectedKurikulum || state.kurikulum.activeKurikulum
 );

--- a/frontend/src/features/adminCabang/screens/kurikulum/SelectKurikulumScreen.js
+++ b/frontend/src/features/adminCabang/screens/kurikulum/SelectKurikulumScreen.js
@@ -138,16 +138,46 @@ const SelectKurikulumScreen = ({ navigation }) => {
 
     const listActiveId = getKurikulumId(activeFromList);
     const normalizedListId = listActiveId ? listActiveId.toString() : null;
+    const shouldSyncSelected = !selectedId
+      || (normalizedListId && selectedId ? normalizedListId === selectedId : false);
+
+    const syncSelection = () => {
+      if (!shouldSyncSelected) {
+        return;
+      }
+
+      const currentSelectedId = selectedKurikulum
+        ? getKurikulumId(selectedKurikulum)?.toString() ?? null
+        : null;
+
+      if (currentSelectedId === normalizedListId && selectedKurikulum?.updated_at === activeFromList?.updated_at) {
+        return;
+      }
+
+      dispatch(setSelectedKurikulum(activeFromList));
+    };
 
     if (!activeId || normalizedListId !== activeId) {
       dispatch(setActiveKurikulum(activeFromList));
+      syncSelection();
       return;
     }
 
     if (activeKurikulum && activeKurikulum.updated_at !== activeFromList?.updated_at) {
       dispatch(setActiveKurikulum(activeFromList));
+      syncSelection();
+      return;
     }
-  }, [kurikulumList, dispatch, activeId, activeKurikulum]);
+
+    syncSelection();
+  }, [
+    kurikulumList,
+    dispatch,
+    activeId,
+    activeKurikulum,
+    selectedId,
+    selectedKurikulum,
+  ]);
 
   const handleSelect = (kurikulum) => {
     dispatch(setSelectedKurikulum(kurikulum));

--- a/frontend/src/features/adminCabang/screens/kurikulum/SemesterFormScreen.js
+++ b/frontend/src/features/adminCabang/screens/kurikulum/SemesterFormScreen.js
@@ -19,10 +19,8 @@ import {
   kurikulumApi
 } from '../../api/kurikulumApi';
 import {
-  selectSelectedKurikulum,
-  selectSelectedKurikulumId,
-  selectActiveKurikulum,
-  selectActiveKurikulumId,
+  selectEffectiveKurikulum,
+  selectEffectiveKurikulumId,
 } from '../../redux/kurikulumSlice';
 
 const resolveKurikulumIdValue = (value) => {
@@ -59,10 +57,8 @@ const SemesterFormScreen = () => {
   const navigation = useNavigation();
   const route = useRoute();
   const dispatch = useDispatch();
-  const selectedKurikulumId = useSelector(selectSelectedKurikulumId);
-  const selectedKurikulum = useSelector(selectSelectedKurikulum);
-  const activeKurikulumIdFromStore = useSelector(selectActiveKurikulumId);
-  const activeKurikulum = useSelector(selectActiveKurikulum);
+  const effectiveKurikulumIdFromStore = useSelector(selectEffectiveKurikulumId);
+  const effectiveKurikulum = useSelector(selectEffectiveKurikulum);
 
   const {
     mode = 'create',
@@ -71,34 +67,23 @@ const SemesterFormScreen = () => {
     kurikulumName: paramKurikulumName,
   } = route.params || {};
 
-  const activeKurikulumId = useMemo(() => {
+  const resolvedKurikulumId = useMemo(() => {
     const resolvedParamId = resolveKurikulumIdValue(paramKurikulumId);
     if (resolvedParamId) {
       return resolvedParamId;
     }
 
-    const resolvedSelected = resolveKurikulumIdValue(
-      selectedKurikulumId ?? getKurikulumIdFromObject(selectedKurikulum)
-    );
-
-    if (resolvedSelected) {
-      return resolvedSelected;
-    }
-
     return resolveKurikulumIdValue(
-      activeKurikulumIdFromStore ?? getKurikulumIdFromObject(activeKurikulum)
+      effectiveKurikulumIdFromStore ?? getKurikulumIdFromObject(effectiveKurikulum)
     );
   }, [
     paramKurikulumId,
-    selectedKurikulumId,
-    selectedKurikulum,
-    activeKurikulumIdFromStore,
-    activeKurikulum,
+    effectiveKurikulumIdFromStore,
+    effectiveKurikulum,
   ]);
 
-  const activeKurikulumName = paramKurikulumName
-    ?? selectedKurikulum?.nama_kurikulum
-    ?? activeKurikulum?.nama_kurikulum
+  const effectiveKurikulumName = paramKurikulumName
+    ?? effectiveKurikulum?.nama_kurikulum
     ?? '';
 
   const { defaultStartDate, defaultEndDate } = useMemo(() => {
@@ -115,7 +100,7 @@ const SemesterFormScreen = () => {
     periode: 'ganjil',
     tanggal_mulai: '',
     tanggal_selesai: '',
-    kurikulum_id: activeKurikulumId ?? '',
+    kurikulum_id: resolvedKurikulumId ?? '',
   });
   const [startDate, setStartDate] = useState(defaultStartDate);
   const [endDate, setEndDate] = useState(defaultEndDate);
@@ -131,7 +116,7 @@ const SemesterFormScreen = () => {
     if (isEditMode) {
       const semesterKurikulumId = semesterParam.kurikulum_id
         ?? semesterParam.id_kurikulum
-        ?? activeKurikulumId
+        ?? resolvedKurikulumId
         ?? '';
 
       setFormData({
@@ -153,12 +138,12 @@ const SemesterFormScreen = () => {
     } else {
       setFormData((prev) => ({
         ...prev,
-        kurikulum_id: activeKurikulumId ?? '',
+        kurikulum_id: resolvedKurikulumId ?? '',
       }));
       setStartDate(defaultStartDate);
       setEndDate(defaultEndDate);
     }
-  }, [isEditMode, semesterParam, activeKurikulumId, defaultStartDate, defaultEndDate]);
+  }, [isEditMode, semesterParam, resolvedKurikulumId, defaultStartDate, defaultEndDate]);
 
   useEffect(() => {
     navigation.setOptions({
@@ -190,7 +175,9 @@ const SemesterFormScreen = () => {
       return;
     }
 
-    const normalizedKurikulumId = resolveKurikulumIdValue(formData.kurikulum_id ?? activeKurikulumId);
+    const normalizedKurikulumId = resolveKurikulumIdValue(
+      formData.kurikulum_id ?? resolvedKurikulumId
+    );
     if (!normalizedKurikulumId) {
       Alert.alert('Error', 'Kurikulum belum dipilih atau tidak valid');
       return;
@@ -275,9 +262,9 @@ const SemesterFormScreen = () => {
             selectTextOnFocus={false}
             placeholder="ID kurikulum terpilih"
           />
-          {(semesterParam?.kurikulum?.nama_kurikulum || activeKurikulumName) ? (
+          {(semesterParam?.kurikulum?.nama_kurikulum || effectiveKurikulumName) ? (
             <Text style={styles.helperText} numberOfLines={2}>
-              Kurikulum: {semesterParam?.kurikulum?.nama_kurikulum || activeKurikulumName}
+              Kurikulum: {semesterParam?.kurikulum?.nama_kurikulum || effectiveKurikulumName}
             </Text>
           ) : null}
         </View>

--- a/frontend/src/features/adminCabang/screens/kurikulum/SemesterManagementScreen.js
+++ b/frontend/src/features/adminCabang/screens/kurikulum/SemesterManagementScreen.js
@@ -18,10 +18,10 @@ import {
 } from '../../api/kurikulumApi';
 import SemesterListSection from './components/SemesterListSection';
 import {
-  selectSelectedKurikulum,
-  selectSelectedKurikulumId,
   selectActiveKurikulum,
   selectActiveKurikulumId,
+  selectEffectiveKurikulum,
+  selectEffectiveKurikulumId,
 } from '../../redux/kurikulumSlice';
 
 // --- Helpers ---
@@ -55,18 +55,25 @@ const normalizeSemesterList = (response) => {
 
 // --- Screen Component ---
 const SemesterManagementScreen = ({ navigation }) => {
-  const selectedKurikulumId = useSelector(selectSelectedKurikulumId);
-  const selectedKurikulum = useSelector(selectSelectedKurikulum);
   const activeKurikulumIdFromStore = useSelector(selectActiveKurikulumId);
   const activeKurikulum = useSelector(selectActiveKurikulum);
+  const effectiveKurikulum = useSelector(selectEffectiveKurikulum);
+  const effectiveKurikulumIdFromStore = useSelector(selectEffectiveKurikulumId);
 
-  const resolvedSelectedId = selectedKurikulumId ?? resolveKurikulumId(selectedKurikulum);
-  const resolvedActiveId = activeKurikulumIdFromStore ?? resolveKurikulumId(activeKurikulum);
-  const effectiveKurikulumId = resolvedSelectedId ?? resolvedActiveId ?? null;
-  const effectiveKurikulum = selectedKurikulum || activeKurikulum || null;
+  const effectiveKurikulumId = effectiveKurikulumIdFromStore
+    ?? resolveKurikulumId(effectiveKurikulum);
   const effectiveKurikulumName = effectiveKurikulum?.nama_kurikulum || '';
+
+  const normalizedEffectiveId = effectiveKurikulumId
+    ? String(effectiveKurikulumId)
+    : null;
+  const normalizedActiveId = activeKurikulumIdFromStore
+    ? String(activeKurikulumIdFromStore)
+    : activeKurikulum
+      ? String(resolveKurikulumId(activeKurikulum))
+      : null;
   const isUsingActiveKurikulum = Boolean(
-    effectiveKurikulumId && resolvedActiveId && String(effectiveKurikulumId) === String(resolvedActiveId)
+    normalizedEffectiveId && normalizedActiveId && normalizedEffectiveId === normalizedActiveId
   );
 
   const [selectedTab, setSelectedTab] = useState('active');
@@ -179,7 +186,6 @@ const SemesterManagementScreen = ({ navigation }) => {
 
   const allSemesters = useMemo(() => normalizeSemesterList(semesterResponse), [semesterResponse]);
 
-  const normalizedEffectiveId = effectiveKurikulumId ? String(effectiveKurikulumId) : null;
   const filteredSemesters = useMemo(() => {
     if (!normalizedEffectiveId) return [];
     return allSemesters.filter((semester) => {


### PR DESCRIPTION
## Summary
- ensure activating a kurikulum also refreshes the selected kurikulum state and clears selections when nothing is active
- keep the selection list in sync with the active kurikulum so the default highlights follow the current active item
- update semester management and form screens to rely on the effective kurikulum selectors for default context handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc9be45cc88323b82b3c83effcb67a