### PR TITLE
Add admin shelter notifications management

### DIFF
--- a/frontend/src/features/adminShelter/redux/notificationSlice.js
+++ b/frontend/src/features/adminShelter/redux/notificationSlice.js
@@ -1,0 +1,141 @@
+import { createSlice, createAsyncThunk, createSelector } from '@reduxjs/toolkit';
+import { shelterOperationsApi } from '../api/shelterOperationsApi';
+
+const normalizeNotification = (notification) => {
+  if (!notification) {
+    return notification;
+  }
+
+  const idValue =
+    notification.id ??
+    notification.notification_id ??
+    notification.uuid ??
+    notification.id_notification ??
+    notification.id_notifikasi;
+
+  const id = idValue !== undefined && idValue !== null ? String(idValue) : undefined;
+
+  const rawIsRead =
+    notification.is_read ??
+    notification.isRead ??
+    notification.status_read ??
+    notification.read_status;
+
+  const isRead = typeof rawIsRead === 'boolean'
+    ? rawIsRead
+    : rawIsRead === 1 || rawIsRead === '1' || rawIsRead === 'true' || !!notification.read_at;
+
+  return {
+    ...notification,
+    id,
+    is_read: isRead,
+  };
+};
+
+export const fetchNotifications = createAsyncThunk(
+  'notification/fetchNotifications',
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await shelterOperationsApi.getKurikulumNotifications();
+      return response.data?.data ?? [];
+    } catch (error) {
+      const message = error.response?.data?.message || 'Gagal memuat notifikasi';
+      return rejectWithValue(message);
+    }
+  }
+);
+
+export const markNotificationAsRead = createAsyncThunk(
+  'notification/markNotificationAsRead',
+  async (notificationId, { rejectWithValue }) => {
+    try {
+      const response = await shelterOperationsApi.markNotificationAsRead(notificationId);
+      return response.data?.data ?? null;
+    } catch (error) {
+      const message = error.response?.data?.message || 'Gagal memperbarui notifikasi';
+      return rejectWithValue(message);
+    }
+  }
+);
+
+const initialState = {
+  items: [],
+  status: 'idle',
+  error: null,
+  markingIds: [],
+};
+
+const notificationSlice = createSlice({
+  name: 'notification',
+  initialState,
+  reducers: {
+    clearNotificationError: (state) => {
+      state.error = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchNotifications.pending, (state) => {
+        state.status = 'loading';
+        state.error = null;
+      })
+      .addCase(fetchNotifications.fulfilled, (state, action) => {
+        state.status = 'succeeded';
+        state.items = (action.payload ?? []).map(normalizeNotification);
+      })
+      .addCase(fetchNotifications.rejected, (state, action) => {
+        state.status = 'failed';
+        state.error = action.payload || 'Gagal memuat notifikasi';
+      })
+      .addCase(markNotificationAsRead.pending, (state, action) => {
+        const notificationId = action.meta.arg != null ? String(action.meta.arg) : action.meta.arg;
+        if (!state.markingIds.includes(notificationId)) {
+          state.markingIds.push(notificationId);
+        }
+      })
+      .addCase(markNotificationAsRead.fulfilled, (state, action) => {
+        const notificationId = action.meta.arg != null ? String(action.meta.arg) : action.meta.arg;
+        state.markingIds = state.markingIds.filter((id) => id !== notificationId);
+
+        const updatedNotification = action.payload ? normalizeNotification(action.payload) : null;
+
+        state.items = state.items.map((notification) => {
+          if (notification.id === notificationId) {
+            if (updatedNotification) {
+              return {
+                ...notification,
+                ...updatedNotification,
+                is_read: true,
+              };
+            }
+
+            return {
+              ...notification,
+              is_read: true,
+            };
+          }
+
+          return notification;
+        });
+      })
+      .addCase(markNotificationAsRead.rejected, (state, action) => {
+        const notificationId = action.meta.arg != null ? String(action.meta.arg) : action.meta.arg;
+        state.markingIds = state.markingIds.filter((id) => id !== notificationId);
+        state.error = action.payload || 'Gagal memperbarui notifikasi';
+      });
+  },
+});
+
+export const selectNotifications = (state) => state.notification.items;
+export const selectNotificationStatus = (state) => state.notification.status;
+export const selectNotificationError = (state) => state.notification.error;
+export const selectMarkingNotificationIds = (state) => state.notification.markingIds;
+
+export const selectUnreadNotificationCount = createSelector(
+  selectNotifications,
+  (notifications) => notifications.filter((notification) => !notification.is_read).length
+);
+
+export const { clearNotificationError } = notificationSlice.actions;
+
+export default notificationSlice.reducer;

--- a/frontend/src/features/adminShelter/screens/AdminShelterDashboardScreen.js
+++ b/frontend/src/features/adminShelter/screens/AdminShelterDashboardScreen.js
@@ -1,16 +1,19 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, RefreshControl, Dimensions, SafeAreaView } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import LoadingSpinner from '../../../common/components/LoadingSpinner';
 import ErrorMessage from '../../../common/components/ErrorMessage';
 import TodayActivitiesCard from '../components/TodayActivitiesCard';
 import { adminShelterApi } from '../api/adminShelterApi';
+import { useDispatch } from 'react-redux';
+import { fetchNotifications } from '../redux/notificationSlice';
 
 const { width, height } = Dimensions.get('window');
 
 const AdminShelterDashboardScreen = () => {
   const navigation = useNavigation();
+  const dispatch = useDispatch();
   const [dashboardData, setDashboardData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -25,7 +28,7 @@ const AdminShelterDashboardScreen = () => {
     { title: 'Laporan Kegiatan', icon: 'bar-chart', color: '#e67e22', onPress: () => navigation.navigate('Management', { screen: 'LaporanKegiatanMain' }) }
   ];
 
-  const fetchDashboardData = async () => {
+  const fetchDashboardData = useCallback(async () => {
     try {
       setError(null);
       const response = await adminShelterApi.getDashboard();
@@ -37,9 +40,15 @@ const AdminShelterDashboardScreen = () => {
       setLoading(false);
       setRefreshing(false);
     }
-  };
+  }, []);
 
-  useEffect(() => { fetchDashboardData(); }, []);
+  useEffect(() => { fetchDashboardData(); }, [fetchDashboardData]);
+
+  useFocusEffect(
+    useCallback(() => {
+      dispatch(fetchNotifications());
+    }, [dispatch])
+  );
 
   const handleRefresh = () => {
     setRefreshing(true);

--- a/frontend/src/features/adminShelter/screens/NotificationsScreen.js
+++ b/frontend/src/features/adminShelter/screens/NotificationsScreen.js
@@ -1,0 +1,285 @@
+import React, { useCallback, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  RefreshControl,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  fetchNotifications,
+  markNotificationAsRead,
+  selectMarkingNotificationIds,
+  selectNotificationError,
+  selectNotificationStatus,
+  selectNotifications,
+} from '../redux/notificationSlice';
+
+const formatDateTime = (timestamp) => {
+  if (!timestamp) return '';
+
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return String(timestamp);
+  }
+
+  return date.toLocaleString('id-ID', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+};
+
+const NotificationsScreen = () => {
+  const dispatch = useDispatch();
+  const notifications = useSelector(selectNotifications);
+  const status = useSelector(selectNotificationStatus);
+  const error = useSelector(selectNotificationError);
+  const markingIds = useSelector(selectMarkingNotificationIds);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      dispatch(fetchNotifications());
+    }, [dispatch])
+  );
+
+  const handleRefresh = useCallback(() => {
+    setRefreshing(true);
+    dispatch(fetchNotifications())
+      .finally(() => {
+        setRefreshing(false);
+      });
+  }, [dispatch]);
+
+  const handleNotificationPress = useCallback(
+    (notification) => {
+      if (notification.is_read) {
+        return;
+      }
+
+      const notificationId = notification.id ?? notification.notification_id;
+      if (!notificationId) {
+        return;
+      }
+
+      const normalizedId = String(notificationId);
+      if (markingIds.includes(normalizedId)) {
+        return;
+      }
+
+      dispatch(markNotificationAsRead(normalizedId));
+    },
+    [dispatch, markingIds]
+  );
+
+  const renderNotificationItem = useCallback(
+    ({ item }) => {
+      const isUpdating = markingIds.includes(String(item.id));
+
+      return (
+        <TouchableOpacity
+          style={[styles.card, !item.is_read && styles.unreadCard]}
+          activeOpacity={0.8}
+          onPress={() => handleNotificationPress(item)}
+        >
+          <View style={styles.iconWrapper}>
+            <Ionicons
+              name={item.is_read ? 'notifications' : 'notifications-outline'}
+              size={22}
+              color={item.is_read ? '#4caf50' : '#f39c12'}
+            />
+          </View>
+          <View style={styles.contentWrapper}>
+            <Text style={[styles.title, !item.is_read && styles.unreadTitle]} numberOfLines={2}>
+              {item.title || 'Pembaruan Kurikulum'}
+            </Text>
+            {item.message ? (
+              <Text style={styles.message} numberOfLines={3}>
+                {item.message}
+              </Text>
+            ) : null}
+            {item.created_at || item.updated_at ? (
+              <Text style={styles.timestamp}>
+                {formatDateTime(item.created_at || item.updated_at)}
+              </Text>
+            ) : null}
+          </View>
+          {!item.is_read && !isUpdating ? <View style={styles.unreadDot} /> : null}
+          {isUpdating ? <ActivityIndicator size="small" color="#1976d2" style={styles.loader} /> : null}
+        </TouchableOpacity>
+      );
+    },
+    [handleNotificationPress, markingIds]
+  );
+
+  const keyExtractor = useCallback((item, index) => {
+    if (item.id !== undefined && item.id !== null) {
+      return String(item.id);
+    }
+
+    if (item.notification_id !== undefined && item.notification_id !== null) {
+      return String(item.notification_id);
+    }
+
+    return `notification-${index}`;
+  }, []);
+
+  const listEmptyComponent = (
+    <View style={styles.emptyStateContainer}>
+      <Ionicons name="notifications-off" size={48} color="#b0bec5" style={styles.emptyIcon} />
+      <Text style={styles.emptyTitle}>Belum ada notifikasi</Text>
+      <Text style={styles.emptySubtitle}>Semua notifikasi terbaru akan tampil di sini.</Text>
+    </View>
+  );
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <FlatList
+        data={notifications}
+        keyExtractor={keyExtractor}
+        renderItem={renderNotificationItem}
+        contentContainerStyle={
+          notifications.length === 0 ? styles.emptyListContent : styles.listContent
+        }
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor="#1976d2" />
+        }
+        ListEmptyComponent={status === 'loading' ? null : listEmptyComponent}
+        ListHeaderComponent={
+          status === 'failed' && error ? (
+            <View style={styles.errorContainer}>
+              <Ionicons name="alert-circle" size={20} color="#e53935" style={styles.errorIcon} />
+              <Text style={styles.errorText}>{error}</Text>
+            </View>
+          ) : null
+        }
+      />
+      {status === 'loading' && notifications.length === 0 ? (
+        <View style={styles.loadingOverlay}>
+          <ActivityIndicator size="large" color="#1976d2" />
+        </View>
+      ) : null}
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#f4f6f8',
+  },
+  listContent: {
+    padding: 16,
+  },
+  emptyListContent: {
+    flexGrow: 1,
+    padding: 16,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#ffffff',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  unreadCard: {
+    borderLeftWidth: 4,
+    borderLeftColor: '#1976d2',
+    backgroundColor: '#eef5ff',
+  },
+  iconWrapper: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#e3f2fd',
+    marginRight: 12,
+  },
+  contentWrapper: {
+    flex: 1,
+  },
+  title: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#263238',
+    marginBottom: 4,
+  },
+  unreadTitle: {
+    color: '#0d47a1',
+  },
+  message: {
+    fontSize: 13,
+    color: '#546e7a',
+    marginBottom: 6,
+  },
+  timestamp: {
+    fontSize: 12,
+    color: '#90a4ae',
+  },
+  unreadDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: '#e53935',
+    marginLeft: 10,
+  },
+  loader: {
+    marginLeft: 10,
+  },
+  emptyStateContainer: {
+    alignItems: 'center',
+  },
+  emptyIcon: {
+    marginBottom: 12,
+  },
+  emptyTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#37474f',
+    marginBottom: 4,
+  },
+  emptySubtitle: {
+    fontSize: 13,
+    color: '#90a4ae',
+    textAlign: 'center',
+  },
+  errorContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#fdecea',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 12,
+  },
+  errorIcon: {
+    marginRight: 8,
+  },
+  errorText: {
+    color: '#c62828',
+    flex: 1,
+    fontSize: 13,
+  },
+  loadingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(255,255,255,0.7)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default NotificationsScreen;

--- a/frontend/src/navigation/AdminShelterNavigator.js
+++ b/frontend/src/navigation/AdminShelterNavigator.js
@@ -2,12 +2,16 @@ import React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createStackNavigator } from '@react-navigation/stack';
 import { Ionicons } from '@expo/vector-icons';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useSelector } from 'react-redux';
 
 // Core screens
 import AdminShelterDashboardScreen from '../features/adminShelter/screens/AdminShelterDashboardScreen';
 import AdminShelterProfileScreen from '../features/adminShelter/screens/AdminShelterProfileScreen';
 import AdminShelterSettingsScreen from '../features/adminShelter/screens/AdminShelterSettingsScreen';
 import ShelterGpsSettingScreen from '../features/adminShelter/screens/ShelterGpsSettingScreen';
+import NotificationsScreen from '../features/adminShelter/screens/NotificationsScreen';
+import { selectUnreadNotificationCount } from '../features/adminShelter/redux/notificationSlice';
 
 // Primary feature screens  
 import QrScannerScreen from '../features/adminShelter/screens/attendance/QrScannerScreen';
@@ -104,10 +108,76 @@ const HomeStack = createStackNavigator();
 const ProfileStack = createStackNavigator();
 const ManagementStack = createStackNavigator();
 
-const HomeStackNavigator = () => (
-  <HomeStack.Navigator>
-    <HomeStack.Screen name="Dashboard" component={AdminShelterDashboardScreen} options={{ headerTitle: 'Dashboard Admin Shelter' }} />
-    
+const headerStyles = StyleSheet.create({
+  headerButton: {
+    marginRight: 12,
+    padding: 4,
+  },
+  headerRightContainer: {
+    marginRight: 12,
+  },
+  badgeContainer: {
+    position: 'absolute',
+    top: -4,
+    right: -6,
+    minWidth: 18,
+    height: 18,
+    borderRadius: 9,
+    backgroundColor: '#e53935',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+  },
+  badgeText: {
+    color: '#ffffff',
+    fontSize: 10,
+    fontWeight: '700',
+  },
+});
+
+const NotificationBell = ({ onPress, unreadCount }) => (
+  <TouchableOpacity
+    onPress={onPress}
+    style={headerStyles.headerButton}
+    accessibilityRole="button"
+    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+  >
+    <View>
+      <Ionicons name="notifications-outline" size={24} color="#1f2933" />
+      {unreadCount > 0 && (
+        <View style={headerStyles.badgeContainer}>
+          <Text style={headerStyles.badgeText}>{unreadCount > 99 ? '99+' : unreadCount}</Text>
+        </View>
+      )}
+    </View>
+  </TouchableOpacity>
+);
+
+const HomeStackNavigator = () => {
+  const unreadCount = useSelector(selectUnreadNotificationCount);
+
+  return (
+    <HomeStack.Navigator>
+      <HomeStack.Screen
+        name="Dashboard"
+        component={AdminShelterDashboardScreen}
+        options={({ navigation }) => ({
+          headerTitle: 'Dashboard Admin Shelter',
+          headerRight: () => (
+            <NotificationBell
+              onPress={() => navigation.navigate('Notifications')}
+              unreadCount={unreadCount}
+            />
+          ),
+          headerRightContainerStyle: headerStyles.headerRightContainer,
+        })}
+      />
+      <HomeStack.Screen
+        name="Notifications"
+        component={NotificationsScreen}
+        options={{ headerTitle: 'Notifikasi', headerBackTitleVisible: false }}
+      />
+
     {/* Core feature screens */}
     <HomeStack.Screen name="QrScanner" component={QrScannerScreen} options={{ headerTitle: 'Scan QR Code' }} />
     <HomeStack.Screen name="ViewReportScreen" component={ViewReportScreen} options={{ headerTitle: 'View Report' }} />

--- a/frontend/src/redux/rootReducer.js
+++ b/frontend/src/redux/rootReducer.js
@@ -22,6 +22,7 @@ import raportLaporanReducer from '../features/adminShelter/redux/raportLaporanSl
 import laporanSuratReducer from '../features/adminShelter/redux/laporanSuratSlice';
 import laporanAktivitasReducer from '../features/adminShelter/redux/laporanAktivitasSlice';
 import historiLaporanReducer from '../features/adminShelter/redux/historiLaporanSlice';
+import notificationReducer from '../features/adminShelter/redux/notificationSlice';
 
 // Admin Cabang reducers
 import kurikulumReducer from '../features/adminCabang/redux/kurikulumSlice';
@@ -60,6 +61,7 @@ const appReducer = combineReducers({
   laporanSurat: laporanSuratReducer,
   laporanAktivitas: laporanAktivitasReducer,
   historiLaporan: historiLaporanReducer,
+  notification: notificationReducer,
   
   // Admin Cabang reducers
   kurikulum: kurikulumReducer,


### PR DESCRIPTION
## Summary
- add a Redux Toolkit slice to load and track admin shelter notifications
- create a dedicated notifications screen with unread highlighting and mark-as-read handling
- surface unread counts in the dashboard header and wire the notifications route into the navigator

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dccc7253fc8323bf021d91c80f0a63