### PR TITLE
Add Expo push token management for admin shelter notifications

### DIFF
--- a/backend/app/Http/Controllers/API/AdminShelter/NotificationTokenController.php
+++ b/backend/app/Http/Controllers/API/AdminShelter/NotificationTokenController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Http\Controllers\API\AdminShelter;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Validator;
+
+class NotificationTokenController extends Controller
+{
+    public function store(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'expo_push_token' => 'required|string',
+            'device_info' => 'nullable',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $validated = $validator->validated();
+        $deviceInfo = $validated['device_info'] ?? null;
+
+        if (is_string($deviceInfo)) {
+            $decoded = json_decode($deviceInfo, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $deviceInfo = $decoded;
+            } else {
+                $deviceInfo = ['raw' => $deviceInfo];
+            }
+        }
+
+        $user = $request->user();
+
+        $token = $user->pushTokens()->updateOrCreate(
+            ['expo_push_token' => $validated['expo_push_token']],
+            [
+                'device_info' => $deviceInfo,
+                'last_used_at' => now(),
+            ]
+        );
+
+        Log::info('Expo push token stored for user', [
+            'user_id' => $user->id_users,
+            'token_id' => $token->id,
+        ]);
+
+        return response()->json([
+            'message' => 'Push notification token stored successfully',
+            'data' => $token,
+        ], 201);
+    }
+
+    public function destroy(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'expo_push_token' => 'required|string',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $user = $request->user();
+
+        $deleted = $user->pushTokens()
+            ->where('expo_push_token', $validator->validated()['expo_push_token'])
+            ->delete();
+
+        if (! $deleted) {
+            return response()->json([
+                'message' => 'Push notification token not found',
+            ], 404);
+        }
+
+        Log::info('Expo push token removed for user', [
+            'user_id' => $user->id_users,
+            'expo_push_token' => $validator->validated()['expo_push_token'],
+        ]);
+
+        return response()->json([
+            'message' => 'Push notification token removed successfully',
+        ]);
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
@@ -67,6 +68,11 @@ class User extends Authenticatable
     public function donatur()
     {
         return $this->hasOne(Donatur::class, 'id_users', 'id_users');
+    }
+
+    public function pushTokens(): HasMany
+    {
+        return $this->hasMany(UserPushToken::class, 'user_id', 'id_users');
     }
 
 

--- a/backend/app/Models/UserPushToken.php
+++ b/backend/app/Models/UserPushToken.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class UserPushToken extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'expo_push_token',
+        'device_info',
+        'last_used_at',
+    ];
+
+    protected $casts = [
+        'device_info' => 'array',
+        'last_used_at' => 'datetime',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id', 'id_users');
+    }
+}

--- a/backend/app/Services/PushNotificationService.php
+++ b/backend/app/Services/PushNotificationService.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Services;
+
+use ExponentPhpSDK\Expo;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class PushNotificationService
+{
+    /**
+     * Send a push notification to the provided Expo tokens.
+     *
+     * @param  array<int, string>  $tokens
+     * @param  array<string, mixed>  $message
+     * @return array{success: bool, response: mixed, errors: array<int, mixed>}
+     */
+    public function send(array $tokens, array $message): array
+    {
+        $tokens = array_values(array_filter(array_unique($tokens)));
+
+        if (empty($tokens)) {
+            return [
+                'success' => false,
+                'response' => null,
+                'errors' => ['No Expo push tokens supplied'],
+            ];
+        }
+
+        try {
+            $response = Expo::send($message, $tokens);
+
+            $errors = [];
+
+            if (is_array($response)) {
+                foreach ($response as $result) {
+                    $status = Arr::get($result, 'status');
+                    if ($status !== null && $status !== 'ok') {
+                        $errors[] = $result;
+                    }
+                }
+            }
+
+            if (! empty($errors)) {
+                Log::warning('Expo push notification delivered with errors', [
+                    'tokens' => $tokens,
+                    'errors' => $errors,
+                ]);
+            }
+
+            return [
+                'success' => empty($errors),
+                'response' => $response,
+                'errors' => $errors,
+            ];
+        } catch (Throwable $exception) {
+            Log::error('Expo push notification failed to send', [
+                'tokens' => $tokens,
+                'message' => $message,
+                'exception' => $exception->getMessage(),
+            ]);
+
+            return [
+                'success' => false,
+                'response' => null,
+                'errors' => [$exception->getMessage()],
+            ];
+        }
+    }
+}

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -10,7 +10,8 @@
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",
-        "laravel/tinker": "^2.8"
+        "laravel/tinker": "^2.8",
+        "alopeyk/exponent-php-sdk": "^1.1"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/backend/database/migrations/2025_10_01_065515_create_user_push_tokens_table.php
+++ b/backend/database/migrations/2025_10_01_065515_create_user_push_tokens_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('user_push_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->string('expo_push_token')->unique();
+            $table->json('device_info')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('user_id')
+                ->references('id_users')
+                ->on('users')
+                ->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('user_push_tokens');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -203,6 +203,8 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/dashboard', [App\Http\Controllers\API\AdminShelterController::class, 'dashboard']);
     Route::get('/profile', [App\Http\Controllers\API\AdminShelterController::class, 'getProfile']);
     Route::post('/profile', [App\Http\Controllers\API\AdminShelterController::class, 'updateProfile']);
+    Route::post('/notifications/token', [App\Http\Controllers\API\AdminShelter\NotificationTokenController::class, 'store']);
+    Route::delete('/notifications/token', [App\Http\Controllers\API\AdminShelter\NotificationTokenController::class, 'destroy']);
     
         Route::controller(App\Http\Controllers\API\AdminShelter\AdminShelterKurikulumController::class)->group(function () {
             Route::get('/kurikulum', 'index');


### PR DESCRIPTION
## Summary
- add the Expo PHP SDK dependency to enable push messaging
- create the user push token schema, model relationship, and admin shelter API endpoints for registering/removing tokens
- introduce a reusable push notification service that wraps the Expo client with error handling

## Testing
- composer install

------
https://chatgpt.com/codex/tasks/task_e_68dccffe46588323a71f88ef4d547b32