### PR TITLE
feat: send upcoming activity notifications

### DIFF
--- a/backend/app/Console/Commands/SendUpcomingActivityNotifications.php
+++ b/backend/app/Console/Commands/SendUpcomingActivityNotifications.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Aktivitas;
+use App\Models\UserPushToken;
+use App\Services\PushNotificationService;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class SendUpcomingActivityNotifications extends Command
+{
+    protected $signature = 'notifications:send-upcoming-activities
+                            {--window-start=15 : Minutes from now to start the notification window}
+                            {--window-end=30 : Minutes from now to end the notification window}';
+
+    protected $description = 'Send push notifications for upcoming Admin Shelter activities.';
+
+    public function __construct(private readonly PushNotificationService $pushNotificationService)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $now = now();
+        $startMinutes = (int) $this->option('window-start');
+        $endMinutes = (int) $this->option('window-end');
+
+        if ($startMinutes < 0) {
+            $startMinutes = 0;
+        }
+
+        if ($endMinutes <= $startMinutes) {
+            $endMinutes = $startMinutes + 15;
+        }
+
+        $startWindow = $now->copy()->addMinutes($startMinutes);
+        $endWindow = $now->copy()->addMinutes($endMinutes);
+
+        Log::info('SendUpcomingActivityNotifications started', [
+            'now' => $now->toIso8601String(),
+            'window_start' => $startWindow->toIso8601String(),
+            'window_end' => $endWindow->toIso8601String(),
+        ]);
+
+        $activities = Aktivitas::query()
+            ->with(['shelter.adminShelters.user.pushTokens'])
+            ->whereDate('tanggal', $now->toDateString())
+            ->whereNull('notified_at')
+            ->whereNotNull('start_time')
+            ->get()
+            ->filter(function (Aktivitas $activity) use ($startWindow, $endWindow) {
+                $startDateTime = $this->resolveStartDateTime($activity);
+
+                if (! $startDateTime) {
+                    return false;
+                }
+
+                return $startDateTime->greaterThanOrEqualTo($startWindow)
+                    && $startDateTime->lessThanOrEqualTo($endWindow);
+            });
+
+        if ($activities->isEmpty()) {
+            $this->info('Tidak ada aktivitas yang perlu dikirim notifikasinya saat ini.');
+            Log::info('SendUpcomingActivityNotifications finished - no activities to notify');
+
+            return self::SUCCESS;
+        }
+
+        $sentCount = 0;
+        $failedCount = 0;
+
+        foreach ($activities as $activity) {
+            $startDateTime = $this->resolveStartDateTime($activity);
+
+            if (! $startDateTime) {
+                Log::warning('Aktivitas dilewati karena tidak memiliki start_time yang valid', [
+                    'activity_id' => $activity->id_aktivitas,
+                ]);
+
+                continue;
+            }
+
+            $adminShelters = $activity->shelter?->adminShelters ?? collect();
+
+            if ($adminShelters->isEmpty()) {
+                Log::warning('Tidak ada admin shelter terkait aktivitas', [
+                    'activity_id' => $activity->id_aktivitas,
+                ]);
+                $this->warn("Tidak ada admin shelter untuk aktivitas ID {$activity->id_aktivitas}");
+
+                continue;
+            }
+
+            $tokenModels = $adminShelters
+                ->flatMap(function ($adminShelter) {
+                    return $adminShelter->user?->pushTokens ?? collect();
+                })
+                ->filter(function ($token) {
+                    return filled($token->expo_push_token);
+                })
+                ->unique('expo_push_token')
+                ->values();
+
+            if ($tokenModels->isEmpty()) {
+                Log::warning('Tidak ada token push untuk aktivitas', [
+                    'activity_id' => $activity->id_aktivitas,
+                ]);
+                $this->warn("Tidak ada token push untuk aktivitas ID {$activity->id_aktivitas}");
+
+                continue;
+            }
+
+            $tokens = $tokenModels->pluck('expo_push_token')->values()->all();
+            $activityTitle = $activity->materi ?: $activity->jenis_kegiatan ?: 'Aktivitas Shelter';
+            $startTimeLabel = $startDateTime->timezone(config('app.timezone'))
+                ->format('H:i');
+
+            $payload = [
+                'title' => 'Pengingat Aktivitas',
+                'body' => sprintf('%s akan dimulai pada %s', $activityTitle, $startTimeLabel),
+                'data' => [
+                    'activity' => [
+                        'id' => $activity->id_aktivitas,
+                        'shelter_id' => $activity->id_shelter,
+                        'title' => $activityTitle,
+                        'tanggal' => optional($activity->tanggal)->toDateString(),
+                        'start_time' => $startDateTime->toIso8601String(),
+                        'jenis_kegiatan' => $activity->jenis_kegiatan,
+                        'materi' => $activity->materi,
+                    ],
+                ],
+            ];
+
+            $this->info(sprintf(
+                'Mengirim notifikasi aktivitas #%d ke %d token',
+                $activity->id_aktivitas,
+                count($tokens)
+            ));
+
+            $response = $this->pushNotificationService->send($tokens, $payload);
+
+            if (! $response['success']) {
+                $failedCount++;
+                Log::error('Gagal mengirim notifikasi aktivitas', [
+                    'activity_id' => $activity->id_aktivitas,
+                    'tokens' => $tokens,
+                    'errors' => $response['errors'],
+                ]);
+
+                $this->error(sprintf(
+                    'Gagal mengirim notifikasi untuk aktivitas #%d. Lihat log untuk detailnya.',
+                    $activity->id_aktivitas
+                ));
+
+                continue;
+            }
+
+            $activity->forceFill(['notified_at' => $now])->save();
+
+            $tokenModels->each(function (UserPushToken $token) use ($now) {
+                $token->forceFill(['last_used_at' => $now])->save();
+            });
+
+            $sentCount++;
+
+            Log::info('Notifikasi aktivitas berhasil dikirim', [
+                'activity_id' => $activity->id_aktivitas,
+                'tokens' => $tokens,
+            ]);
+        }
+
+        $this->info(sprintf(
+            'Selesai: %d aktivitas terkirim, %d gagal.',
+            $sentCount,
+            $failedCount
+        ));
+
+        Log::info('SendUpcomingActivityNotifications finished', [
+            'sent' => $sentCount,
+            'failed' => $failedCount,
+        ]);
+
+        return $failedCount > 0 ? self::FAILURE : self::SUCCESS;
+    }
+
+    private function resolveStartDateTime(Aktivitas $activity): ?Carbon
+    {
+        if (! $activity->start_time) {
+            return null;
+        }
+
+        $startTime = $activity->start_time;
+
+        if (Str::contains($startTime, [' ', 'T'])) {
+            return Carbon::parse($startTime, config('app.timezone'));
+        }
+
+        if (! $activity->tanggal) {
+            return null;
+        }
+
+        return Carbon::parse(
+            $activity->tanggal->format('Y-m-d') . ' ' . $startTime,
+            config('app.timezone')
+        );
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -17,6 +17,12 @@ class Kernel extends ConsoleKernel
                  ->dailyAt('01:00')
                  ->withoutOverlapping()
                  ->runInBackground();
+
+        // Send push notifications for upcoming Admin Shelter activities
+        $schedule->command('notifications:send-upcoming-activities')
+                 ->everyFiveMinutes()
+                 ->withoutOverlapping()
+                 ->runInBackground();
     }
 
     /**

--- a/backend/app/Models/Aktivitas.php
+++ b/backend/app/Models/Aktivitas.php
@@ -34,6 +34,7 @@ class Aktivitas extends Model
         'gps_recorded_at',
         'location_name',
         'status',
+        'notified_at',
     ];
 
     protected $attributes = [
@@ -49,7 +50,8 @@ class Aktivitas extends Model
         'require_gps' => 'boolean',
         'max_distance_meters' => 'integer',
         'gps_accuracy' => 'decimal:2',
-        'gps_recorded_at' => 'datetime'
+        'gps_recorded_at' => 'datetime',
+        'notified_at' => 'datetime',
     ];
 
 

--- a/backend/database/migrations/2025_10_01_070128_add_notified_at_to_aktivitas_table.php
+++ b/backend/database/migrations/2025_10_01_070128_add_notified_at_to_aktivitas_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('aktivitas', function (Blueprint $table) {
+            $table->timestamp('notified_at')->nullable()->after('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('aktivitas', function (Blueprint $table) {
+            $table->dropColumn('notified_at');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add a notified_at timestamp to the aktivitas table and model for tracking push delivery
- implement a scheduled command that sends upcoming Admin Shelter activity notifications and records token usage
- register the command with the scheduler to run every five minutes without overlapping

## Testing
- ⚠️ `php artisan test` *(fails: Could not open input file: artisan)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd17bf6f0832388c65f28c1b25495