### PR TITLE
Configure Expo notifications plugin

### DIFF
--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -33,6 +33,7 @@ export default {
         "android.permission.CAMERA",
         "android.permission.RECORD_AUDIO",
         "android.permission.MODIFY_AUDIO_SETTINGS",
+        "android.permission.POST_NOTIFICATIONS",
         "ACCESS_FINE_LOCATION",
         "ACCESS_COARSE_LOCATION"
       ],
@@ -54,6 +55,14 @@ export default {
         "expo-location",
         {
           locationAlwaysAndWhenInUsePermission: "This app uses location to verify attendance at shelter activities."
+        }
+      ],
+      [
+        "expo-notifications",
+        {
+          icon: "./assets/icon.png",
+          color: "#ffffff",
+          mode: IS_DEV ? "development" : "production"
         }
       ],
       "expo-audio"


### PR DESCRIPTION
## Summary
- add the Android POST_NOTIFICATIONS permission to the Expo app config
- register the expo-notifications plugin with icon, color, and mode configuration

## Testing
- npx expo prebuild *(fails: npm view expo-template-bare-minimum@sdk-53 dist --json exited with non-zero code: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd6aa4fb483238caac4899bd8b4fb