### PR TITLE
Replace Expo PHP SDK dependency

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -11,7 +11,7 @@
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",
         "laravel/tinker": "^2.8",
-        "alopeyk/exponent-php-sdk": "^1.1"
+        "alymosul/exponent-server-sdk-php": "^1.3"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",


### PR DESCRIPTION
## Summary
- replace the deprecated alopeyk/exponent-php-sdk dependency with alymosul/exponent-server-sdk-php to align with the currently maintained Expo PHP SDK

## Testing
- composer update alymosul/exponent-server-sdk-php *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dcdf50f4b08323bf1b806924f099cd