### PR TITLE
Add Android google services configuration

### DIFF
--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -37,6 +37,7 @@ export default {
         "ACCESS_FINE_LOCATION",
         "ACCESS_COARSE_LOCATION"
       ],
+      googleServicesFile: "./google-services.json",
     },
     web: {
       favicon: "./assets/favicon.png"


### PR DESCRIPTION
## Summary
- add the android `googleServicesFile` setting so Expo copies the Firebase credentials during prebuild

## Testing
- `npx expo prebuild` *(fails with npm 403 when downloading expo package)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2ff0de1c83238b6b2b2cca76c271