### PR TITLE
Replace Expo push notifications with Firebase messaging

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+FIREBASE_PROJECT_ID=app
+# Paste your Firebase service account JSON or base64-encoded credentials below.
+FIREBASE_CREDENTIALS=

--- a/backend/app/Services/PushNotificationService.php
+++ b/backend/app/Services/PushNotificationService.php
@@ -2,13 +2,20 @@
 
 namespace App\Services;
 
-use ExponentPhpSDK\Expo;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
+use Kreait\Firebase\Contract\Messaging;
+use Kreait\Firebase\Exception\FirebaseException;
+use Kreait\Firebase\Exception\MessagingException;
+use Kreait\Firebase\Messaging\CloudMessage;
+use Kreait\Firebase\Messaging\Notification;
 use Throwable;
 
 class PushNotificationService
 {
+    public function __construct(private readonly Messaging $messaging)
+    {
+    }
+
     /**
      * Send a push notification to the provided Expo tokens.
      *
@@ -24,35 +31,67 @@ class PushNotificationService
             return [
                 'success' => false,
                 'response' => null,
-                'errors' => ['No Expo push tokens supplied'],
+                'errors' => ['No push tokens supplied'],
             ];
         }
 
+        $title = isset($message['title']) ? (string) $message['title'] : null;
+        $body = isset($message['body']) ? (string) $message['body'] : null;
+        $data = [];
+
+        if (isset($message['data']) && is_array($message['data'])) {
+            foreach ($message['data'] as $key => $value) {
+                if (! is_scalar($value) && $value !== null) {
+                    $encoded = json_encode($value);
+                    $value = $encoded !== false ? $encoded : null;
+                }
+
+                $data[$key] = $value === null ? null : (string) $value;
+            }
+
+            $data = array_filter($data, static fn ($value) => $value !== null);
+        }
+
+        $cloudMessage = CloudMessage::new();
+
+        if ($title !== null || $body !== null) {
+            $cloudMessage = $cloudMessage->withNotification(Notification::create($title, $body));
+        }
+
+        if (! empty($data)) {
+            $cloudMessage = $cloudMessage->withData($data);
+        }
+
         try {
-            $expo = Expo::normalSetup();
-            $response = $expo->notify($tokens, $message);
+            $report = $this->messaging->sendMulticast($cloudMessage, $tokens);
 
             $errors = [];
 
-            if (is_array($response)) {
-                $results = Arr::isAssoc($response) ? [$response] : $response;
-
-                foreach ($results as $index => $result) {
-                    $status = Arr::get($result, 'status');
-
-                    if ($status === null || $status !== 'ok') {
-                        $errors[] = array_filter([
-                            'token' => $tokens[$index] ?? null,
-                            'status' => $status,
-                            'message' => Arr::get($result, 'message'),
-                            'details' => Arr::get($result, 'details'),
-                        ], static fn ($value) => $value !== null);
-                    }
+            foreach ($report->responses() as $index => $response) {
+                if ($response->isSuccess()) {
+                    continue;
                 }
+
+                $error = $response->error();
+                $target = $response->target();
+
+                $token = $tokens[$index] ?? null;
+
+                if (is_string($target)) {
+                    $token = $target;
+                } elseif (is_object($target) && method_exists($target, 'value')) {
+                    $token = $target->value();
+                }
+
+                $errors[] = array_filter([
+                    'token' => $token,
+                    'code' => is_object($error) && method_exists($error, 'getCode') ? $error->getCode() : null,
+                    'message' => $error?->getMessage(),
+                ], static fn ($value) => $value !== null);
             }
 
             if (! empty($errors)) {
-                Log::warning('Expo push notification delivered with errors', [
+                Log::warning('Firebase push notification delivered with errors', [
                     'tokens' => $tokens,
                     'errors' => $errors,
                 ]);
@@ -60,11 +99,26 @@ class PushNotificationService
 
             return [
                 'success' => empty($errors),
-                'response' => $response,
+                'response' => [
+                    'successes' => $report->successes()->count(),
+                    'failures' => $report->failures()->count(),
+                ],
                 'errors' => $errors,
             ];
+        } catch (MessagingException|FirebaseException $exception) {
+            Log::error('Firebase push notification failed to send', [
+                'tokens' => $tokens,
+                'message' => $message,
+                'exception' => $exception->getMessage(),
+            ]);
+
+            return [
+                'success' => false,
+                'response' => null,
+                'errors' => [$exception->getMessage()],
+            ];
         } catch (Throwable $exception) {
-            Log::error('Expo push notification failed to send', [
+            Log::error('Unexpected error while sending Firebase push notification', [
                 'tokens' => $tokens,
                 'message' => $message,
                 'exception' => $exception->getMessage(),

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -11,7 +11,7 @@
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",
         "laravel/tinker": "^2.8",
-        "alymosul/exponent-server-sdk-php": "^1.3"
+        "kreait/laravel-firebase": "^4.3"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/backend/config/firebase.php
+++ b/backend/config/firebase.php
@@ -1,0 +1,30 @@
+<?php
+
+$projectId = env('FIREBASE_PROJECT_ID', 'app');
+$credentials = env('FIREBASE_CREDENTIALS');
+$credentialsValue = null;
+
+if (! empty($credentials)) {
+    $decoded = base64_decode($credentials, true);
+    $payload = $decoded !== false ? $decoded : $credentials;
+
+    $json = json_decode($payload, true);
+
+    if (json_last_error() === JSON_ERROR_NONE && is_array($json)) {
+        $credentialsValue = $json;
+    } elseif ($decoded !== false) {
+        $credentialsValue = $decoded;
+    } else {
+        $credentialsValue = $credentials;
+    }
+}
+
+return [
+    'default' => $projectId,
+
+    'projects' => [
+        $projectId => array_filter([
+            'credentials' => $credentialsValue,
+        ], static fn ($value) => $value !== null),
+    ],
+];


### PR DESCRIPTION
## Summary
- replace the Expo push dependency with the Kreait Laravel Firebase package
- add Firebase configuration that accepts base64 or JSON credentials via environment variables
- refactor the push notification service to send HTTP v1 messages with Firebase Messaging and improved error mapping

## Testing
- `composer update` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dde165e6c483239c3e41459acdac63