### PR TITLE
Refactor push notification tokens to use FCM metadata

### DIFF
--- a/backend/app/Jobs/PurgeInvalidFcmTokens.php
+++ b/backend/app/Jobs/PurgeInvalidFcmTokens.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\UserPushToken;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class PurgeInvalidFcmTokens implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(private readonly int $graceMinutes = 60)
+    {
+    }
+
+    public function handle(): void
+    {
+        $threshold = now()->subMinutes($this->graceMinutes);
+        $totalDeleted = 0;
+
+        UserPushToken::query()
+            ->whereNotNull('invalidated_at')
+            ->where('invalidated_at', '<=', $threshold)
+            ->chunkById(500, function ($tokens) use (&$totalDeleted) {
+                $ids = $tokens->pluck('id')->all();
+
+                if (empty($ids)) {
+                    return false;
+                }
+
+                $deleted = UserPushToken::query()->whereIn('id', $ids)->delete();
+                $totalDeleted += $deleted;
+            });
+
+        if ($totalDeleted > 0) {
+            Log::info('PurgeInvalidFcmTokens removed invalidated tokens', [
+                'deleted' => $totalDeleted,
+                'grace_minutes' => $this->graceMinutes,
+            ]);
+        }
+    }
+}

--- a/backend/app/Models/UserPushToken.php
+++ b/backend/app/Models/UserPushToken.php
@@ -11,14 +11,17 @@ class UserPushToken extends Model
 
     protected $fillable = [
         'user_id',
-        'expo_push_token',
+        'fcm_token',
+        'platform',
         'device_info',
         'last_used_at',
+        'invalidated_at',
     ];
 
     protected $casts = [
         'device_info' => 'array',
         'last_used_at' => 'datetime',
+        'invalidated_at' => 'datetime',
     ];
 
     public function user()

--- a/backend/database/migrations/2025_10_05_000000_update_user_push_tokens_for_fcm.php
+++ b/backend/database/migrations/2025_10_05_000000_update_user_push_tokens_for_fcm.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user_push_tokens', function (Blueprint $table) {
+            $table->text('fcm_token')->after('user_id');
+            $table->string('platform', 64)->nullable()->after('fcm_token');
+            $table->timestamp('invalidated_at')->nullable()->after('last_used_at');
+        });
+
+        DB::table('user_push_tokens')->select('id', 'expo_push_token')->chunkById(100, function ($tokens) {
+            foreach ($tokens as $token) {
+                DB::table('user_push_tokens')
+                    ->where('id', $token->id)
+                    ->update(['fcm_token' => $token->expo_push_token]);
+            }
+        });
+
+        Schema::table('user_push_tokens', function (Blueprint $table) {
+            $table->dropUnique(['expo_push_token']);
+            $table->dropColumn('expo_push_token');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('user_push_tokens', function (Blueprint $table) {
+            $table->string('expo_push_token')->after('user_id');
+        });
+
+        DB::table('user_push_tokens')->select('id', 'fcm_token')->chunkById(100, function ($tokens) {
+            foreach ($tokens as $token) {
+                DB::table('user_push_tokens')
+                    ->where('id', $token->id)
+                    ->update(['expo_push_token' => $token->fcm_token]);
+            }
+        });
+
+        Schema::table('user_push_tokens', function (Blueprint $table) {
+            $table->unique('expo_push_token');
+            $table->dropColumn(['fcm_token', 'platform', 'invalidated_at']);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration that renames Expo push tokens to FCM tokens, stores platform metadata, and tracks invalidation timestamps
- update the user push token model, controller, and upcoming activity notification command to work with the new FCM fields and mark invalid tokens
- add a queued job to purge invalid FCM tokens after they have been flagged

## Testing
- php -l app/Http/Controllers/API/AdminShelter/NotificationTokenController.php
- php -l app/Console/Commands/SendUpcomingActivityNotifications.php
- php -l app/Jobs/PurgeInvalidFcmTokens.php
- php -l database/migrations/2025_10_05_000000_update_user_push_tokens_for_fcm.php

------
https://chatgpt.com/codex/tasks/task_e_68dde674822c8323a9e1cf91f1790ded