### PR TITLE
Switch push token registration to Firebase Cloud Messaging

### DIFF
--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -69,6 +69,9 @@ export default {
       "expo-audio"
     ],
     extra: {
+      firebase: {
+        gcmSenderId: "1055477950973"
+      },
       eas: {
         projectId: "2e83c4d0-499c-413b-ad59-f173fff2ae4f"
       }

--- a/frontend/src/features/auth/redux/authSlice.js
+++ b/frontend/src/features/auth/redux/authSlice.js
@@ -12,7 +12,7 @@ const initialState = {
   loading: false,             // Loading state
   initializing: true,         // App initialization state
   error: null,                // Error message if any
-  pushToken: null             // Expo push notification token
+  fcmToken: null              // Firebase Cloud Messaging device token
 };
 
 /**
@@ -123,8 +123,8 @@ const authSlice = createSlice({
     },
 
     // Push notification token management
-    setPushToken: (state, action) => {
-      state.pushToken = action.payload;
+    setFcmToken: (state, action) => {
+      state.fcmToken = action.payload;
     }
   }
 });
@@ -146,7 +146,7 @@ export const {
   initializeStart,
   initializeSuccess,
   initializeFailure,
-  setPushToken
+  setFcmToken
 } = authSlice.actions;
 
 // Export selectors
@@ -159,7 +159,7 @@ export const selectUser = (state) => state.auth.user;
 export const selectUserProfile = (state) => state.auth.profile;
 export const selectAuthLoading = (state) => state.auth.loading;
 export const selectAuthError = (state) => state.auth.error;
-export const selectPushToken = (state) => state.auth.pushToken;
+export const selectFcmToken = (state) => state.auth.fcmToken;
 
 // Export reducer
 export default authSlice.reducer;


### PR DESCRIPTION
## Summary
- configure the Expo app with the Firebase sender ID so we can request FCM tokens
- refactor the push token registration helper to fetch FCM device tokens, post them to the backend, and listen for refreshes
- rename the auth slice field and navigator wiring to store and refresh FCM tokens instead of Expo push tokens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dde84267748323bdcdd1df325eb323