### PR TITLE
Add attendance formula clarification to child summary card

### DIFF
--- a/frontend/src/features/adminShelter/components/ChildSummaryCard.js
+++ b/frontend/src/features/adminShelter/components/ChildSummaryCard.js
@@ -115,8 +115,12 @@ const ChildSummaryCard = ({ summary }) => {
             {formatPercentage(derivedAverage ?? 0)}%
           </Text>
           <Text style={styles.label}>Rata-rata Kehadiran</Text>
+          <Text style={styles.helperDescription}>
+            Rumus backend: rata-rata dari (total hadir ÷ total peluang kehadiran)
+            setiap anak × 100%
+          </Text>
           {shouldUseFallback && (
-            <>
+            <View style={styles.helperFallbackContainer}>
               <Text style={styles.helperText}>
                 = total hadir ÷ total peluang kehadiran
               </Text>
@@ -125,7 +129,7 @@ const ChildSummaryCard = ({ summary }) => {
                   fallbackOpportunitiesDisplay ?? 0
                 }`}
               </Text>
-            </>
+            </View>
           )}
         </View>
         <View style={styles.item}>
@@ -176,6 +180,16 @@ const styles = StyleSheet.create({
     color: '#888',
     marginTop: 4,
     textAlign: 'center'
+  },
+  helperDescription: {
+    fontSize: 10,
+    color: '#888',
+    marginTop: 4,
+    textAlign: 'center'
+  },
+  helperFallbackContainer: {
+    marginTop: 4,
+    alignItems: 'center'
   },
   helperRatio: {
     fontSize: 10,


### PR DESCRIPTION
## Summary
- add a persistent explanation of the backend attendance formula in the "Rata-rata Kehadiran" section
- adjust the fallback attendance details layout to keep the helper text readable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df850d3458832385d07575554d1dd2