### PR TITLE
Add reload spinner to Admin Cabang child report list

### DIFF
--- a/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
@@ -304,10 +304,18 @@ const AdminCabangChildReportScreen = () => {
     </View>
   );
 
+  const showReloadingOverlay = loading && !initializing && !loadingMore;
+
   return (
     <View style={styles.container}>
       {initializing && (
         <View style={styles.loadingOverlay}>
+          <LoadingSpinner />
+        </View>
+      )}
+
+      {showReloadingOverlay && (
+        <View style={styles.reloadingOverlay}>
           <LoadingSpinner />
         </View>
       )}
@@ -442,6 +450,13 @@ const styles = StyleSheet.create({
   loadingOverlay: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(255,255,255,0.7)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1,
+  },
+  reloadingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(255,255,255,0.4)',
     alignItems: 'center',
     justifyContent: 'center',
     zIndex: 1,


### PR DESCRIPTION
## Summary
- add a lightweight overlay spinner when the child report list is reloading the first page
- ensure the spinner does not conflict with the initializing or load-more indicators

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfd0faca108323bc66cb7b1d045c2c