### PR TITLE
Handle shelter fetch errors in child report filters

### DIFF
--- a/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
@@ -236,7 +236,7 @@ const AdminCabangChildReportScreen = () => {
       filterOptions.sheltersByWilayah?.[wilayahId] ||
       filterOptions.sheltersByWilayah?.[String(wilayahId)];
 
-    if (Array.isArray(existingOptions)) {
+    if (Array.isArray(existingOptions) && !filterOptions.sheltersError) {
       // Data for this wilayah has already been loaded from the initial payload.
       return;
     }
@@ -356,6 +356,7 @@ const AdminCabangChildReportScreen = () => {
         wilayahOptions={filterOptions.wilayahBinaan}
         shelterOptions={shelterOptions}
         shelterLoading={filterOptions.sheltersLoading}
+        shelterError={filterOptions.sheltersError}
         onApply={handleApplyFilters}
         onClear={handleClearFilters}
         onWilayahFetch={handleWilayahFetch}


### PR DESCRIPTION
## Summary
- surface shelter fetch errors in the child report filter modal with messaging and retry support
- disable shelter choices when an error occurs and trigger a fresh fetch on retry
- pass shelter error state from the child report screen and allow retries even when cached data exists

## Testing
- not run (React Native project)


------
https://chatgpt.com/codex/tasks/task_e_68dfd255395083239c0f2d8b785db48f