### PR TITLE
feat: refresh admin cabang child summary display

### DIFF
--- a/frontend/src/features/adminCabang/components/reports/CabangChildSummaryCard.js
+++ b/frontend/src/features/adminCabang/components/reports/CabangChildSummaryCard.js
@@ -1,0 +1,179 @@
+import React, { useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import ReportSummaryCard from './ReportSummaryCard';
+import {
+  calculateAttendancePercentage,
+  formatPercentage,
+  getPercentageColor,
+} from '../../../adminShelter/utils/reportUtils';
+
+const normalizePercentageValue = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isNaN(value) ? null : value;
+  }
+
+  if (typeof value === 'string') {
+    const numeric = parseFloat(value.replace('%', '').trim());
+    return Number.isNaN(numeric) ? null : numeric;
+  }
+
+  const numeric = Number(value);
+  return Number.isNaN(numeric) ? null : numeric;
+};
+
+const CabangChildSummaryCard = ({ summary }) => {
+  const metrics = useMemo(() => {
+    if (!summary) {
+      return null;
+    }
+
+    const totalChildren = summary.total_children ?? summary.total ?? 0;
+    const totalActivities = summary.total_activities ?? summary.totalActivities ?? 0;
+    const totalAttended = summary.total_attended ?? summary.totalAttended ?? null;
+    const totalAttendanceOpportunities =
+      summary.total_attendance_opportunities ??
+      summary.attendance_opportunities_total ??
+      summary.totalAttendanceOpportunities ??
+      summary.total_attendance_opportunity ??
+      summary.totalAttendanceOpportunity ??
+      null;
+
+    const numericTotalChildren = Number(totalChildren);
+    const numericTotalActivities = Number(totalActivities);
+    const numericTotalAttended =
+      totalAttended !== null && totalAttended !== undefined ? Number(totalAttended) : null;
+    const numericTotalAttendanceOpportunities =
+      totalAttendanceOpportunities !== null && totalAttendanceOpportunities !== undefined
+        ? Number(totalAttendanceOpportunities)
+        : null;
+
+    const candidateAverageKeys = [
+      'average_attendance',
+      'attendance_rate',
+      'average',
+      'average_percentage',
+      'attendance_percentage',
+      'percentage',
+      'overall_percentage',
+    ];
+
+    const explicitAverage = candidateAverageKeys.reduce((acc, key) => {
+      if (acc !== null) {
+        return acc;
+      }
+
+      return normalizePercentageValue(summary[key]);
+    }, null);
+
+    const hasValidAttended =
+      numericTotalAttended !== null &&
+      numericTotalAttended !== undefined &&
+      !Number.isNaN(numericTotalAttended);
+
+    const hasAttendanceDetails =
+      !Number.isNaN(numericTotalChildren) &&
+      !Number.isNaN(numericTotalActivities) &&
+      numericTotalChildren !== null &&
+      numericTotalActivities !== null;
+
+    const hasAttendanceOpportunityDetails =
+      numericTotalAttendanceOpportunities !== null &&
+      !Number.isNaN(numericTotalAttendanceOpportunities);
+
+    const totalPotentialAttendance =
+      hasAttendanceDetails && Number.isFinite(numericTotalChildren) && Number.isFinite(numericTotalActivities)
+        ? numericTotalChildren * numericTotalActivities
+        : null;
+
+    const fallbackAttendanceOpportunities = hasAttendanceOpportunityDetails
+      ? numericTotalAttendanceOpportunities
+      : totalPotentialAttendance;
+
+    const shouldUseFallback =
+      explicitAverage === null &&
+      hasValidAttended &&
+      fallbackAttendanceOpportunities !== null &&
+      Number.isFinite(fallbackAttendanceOpportunities) &&
+      fallbackAttendanceOpportunities > 0;
+
+    const attendancePercentage = shouldUseFallback
+      ? calculateAttendancePercentage(numericTotalAttended, fallbackAttendanceOpportunities)
+      : explicitAverage ?? 0;
+
+    const safeAttendancePercentage = normalizePercentageValue(attendancePercentage) ?? 0;
+
+    return {
+      attendancePercentage: safeAttendancePercentage,
+      cards: [
+        {
+          key: 'children',
+          label: 'Total Anak',
+          value: totalChildren ?? 0,
+          icon: 'people',
+          color: '#2980b9',
+        },
+        {
+          key: 'attendance',
+          label: 'Rata-rata Kehadiran',
+          value: `${formatPercentage(safeAttendancePercentage)}%`,
+          icon: 'stats-chart',
+          color: getPercentageColor(safeAttendancePercentage),
+        },
+        {
+          key: 'activities',
+          label: 'Aktivitas',
+          value: totalActivities ?? 0,
+          icon: 'calendar',
+          color: '#e67e22',
+        },
+      ],
+    };
+  }, [summary]);
+
+  if (!metrics) {
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.cardsContainer}>
+        {metrics.cards.map((card) => (
+          <View
+            key={card.key}
+            style={styles.cardWrapper}
+          >
+            <ReportSummaryCard
+              label={card.label}
+              value={card.value}
+              icon={card.icon}
+              color={card.color}
+            />
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: 4,
+    marginBottom: 12,
+  },
+  cardsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginHorizontal: -6,
+  },
+  cardWrapper: {
+    flexBasis: '33.3333%',
+    maxWidth: '33.3333%',
+    paddingHorizontal: 6,
+  },
+});
+
+export default CabangChildSummaryCard;

--- a/frontend/src/features/adminCabang/components/reports/ChildReportSummary.js
+++ b/frontend/src/features/adminCabang/components/reports/ChildReportSummary.js
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
-import ChildSummaryCard from '../../../adminShelter/components/ChildSummaryCard';
+import CabangChildSummaryCard from './CabangChildSummaryCard';
 import ReportSummaryCard from './ReportSummaryCard';
 
 const ChildReportSummary = ({ summary }) => {
@@ -10,6 +10,7 @@ const ChildReportSummary = ({ summary }) => {
     }
 
     return {
+      ...summary,
       total_children: summary.total_children ?? summary.children_total ?? summary.totalAnak ?? summary.total ?? 0,
       average_attendance: summary.average_attendance ?? summary.attendance_rate ?? summary.average ?? 0,
       total_activities: summary.total_activities ?? summary.activities_total ?? summary.totalActivities ?? 0,
@@ -92,7 +93,7 @@ const ChildReportSummary = ({ summary }) => {
 
   return (
     <View style={styles.container}>
-      <ChildSummaryCard summary={normalizedSummary} />
+      <CabangChildSummaryCard summary={normalizedSummary} />
       {extraCards.length > 0 && (
         <View style={styles.cardsGrid}>
           {extraCards.map((card) => (


### PR DESCRIPTION
## Summary
- add a dedicated CabangChildSummaryCard that formats key child statistics for the cabang admin reports
- update the child report summary to use the new card while keeping existing supplemental report cards

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0b3a7b3e88323b627660957d15c58