### PR TITLE
Adjust admin cabang report summary layout

### DIFF
--- a/frontend/src/features/adminCabang/components/reports/CabangChildSummaryCard.js
+++ b/frontend/src/features/adminCabang/components/reports/CabangChildSummaryCard.js
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, useWindowDimensions } from 'react-native';
 import ReportSummaryCard from './ReportSummaryCard';
 import {
   calculateAttendancePercentage,
@@ -25,7 +25,10 @@ const normalizePercentageValue = (value) => {
   return Number.isNaN(numeric) ? null : numeric;
 };
 
-const CabangChildSummaryCard = ({ summary }) => {
+const CabangChildSummaryCard = ({ summary, variant = 'default' }) => {
+  const { width } = useWindowDimensions();
+  const isMdUp = width >= 768;
+
   const metrics = useMemo(() => {
     if (!summary) {
       return null;
@@ -138,19 +141,23 @@ const CabangChildSummaryCard = ({ summary }) => {
     return null;
   }
 
+  const cardsContainerStyle = [styles.cardsContainer, isMdUp ? styles.cardsContainerMd : styles.cardsContainerSm];
+  const cardWrapperStyle = [styles.cardWrapper, isMdUp ? styles.cardWrapperMd : styles.cardWrapperSm];
+
   return (
     <View style={styles.container}>
-      <View style={styles.cardsContainer}>
+      <View style={cardsContainerStyle}>
         {metrics.cards.map((card) => (
           <View
             key={card.key}
-            style={styles.cardWrapper}
+            style={cardWrapperStyle}
           >
             <ReportSummaryCard
               label={card.label}
               value={card.value}
               icon={card.icon}
               color={card.color}
+              variant={variant}
             />
           </View>
         ))}
@@ -161,17 +168,31 @@ const CabangChildSummaryCard = ({ summary }) => {
 
 const styles = StyleSheet.create({
   container: {
-    paddingVertical: 4,
-    marginBottom: 12,
+    paddingVertical: 2,
+    marginBottom: 8,
   },
   cardsContainer: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    marginHorizontal: -6,
+    alignItems: 'stretch',
   },
   cardWrapper: {
-    flexBasis: '33.3333%',
-    maxWidth: '33.3333%',
+    paddingBottom: 8,
+  },
+  cardsContainerSm: {
+    marginHorizontal: -4,
+  },
+  cardsContainerMd: {
+    marginHorizontal: -6,
+  },
+  cardWrapperSm: {
+    flexBasis: '100%',
+    maxWidth: '100%',
+    paddingHorizontal: 4,
+  },
+  cardWrapperMd: {
+    flexBasis: '50%',
+    maxWidth: '50%',
     paddingHorizontal: 6,
   },
 });

--- a/frontend/src/features/adminCabang/components/reports/ChildReportSummary.js
+++ b/frontend/src/features/adminCabang/components/reports/ChildReportSummary.js
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, useWindowDimensions } from 'react-native';
 import CabangChildSummaryCard from './CabangChildSummaryCard';
 import ReportSummaryCard from './ReportSummaryCard';
 
@@ -87,23 +87,37 @@ const ChildReportSummary = ({ summary }) => {
     return cards;
   }, [summary]);
 
+  const { width } = useWindowDimensions();
+  const isMdUp = width >= 768;
+
+  const cardsGridStyle = useMemo(
+    () => [styles.cardsGrid, isMdUp ? styles.cardsGridMd : styles.cardsGridSm],
+    [isMdUp],
+  );
+
+  const summaryCardWrapperStyle = useMemo(
+    () => [styles.summaryCardWrapper, isMdUp ? styles.summaryCardWrapperMd : styles.summaryCardWrapperSm],
+    [isMdUp],
+  );
+
   if (!normalizedSummary) {
     return null;
   }
 
   return (
     <View style={styles.container}>
-      <CabangChildSummaryCard summary={normalizedSummary} />
+      <CabangChildSummaryCard summary={normalizedSummary} variant="compact" />
       {extraCards.length > 0 && (
-        <View style={styles.cardsGrid}>
+        <View style={cardsGridStyle}>
           {extraCards.map((card) => (
-            <View key={card.key} style={styles.summaryCardWrapper}>
+            <View key={card.key} style={summaryCardWrapperStyle}>
               <ReportSummaryCard
                 label={card.label}
                 value={card.value}
                 icon={card.icon}
                 color={card.color}
                 description={card.description}
+                variant="compact"
               />
             </View>
           ))}
@@ -115,14 +129,32 @@ const ChildReportSummary = ({ summary }) => {
 
 const styles = StyleSheet.create({
   container: {
-    marginBottom: 16,
+    marginBottom: 12,
   },
   cardsGrid: {
-    flexDirection: 'column',
-    marginTop: 12,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'stretch',
+    marginTop: 8,
   },
   summaryCardWrapper: {
-    marginBottom: 12,
+    paddingBottom: 8,
+  },
+  cardsGridSm: {
+    marginHorizontal: -4,
+  },
+  cardsGridMd: {
+    marginHorizontal: -6,
+  },
+  summaryCardWrapperSm: {
+    flexBasis: '100%',
+    maxWidth: '100%',
+    paddingHorizontal: 4,
+  },
+  summaryCardWrapperMd: {
+    flexBasis: '50%',
+    maxWidth: '50%',
+    paddingHorizontal: 6,
   },
 });
 

--- a/frontend/src/features/adminCabang/components/reports/ReportSummaryCard.js
+++ b/frontend/src/features/adminCabang/components/reports/ReportSummaryCard.js
@@ -9,32 +9,43 @@ const ReportSummaryCard = ({
   description,
   color = '#2ecc71',
   accessory,
+  variant = 'default',
 }) => {
+  const isCompact = variant === 'compact';
   const formattedValue = typeof value === 'number'
     ? value.toLocaleString('id-ID')
     : value;
 
   return (
-    <View style={styles.card}>
-      <View style={[styles.iconContainer, { backgroundColor: color }]}>
-        <Ionicons name={icon} size={22} color="#fff" />
+    <View style={[styles.card, isCompact && styles.cardCompact]}>
+      <View style={[styles.iconContainer, { backgroundColor: color }, isCompact && styles.iconContainerCompact]}>
+        <Ionicons name={icon} size={isCompact ? 18 : 22} color="#fff" />
       </View>
-      <View style={styles.textContainer}>
-        <Text style={styles.valueText} numberOfLines={1}>
+      <View style={[styles.textContainer, isCompact && styles.textContainerCompact]}>
+        <Text
+          style={[styles.valueText, isCompact && styles.valueTextCompact]}
+          numberOfLines={isCompact ? 2 : 1}
+        >
           {formattedValue ?? '-'}
         </Text>
         {label && (
-          <Text style={styles.labelText} numberOfLines={2}>
+          <Text
+            style={[styles.labelText, isCompact && styles.labelTextCompact]}
+            numberOfLines={isCompact ? 3 : 2}
+          >
             {label}
           </Text>
         )}
         {description && (
-          <Text style={styles.descriptionText} numberOfLines={2}>
+          <Text
+            style={[styles.descriptionText, isCompact && styles.descriptionTextCompact]}
+            numberOfLines={isCompact ? 3 : 2}
+          >
             {description}
           </Text>
         )}
       </View>
-      {accessory}
+      {accessory && <View style={[styles.accessoryContainer, isCompact && styles.accessoryCompact]}>{accessory}</View>}
     </View>
   );
 };
@@ -82,6 +93,47 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: '#95a5a6',
     marginTop: 2,
+  },
+  accessoryContainer: {
+    marginLeft: 8,
+  },
+  cardCompact: {
+    flexDirection: 'column',
+    alignItems: 'center',
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    marginBottom: 8,
+    minHeight: 88,
+  },
+  iconContainerCompact: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    marginRight: 0,
+    marginBottom: 8,
+  },
+  textContainerCompact: {
+    width: '100%',
+    alignItems: 'center',
+  },
+  valueTextCompact: {
+    fontSize: 18,
+    textAlign: 'center',
+  },
+  labelTextCompact: {
+    fontSize: 12,
+    textAlign: 'center',
+    marginTop: 2,
+  },
+  descriptionTextCompact: {
+    fontSize: 11,
+    textAlign: 'center',
+    marginTop: 2,
+  },
+  accessoryCompact: {
+    marginLeft: 0,
+    marginTop: 8,
+    alignSelf: 'center',
   },
 });
 


### PR DESCRIPTION
## Summary
- update cabang child summary grid to use responsive columns with tighter spacing
- add a compact variant to report summary cards with centered content and smaller dimensions
- apply the compact card variant across child report summary sections with responsive wrapping

## Testing
- npm run web *(fails: Expo CLI fetch failed while ensuring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ba69927c8323aa98a059aad4a1c2