### PR TITLE
Add attendance analytics to admin cabang child report

### DIFF
--- a/frontend/src/features/adminCabang/components/reports/ChildAttendanceDistributionCard.js
+++ b/frontend/src/features/adminCabang/components/reports/ChildAttendanceDistributionCard.js
@@ -1,0 +1,300 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+
+const MODE_DESCRIPTIONS = {
+  level: 'Perbandingan jumlah anak berdasarkan level kehadiran.',
+  wilayah: 'Sebaran anak binaan pada masing-masing wilayah binaan.',
+  shelter: 'Sebaran anak binaan untuk tiap shelter yang dikelola cabang.',
+};
+
+const LEVEL_COLOR_MAP = {
+  high: '#27ae60',
+  tinggi: '#27ae60',
+  medium: '#f39c12',
+  sedang: '#f39c12',
+  low: '#e74c3c',
+  rendah: '#e74c3c',
+};
+
+const DEFAULT_PALETTE = ['#3498db', '#9b59b6', '#1abc9c', '#e67e22', '#2ecc71', '#34495e', '#f39c12', '#16a085'];
+const MAX_ITEMS = 16;
+const MAX_BAR_HEIGHT = 120;
+
+const formatPercentage = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return null;
+  }
+
+  const normalized = Math.max(0, Math.min(100, numeric));
+  const fractionDigits = normalized >= 10 ? 0 : 1;
+  return `${normalized.toFixed(fractionDigits)}%`;
+};
+
+const normalizePaletteColor = (modeKey, item, index) => {
+  if (modeKey === 'level') {
+    const normalizedKey = (item?.normalizedKey ?? item?.key ?? '')
+      .toString()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '');
+
+    if (LEVEL_COLOR_MAP[normalizedKey]) {
+      return LEVEL_COLOR_MAP[normalizedKey];
+    }
+  }
+
+  if (item?.color) {
+    return item.color;
+  }
+
+  return DEFAULT_PALETTE[index % DEFAULT_PALETTE.length];
+};
+
+const ChildAttendanceDistributionCard = ({ levelData = [], wilayahData = [], shelterData = [] }) => {
+  const modes = useMemo(() => {
+    const baseModes = [
+      { key: 'level', label: 'Level', dataset: Array.isArray(levelData) ? levelData.slice(0, MAX_ITEMS) : [] },
+      { key: 'wilayah', label: 'Wilayah', dataset: Array.isArray(wilayahData) ? wilayahData.slice(0, MAX_ITEMS) : [] },
+      { key: 'shelter', label: 'Shelter', dataset: Array.isArray(shelterData) ? shelterData.slice(0, MAX_ITEMS) : [] },
+    ];
+
+    const available = baseModes.filter((mode) => mode.dataset.length > 0);
+    if (available.length === 0) {
+      return [baseModes[0]];
+    }
+
+    return available;
+  }, [levelData, wilayahData, shelterData]);
+
+  const [activeModeKey, setActiveModeKey] = useState(modes[0]?.key ?? 'level');
+
+  useEffect(() => {
+    if (!modes.some((mode) => mode.key === activeModeKey)) {
+      setActiveModeKey(modes[0]?.key ?? 'level');
+    }
+  }, [modes, activeModeKey]);
+
+  const activeMode = useMemo(() => modes.find((mode) => mode.key === activeModeKey) ?? modes[0], [activeModeKey, modes]);
+  const dataset = activeMode?.dataset ?? [];
+
+  const totalValue = useMemo(
+    () => dataset.reduce((sum, item) => sum + (Number.isFinite(item?.value) ? item.value : 0), 0),
+    [dataset],
+  );
+
+  const normalizedDataset = useMemo(() => {
+    if (dataset.length === 0) {
+      return [];
+    }
+
+    return dataset.map((item, index) => {
+      const percentage =
+        item?.percentage !== undefined && item?.percentage !== null && Number.isFinite(Number(item.percentage))
+          ? Number(item.percentage)
+          : totalValue > 0
+          ? (item.value / totalValue) * 100
+          : null;
+
+      return {
+        ...item,
+        percentage,
+        normalizedKey: item?.normalizedKey ?? item?.key ?? item?.label ?? `item-${index}`,
+        color: normalizePaletteColor(activeMode?.key, item, index),
+      };
+    });
+  }, [dataset, totalValue, activeMode?.key]);
+
+  const maxValue = normalizedDataset.reduce((max, item) => Math.max(max, Number(item.value) || 0), 0);
+  const isEmpty = normalizedDataset.length === 0 || maxValue <= 0;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.headerRow}>
+        <View style={styles.headerTextGroup}>
+          <Text style={styles.title}>Sebaran Kehadiran</Text>
+          <Text style={styles.subtitle}>{MODE_DESCRIPTIONS[activeMode?.key] ?? MODE_DESCRIPTIONS.level}</Text>
+        </View>
+
+        {modes.length > 1 && (
+          <View style={styles.modeGroup}>
+            {modes.map((mode) => (
+              <TouchableOpacity
+                key={mode.key}
+                style={[styles.modeButton, mode.key === activeMode?.key && styles.modeButtonActive]}
+                onPress={() => setActiveModeKey(mode.key)}
+                activeOpacity={0.85}
+                accessibilityRole="button"
+                accessibilityLabel={`Tampilkan distribusi berdasarkan ${mode.label}`}
+              >
+                <Text style={[styles.modeButtonText, mode.key === activeMode?.key && styles.modeButtonTextActive]}>
+                  {mode.label}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        )}
+      </View>
+
+      {isEmpty ? (
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyText}>Belum ada data distribusi yang dapat ditampilkan.</Text>
+        </View>
+      ) : (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.scrollContent}
+        >
+          {normalizedDataset.map((item, index) => {
+            const numericValue = Number(item.value);
+            const safeValue = Number.isFinite(numericValue) ? numericValue : 0;
+            const displayValue = Number.isFinite(numericValue)
+              ? numericValue.toLocaleString('id-ID')
+              : '-';
+            const barHeight = maxValue > 0 ? Math.max(8, (safeValue / maxValue) * MAX_BAR_HEIGHT) : 0;
+
+            return (
+              <View key={item.key ?? item.normalizedKey ?? index} style={styles.itemCard}>
+                <View style={styles.barArea}>
+                  <View style={styles.barTrack}>
+                    <View style={[styles.barFill, { height: barHeight, backgroundColor: item.color }]} />
+                  </View>
+                </View>
+                <Text style={styles.itemValue}>{displayValue}</Text>
+                {formatPercentage(item.percentage) ? (
+                  <Text style={styles.itemPercentage}>{formatPercentage(item.percentage)}</Text>
+                ) : null}
+                <Text style={styles.itemLabel} numberOfLines={2}>
+                  {item.label || item.key}
+                </Text>
+              </View>
+            );
+          })}
+        </ScrollView>
+      )}
+    </View>
+  );
+};
+
+export default ChildAttendanceDistributionCard;
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#ffffff',
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#ecf0f1',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.08,
+    shadowRadius: 2,
+    elevation: 1,
+    marginBottom: 24,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  headerTextGroup: {
+    flexShrink: 1,
+    paddingRight: 12,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#2c3e50',
+  },
+  subtitle: {
+    fontSize: 12,
+    color: '#7f8c8d',
+    marginTop: 4,
+  },
+  modeGroup: {
+    flexDirection: 'row',
+    backgroundColor: '#ecf0f1',
+    borderRadius: 999,
+    padding: 4,
+  },
+  modeButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+  },
+  modeButtonActive: {
+    backgroundColor: '#ffffff',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 1.5,
+    elevation: 2,
+  },
+  modeButtonText: {
+    fontSize: 12,
+    color: '#7f8c8d',
+    fontWeight: '500',
+  },
+  modeButtonTextActive: {
+    color: '#2c3e50',
+    fontWeight: '600',
+  },
+  emptyState: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 32,
+  },
+  emptyText: {
+    fontSize: 13,
+    color: '#7f8c8d',
+    textAlign: 'center',
+  },
+  scrollContent: {
+    paddingVertical: 4,
+  },
+  itemCard: {
+    width: 96,
+    marginRight: 12,
+    alignItems: 'center',
+  },
+  barArea: {
+    height: MAX_BAR_HEIGHT + 12,
+    width: '100%',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  barTrack: {
+    height: MAX_BAR_HEIGHT,
+    width: 36,
+    borderRadius: 18,
+    backgroundColor: '#ecf0f1',
+    justifyContent: 'flex-end',
+    overflow: 'hidden',
+  },
+  barFill: {
+    width: '100%',
+    borderRadius: 18,
+  },
+  itemValue: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#2c3e50',
+  },
+  itemPercentage: {
+    fontSize: 12,
+    color: '#16a085',
+    marginTop: 2,
+  },
+  itemLabel: {
+    fontSize: 11,
+    color: '#7f8c8d',
+    textAlign: 'center',
+    marginTop: 6,
+  },
+});

--- a/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
@@ -16,6 +16,8 @@ import LoadingSpinner from '../../../../common/components/LoadingSpinner';
 import ErrorMessage from '../../../../common/components/ErrorMessage';
 import EmptyState from '../../../../common/components/EmptyState';
 import ChildReportSummary from '../../components/reports/ChildReportSummary';
+import ChildAttendanceTrendChart from '../../components/reports/ChildAttendanceTrendChart';
+import ChildAttendanceDistributionCard from '../../components/reports/ChildAttendanceDistributionCard';
 import ChildReportListItem from '../../components/reports/ChildReportListItem';
 import ChildReportFilterModal from '../../components/reports/ChildReportFilterModal';
 import {
@@ -44,6 +46,563 @@ import {
 } from '../../redux/reportAnakThunks';
 import { formatDateToIndonesian } from '../../../../common/utils/dateFormatter';
 
+const levelLabels = {
+  high: 'Tinggi',
+  medium: 'Sedang',
+  low: 'Rendah',
+};
+
+const LEVEL_DISTRIBUTION_PATHS = [
+  'attendance_distribution.levels',
+  'attendance_distribution.by_level',
+  'attendance_distribution.level',
+  'attendanceDistribution.levels',
+  'attendanceDistribution.byLevel',
+  'attendance_levels',
+  'attendanceLevels',
+  'distribution.levels',
+  'distribution.attendance_levels',
+  'level_distribution',
+  'levels_distribution',
+];
+
+const WILAYAH_DISTRIBUTION_PATHS = [
+  'attendance_distribution.wilayah',
+  'attendance_distribution.by_wilayah',
+  'attendance_distribution.regions',
+  'attendance_distribution.by_region',
+  'attendanceDistribution.wilayah',
+  'attendanceDistribution.regions',
+  'distribution.wilayah',
+  'distribution.regions',
+  'wilayah_distribution',
+  'region_distribution',
+  'wilayah',
+  'regions',
+];
+
+const SHELTER_DISTRIBUTION_PATHS = [
+  'attendance_distribution.shelters',
+  'attendance_distribution.by_shelter',
+  'attendanceDistribution.shelters',
+  'distribution.shelters',
+  'shelter_distribution',
+  'shelters',
+];
+
+const getNestedValue = (object, path) => {
+  if (!object || !path) {
+    return undefined;
+  }
+
+  return path.split('.').reduce((accumulator, segment) => {
+    if (accumulator === null || accumulator === undefined) {
+      return undefined;
+    }
+
+    return accumulator[segment];
+  }, object);
+};
+
+const parseNumeric = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().replace(/%/g, '').replace(/[^0-9,.-]/g, '').replace(',', '.');
+    if (!normalized) {
+      return null;
+    }
+
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const parsed = parseNumeric(item);
+      if (parsed !== null) {
+        return parsed;
+      }
+    }
+    return null;
+  }
+
+  if (typeof value === 'object') {
+    const candidate =
+      value.value ??
+      value.count ??
+      value.total ??
+      value.jumlah ??
+      value.quantity ??
+      value.children ??
+      value.total_children ??
+      value.totalChildren ??
+      value.amount ??
+      value.percentage ??
+      value.percent ??
+      null;
+
+    return candidate !== null ? parseNumeric(candidate) : null;
+  }
+
+  return null;
+};
+
+const parsePercentageValue = (value) => {
+  const numeric = parseNumeric(value);
+
+  if (numeric === null) {
+    return null;
+  }
+
+  if (numeric <= 1 && numeric >= 0) {
+    return Math.max(0, Math.min(100, numeric * 100));
+  }
+
+  return Math.max(0, Math.min(100, numeric));
+};
+
+const mapLevelKey = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const normalized = value.toString().toLowerCase();
+
+  if (normalized.includes('tinggi') || normalized.includes('high') || normalized.includes('baik')) {
+    return 'high';
+  }
+
+  if (normalized.includes('sedang') || normalized.includes('medium') || normalized.includes('cukup')) {
+    return 'medium';
+  }
+
+  if (normalized.includes('rendah') || normalized.includes('low') || normalized.includes('kurang')) {
+    return 'low';
+  }
+
+  return null;
+};
+
+const humanizeLabel = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'object') {
+    const nested =
+      value.name ??
+      value.nama ??
+      value.label ??
+      value.title ??
+      value.display ??
+      value.description ??
+      value.value ??
+      null;
+
+    return nested ? humanizeLabel(nested) : null;
+  }
+
+  const stringValue = value.toString().trim();
+  if (!stringValue) {
+    return null;
+  }
+
+  return stringValue
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/^[a-z]|\s[a-z]/g, (match) => match.toUpperCase());
+};
+
+const determineAttendanceLevel = (percentage) => {
+  if (percentage === null || percentage === undefined) {
+    return null;
+  }
+
+  if (percentage > 80) {
+    return 'high';
+  }
+
+  if (percentage >= 50) {
+    return 'medium';
+  }
+
+  return 'low';
+};
+
+const resolveChildAttendancePercentage = (child) => {
+  if (!child) {
+    return null;
+  }
+
+  const percentageCandidate = parsePercentageValue(
+    child.attendance_percentage ??
+      child.overall_percentage ??
+      child.percentage ??
+      child.attendancePercent ??
+      child.attendance_rate ??
+      child.attendanceRate ??
+      child.attendance?.percentage ??
+      child.attendance?.percent ??
+      child.attendance?.rate ??
+      child.kehadiran ??
+      child.present_percentage,
+  );
+
+  if (percentageCandidate !== null) {
+    return percentageCandidate;
+  }
+
+  const totalAttended = parseNumeric(
+    child.total_attended ??
+      child.attended_count ??
+      child.totalAktivitasHadir ??
+      child.attendance?.attended ??
+      child.jumlah_hadir ??
+      child.totalHadir ??
+      child.hadir,
+  );
+
+  const totalOpportunities = parseNumeric(
+    child.total_attendance_opportunities ??
+      child.attendance_opportunities_total ??
+      child.totalAttendanceOpportunities ??
+      child.total_attendance_opportunity ??
+      child.totalAttendanceOpportunity ??
+      child.total_activities ??
+      child.activities_count ??
+      child.totalAktivitas ??
+      child.totalKesempatanHadir,
+  );
+
+  if (totalAttended !== null && totalOpportunities !== null && totalOpportunities > 0) {
+    return Math.max(0, Math.min(100, (totalAttended / totalOpportunities) * 100));
+  }
+
+  return null;
+};
+
+const pickDisplayLabel = (...candidates) => {
+  for (const candidate of candidates) {
+    if (candidate === null || candidate === undefined) {
+      continue;
+    }
+
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    } else if (typeof candidate === 'object') {
+      const nested =
+        candidate.name ??
+        candidate.nama ??
+        candidate.label ??
+        candidate.title ??
+        candidate.display ??
+        candidate.description ??
+        candidate.wilayah ??
+        candidate.wilbin ??
+        candidate.shelter ??
+        candidate.text ??
+        candidate.value ??
+        null;
+
+      if (typeof nested === 'string') {
+        const trimmed = nested.trim();
+        if (trimmed) {
+          return trimmed;
+        }
+      }
+    }
+  }
+
+  return null;
+};
+
+const normalizeDistributionEntriesFromSummary = (summary, paths, type) => {
+  if (!summary) {
+    return [];
+  }
+
+  for (const path of paths) {
+    const raw = getNestedValue(summary, path);
+    if (!raw) {
+      continue;
+    }
+
+    const dataset = [];
+
+    const appendEntry = (rawKey, rawValue, index) => {
+      if (rawValue === null || rawValue === undefined) {
+        return;
+      }
+
+      let value = parseNumeric(rawValue);
+      if (value === null) {
+        value =
+          parseNumeric(rawValue?.value) ??
+          parseNumeric(rawValue?.count) ??
+          parseNumeric(rawValue?.jumlah) ??
+          parseNumeric(rawValue?.total) ??
+          parseNumeric(rawValue?.children) ??
+          parseNumeric(rawValue?.total_children);
+      }
+
+      if (value === null) {
+        return;
+      }
+
+      const levelKeyCandidate =
+        type === 'level'
+          ? mapLevelKey(rawValue?.key) ||
+            mapLevelKey(rawValue?.level) ||
+            mapLevelKey(rawValue?.label) ||
+            mapLevelKey(rawKey) ||
+            mapLevelKey(rawValue?.name)
+          : null;
+
+      const normalizedKey =
+        type === 'level' && levelKeyCandidate
+          ? levelKeyCandidate
+          : rawValue?.key ?? rawValue?.id ?? rawValue?.slug ?? rawValue?.code ?? rawKey ?? `item-${index}`;
+
+      const labelCandidate =
+        type === 'level' && levelKeyCandidate
+          ? levelLabels[levelKeyCandidate]
+          : humanizeLabel(
+              rawValue?.label ??
+                rawValue?.name ??
+                rawValue?.title ??
+                rawValue?.display ??
+                rawValue?.wilayah ??
+                rawValue?.shelter ??
+                rawValue?.category ??
+                rawValue?.kategori ??
+                rawKey,
+            ) ?? humanizeLabel(normalizedKey);
+
+      let percentage = parsePercentageValue(
+        rawValue?.percentage ??
+          rawValue?.percent ??
+          rawValue?.ratio ??
+          rawValue?.proporsi ??
+          rawValue?.persentase ??
+          rawValue?.share ??
+          rawValue?.proportion,
+      );
+
+      dataset.push({
+        key: String(normalizedKey),
+        label: labelCandidate || (type === 'level' && levelKeyCandidate ? levelLabels[levelKeyCandidate] : 'Item'),
+        value,
+        percentage,
+        normalizedKey: String(normalizedKey),
+        color: rawValue?.color,
+      });
+    };
+
+    if (Array.isArray(raw)) {
+      raw.forEach((item, index) => {
+        const key = item?.key ?? item?.id ?? item?.slug ?? item?.code ?? index;
+        appendEntry(key, item, index);
+      });
+    } else if (typeof raw === 'object') {
+      Object.entries(raw).forEach(([key, value], index) => {
+        appendEntry(key, value, index);
+      });
+    }
+
+    const total = dataset.reduce((sum, item) => sum + (item.value || 0), 0);
+    if (total > 0) {
+      dataset.forEach((item) => {
+        if (item.percentage === null || item.percentage === undefined) {
+          item.percentage = (item.value / total) * 100;
+        }
+      });
+    }
+
+    if (dataset.length > 0) {
+      dataset.sort((a, b) => (b.value || 0) - (a.value || 0));
+      return dataset;
+    }
+  }
+
+  return [];
+};
+
+const computeDistributionFromChildren = (childrenList = []) => {
+  if (!Array.isArray(childrenList) || childrenList.length === 0) {
+    return {
+      level: [],
+      wilayah: [],
+      shelter: [],
+    };
+  }
+
+  const levelCounts = { high: 0, medium: 0, low: 0 };
+  let totalWithLevel = 0;
+
+  const wilayahMap = new Map();
+  const shelterMap = new Map();
+
+  childrenList.forEach((child) => {
+    if (!child) {
+      return;
+    }
+
+    const percentage = resolveChildAttendancePercentage(child);
+    if (percentage !== null) {
+      const levelKey = determineAttendanceLevel(percentage);
+      if (levelKey) {
+        levelCounts[levelKey] += 1;
+        totalWithLevel += 1;
+      }
+    }
+
+    const wilayahLabel = pickDisplayLabel(
+      child.wilayah_name,
+      child.wilbin_name,
+      child.nama_wilayah,
+      child.wilayah?.name,
+      child.wilayah?.nama,
+      child.wilayah?.label,
+      child.wilbin,
+      child.region_name,
+    );
+    if (wilayahLabel) {
+      const key = wilayahLabel.toLowerCase();
+      const current = wilayahMap.get(key);
+      if (current) {
+        current.value += 1;
+      } else {
+        wilayahMap.set(key, {
+          key,
+          normalizedKey: key,
+          label: wilayahLabel,
+          value: 1,
+        });
+      }
+    }
+
+    const shelterLabel = pickDisplayLabel(
+      child.shelter_name,
+      child.shelter?.name,
+      child.shelter?.nama,
+      child.nama_shelter,
+      child.shelter,
+      child.home_name,
+    );
+    if (shelterLabel) {
+      const key = shelterLabel.toLowerCase();
+      const current = shelterMap.get(key);
+      if (current) {
+        current.value += 1;
+      } else {
+        shelterMap.set(key, {
+          key,
+          normalizedKey: key,
+          label: shelterLabel,
+          value: 1,
+        });
+      }
+    }
+  });
+
+  const levelDataset =
+    totalWithLevel > 0
+      ? ['high', 'medium', 'low']
+          .map((levelKey) => ({
+            key: levelKey,
+            normalizedKey: levelKey,
+            label: levelLabels[levelKey],
+            value: levelCounts[levelKey],
+            percentage: (levelCounts[levelKey] / totalWithLevel) * 100,
+          }))
+          .filter((item) => item.value > 0)
+      : [];
+
+  const wilayahDataset = Array.from(wilayahMap.values()).sort((a, b) => b.value - a.value);
+  const wilayahTotal = wilayahDataset.reduce((sum, item) => sum + item.value, 0);
+  wilayahDataset.forEach((item) => {
+    item.percentage = wilayahTotal > 0 ? (item.value / wilayahTotal) * 100 : null;
+  });
+
+  const shelterDataset = Array.from(shelterMap.values()).sort((a, b) => b.value - a.value);
+  const shelterTotal = shelterDataset.reduce((sum, item) => sum + item.value, 0);
+  shelterDataset.forEach((item) => {
+    item.percentage = shelterTotal > 0 ? (item.value / shelterTotal) * 100 : null;
+  });
+
+  return {
+    level: levelDataset,
+    wilayah: wilayahDataset,
+    shelter: shelterDataset,
+  };
+};
+
+const extractMonthlyAttendanceData = (summary) => {
+  if (!summary) {
+    return null;
+  }
+
+  const candidatePaths = [
+    'monthly_attendance',
+    'monthlyAttendance',
+    'attendance_monthly',
+    'attendanceMonthly',
+    'monthly_data',
+    'monthlyData',
+    'monthlyAttendanceData',
+    'attendance.monthly',
+    'attendance.monthly_attendance',
+    'attendance_trend.monthly',
+    'attendanceTrend.monthly',
+    'trend.monthly',
+  ];
+
+  for (const path of candidatePaths) {
+    const value = getNestedValue(summary, path);
+
+    if (!value) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        return value;
+      }
+      continue;
+    }
+
+    if (typeof value === 'object') {
+      if (Array.isArray(value.data) && value.data.length > 0) {
+        return value.data;
+      }
+
+      if (Array.isArray(value.items) && value.items.length > 0) {
+        return value.items;
+      }
+
+      if (Object.keys(value).length > 0) {
+        return value;
+      }
+    }
+  }
+
+  return null;
+};
+
 const AdminCabangChildReportScreen = () => {
   const dispatch = useDispatch();
   const navigation = useNavigation();
@@ -56,6 +615,46 @@ const AdminCabangChildReportScreen = () => {
   const hasMore = useSelector(selectReportAnakHasMore);
   const error = useSelector(selectReportAnakError);
   const pagination = useSelector(selectReportAnakPagination);
+
+  const monthlyAttendanceData = useMemo(() => extractMonthlyAttendanceData(summary), [summary]);
+
+  const summaryLevelDistribution = useMemo(
+    () => normalizeDistributionEntriesFromSummary(summary, LEVEL_DISTRIBUTION_PATHS, 'level'),
+    [summary],
+  );
+
+  const summaryWilayahDistribution = useMemo(
+    () => normalizeDistributionEntriesFromSummary(summary, WILAYAH_DISTRIBUTION_PATHS, 'wilayah'),
+    [summary],
+  );
+
+  const summaryShelterDistribution = useMemo(
+    () => normalizeDistributionEntriesFromSummary(summary, SHELTER_DISTRIBUTION_PATHS, 'shelter'),
+    [summary],
+  );
+
+  const fallbackDistribution = useMemo(() => computeDistributionFromChildren(children), [children]);
+
+  const attendanceDistribution = useMemo(
+    () => ({
+      level:
+        summaryLevelDistribution.length > 0 ? summaryLevelDistribution : fallbackDistribution.level,
+      wilayah:
+        summaryWilayahDistribution.length > 0
+          ? summaryWilayahDistribution
+          : fallbackDistribution.wilayah,
+      shelter:
+        summaryShelterDistribution.length > 0
+          ? summaryShelterDistribution
+          : fallbackDistribution.shelter,
+    }),
+    [
+      summaryLevelDistribution,
+      summaryWilayahDistribution,
+      summaryShelterDistribution,
+      fallbackDistribution,
+    ],
+  );
 
   const [searchText, setSearchText] = useState(filters.search || '');
   const [filterModalVisible, setFilterModalVisible] = useState(false);
@@ -340,6 +939,14 @@ const AdminCabangChildReportScreen = () => {
       )}
 
       <ChildReportSummary summary={summary} />
+
+      <ChildAttendanceTrendChart monthlyData={monthlyAttendanceData} />
+
+      <ChildAttendanceDistributionCard
+        levelData={attendanceDistribution.level}
+        wilayahData={attendanceDistribution.wilayah}
+        shelterData={attendanceDistribution.shelter}
+      />
 
       {error && (
         <View style={styles.errorWrapper}>


### PR DESCRIPTION
## Summary
- add a reusable attendance distribution card for level, wilayah, and shelter insights
- enhance the trend chart with responsive scrolling and a view toggle between line and bar modes
- surface attendance analytics within the admin cabang child report header with flexible data normalization

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0be00de048323b9c575b859a2ff3b