### PR TITLE
Add development logging for admin cabang reports

### DIFF
--- a/frontend/src/features/adminCabang/components/reports/ChildAttendanceTrendChart.js
+++ b/frontend/src/features/adminCabang/components/reports/ChildAttendanceTrendChart.js
@@ -154,11 +154,31 @@ const ChildAttendanceTrendChart = ({
   style,
 }) => {
   const dataset = useMemo(() => normalizeMonthlyDataset(monthlyData), [monthlyData]);
+  const hasSufficientData = dataset.length >= 2;
   const [internalType, setInternalType] = useState(type);
 
   useEffect(() => {
     setInternalType(type);
   }, [type]);
+
+  useEffect(() => {
+    if (!__DEV__) {
+      return;
+    }
+
+    const insufficientReason = hasSufficientData ? null : 'dataset length below minimum threshold (2)';
+
+    console.log('[ChildAttendanceTrendChart] Dataset debug', {
+      rawMonthlyData: monthlyData,
+      normalizedDataset: {
+        length: dataset.length,
+        sample: dataset[0] ?? null,
+        labels: dataset.map((item) => item.label).slice(0, 5),
+      },
+      hasSufficientData,
+      insufficientReason,
+    });
+  }, [monthlyData, dataset, hasSufficientData]);
 
   const activeType = internalType || 'line';
 
@@ -170,8 +190,6 @@ const ChildAttendanceTrendChart = ({
     setInternalType(nextType);
     onTypeChange?.(nextType);
   };
-
-  const hasSufficientData = dataset.length >= 2;
 
   const padding = 24;
   const baseChartWidth = screenWidth - 32;

--- a/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
@@ -618,6 +618,31 @@ const AdminCabangChildReportScreen = () => {
 
   const monthlyAttendanceData = useMemo(() => extractMonthlyAttendanceData(summary), [summary]);
 
+  useEffect(() => {
+    if (!__DEV__) {
+      return;
+    }
+
+    const monthlyAttendanceSummary = Array.isArray(monthlyAttendanceData)
+      ? {
+          type: 'array',
+          length: monthlyAttendanceData.length,
+          sample: monthlyAttendanceData[0] ?? null,
+        }
+      : monthlyAttendanceData && typeof monthlyAttendanceData === 'object'
+      ? {
+          type: 'object',
+          keys: Object.keys(monthlyAttendanceData),
+        }
+      : { type: typeof monthlyAttendanceData, value: monthlyAttendanceData ?? null };
+
+    console.log('[AdminCabangChildReportScreen] Monthly attendance debug', {
+      hasSummary: Boolean(summary),
+      summaryKeys: summary ? Object.keys(summary).slice(0, 10) : [],
+      monthlyAttendance: monthlyAttendanceSummary,
+    });
+  }, [summary, monthlyAttendanceData]);
+
   const summaryLevelDistribution = useMemo(
     () => normalizeDistributionEntriesFromSummary(summary, LEVEL_DISTRIBUTION_PATHS, 'level'),
     [summary],


### PR DESCRIPTION
## Summary
- log extracted monthly attendance data on the admin cabang child report screen when running in development
- add development-only logging for the child attendance trend chart normalization and sufficiency checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0f21ba7008323a3dde403b9e24e76