### PR TITLE
Add helper for Admin Cabang child report filter options

### DIFF
--- a/frontend/src/constants/endpoints.js
+++ b/frontend/src/constants/endpoints.js
@@ -154,6 +154,7 @@ export const ADMIN_CABANG_ENDPOINTS = {
     ANAK: {
       LIST: '/admin-cabang/laporan/anak-binaan',
       DETAIL: (childId) => `/admin-cabang/laporan/anak-binaan/child/${childId}`,
+      FILTER_OPTIONS: '/admin-cabang/reports/anak/filter-options',
       FILTERS: {
         JENIS_KEGIATAN: '/admin-cabang/reports/anak/filter-options/jenis-kegiatan',
         WILAYAH_BINAAN: '/admin-cabang/reports/anak/filter-options/wilayah-binaan',

--- a/frontend/src/features/adminCabang/api/adminCabangReportApi.js
+++ b/frontend/src/features/adminCabang/api/adminCabangReportApi.js
@@ -4,7 +4,12 @@ import { ADMIN_CABANG_ENDPOINTS } from '../../../constants/endpoints';
 const {
   REPORTS: {
     SUMMARY: SUMMARY_ENDPOINT,
-    ANAK: { LIST: LIST_ENDPOINT, DETAIL: DETAIL_ENDPOINT, FILTERS }
+    ANAK: {
+      LIST: LIST_ENDPOINT,
+      DETAIL: DETAIL_ENDPOINT,
+      FILTER_OPTIONS: FILTER_OPTIONS_ENDPOINT,
+      FILTERS
+    }
   }
 } = ADMIN_CABANG_ENDPOINTS;
 
@@ -15,6 +20,10 @@ export const adminCabangReportApi = {
 
   async getLaporanAnakBinaan(params = {}) {
     return api.get(LIST_ENDPOINT, { params });
+  },
+
+  async getLaporanAnakFilterOptions(params = {}) {
+    return api.get(FILTER_OPTIONS_ENDPOINT, { params });
   },
 
   async getChildDetailReport(childId, params = {}) {


### PR DESCRIPTION
## Summary
- add the admin cabang child report filter-options endpoint constant
- expose an API helper to fetch the child report filter options with optional params

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1be7190e08323afd0e85d7559bd77