### PR TITLE
Add filter options route for admin cabang laporan anak

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -195,6 +195,7 @@ Route::middleware('auth:sanctum')->group(function () {
             Route::get('/summary', [App\Http\Controllers\API\AdminCabang\Reports\AdminCabangReportSummaryController::class, 'getSummary']);
             Route::get('/anak-binaan', [App\Http\Controllers\API\AdminCabang\Reports\AdminCabangLaporanAnakController::class, 'index']);
             Route::get('/anak-binaan/child/{id}', [App\Http\Controllers\API\AdminCabang\Reports\AdminCabangLaporanAnakController::class, 'showChild']);
+            Route::get('/anak-binaan/filter-options', [App\Http\Controllers\API\AdminCabang\Reports\AdminCabangLaporanAnakController::class, 'filterOptions']);
         });
 
     });


### PR DESCRIPTION
## Summary
- expose the new Admin Cabang laporan anak filterOptions endpoint under the existing laporan route group

## Testing
- `php artisan route:list` *(fails: backend/vendor/autoload.php missing in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c21a080483238e34c91e66fbad85