### PR TITLE
Enhance child attendance line chart visuals

### DIFF
--- a/frontend/src/features/adminCabang/components/reports/ChildAttendanceLineChart.js
+++ b/frontend/src/features/adminCabang/components/reports/ChildAttendanceLineChart.js
@@ -1,14 +1,45 @@
 import React, { memo, useMemo } from 'react';
-import { LineChart, Grid } from 'react-native-svg-charts';
-import { Defs, LinearGradient, Stop } from 'react-native-svg';
+import { View, Text, StyleSheet } from 'react-native';
+import { LineChart, Grid, XAxis } from 'react-native-svg-charts';
+import { Defs, LinearGradient, Stop, Circle, Text as SvgText } from 'react-native-svg';
 
 const DEFAULT_DATA = [50, 80, 45, 60, 70, 90, 100];
 const DEFAULT_CONTENT_INSET = { top: 20, bottom: 20 };
 const DEFAULT_STYLE = { height: 180 };
+const LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'Mei', 'Jun', 'Jul'];
+
+const Decorator = ({ x, y, data }) =>
+  data.map((value, index) => (
+    <Circle
+      key={`decorator-${index}`}
+      cx={x(index)}
+      cy={y(value)}
+      r={4}
+      stroke="#4a90e2"
+      strokeWidth={2}
+      fill="#ffffff"
+    />
+  ));
+
+const Labels = ({ x, y, data }) =>
+  data.map((value, index) => (
+    <SvgText
+      key={`label-${index}`}
+      x={x(index)}
+      y={y(value) - 10}
+      fontSize={12}
+      fill="#4a90e2"
+      alignmentBaseline="middle"
+      textAnchor="middle"
+    >
+      {`${value}%`}
+    </SvgText>
+  ));
 
 const ChildAttendanceLineChart = ({
   data = DEFAULT_DATA,
   style,
+  containerStyle,
   contentInset = DEFAULT_CONTENT_INSET,
   svgProps,
   gridProps,
@@ -17,29 +48,58 @@ const ChildAttendanceLineChart = ({
   ...rest
 }) => {
   const lineSvg = useMemo(
-    () => ({ stroke: '#4a90e2', strokeWidth: 3, fill: `url(#${gradientId})`, ...(svgProps || {}) }),
+    () => ({ stroke: '#4a90e2', strokeWidth: 2, fill: `url(#${gradientId})`, ...(svgProps || {}) }),
     [gradientId, svgProps]
   );
 
+  const combinedChartStyle = useMemo(() => {
+    const styleArray = Array.isArray(style) ? style : style ? [style] : [];
+    return [DEFAULT_STYLE, ...styleArray];
+  }, [style]);
+
   return (
-    <LineChart
-      style={[DEFAULT_STYLE, style]}
-      data={data}
-      svg={lineSvg}
-      contentInset={contentInset}
-      {...rest}
-    >
-      <Defs key="gradient">
-        <LinearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-          <Stop offset="0%" stopColor="#4a90e2" stopOpacity={0.2} />
-          <Stop offset="100%" stopColor="#4a90e2" stopOpacity={0} />
-        </LinearGradient>
-      </Defs>
-      <Grid {...gridProps} />
-      {children}
-    </LineChart>
+    <View style={containerStyle}>
+      <Text style={styles.title}>Tren Kehadiran Bulanan</Text>
+      <LineChart
+        style={combinedChartStyle}
+        data={data}
+        svg={lineSvg}
+        contentInset={contentInset}
+        {...rest}
+      >
+        <Defs key="gradient">
+          <LinearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <Stop offset="0%" stopColor="#4a90e2" stopOpacity={0.2} />
+            <Stop offset="100%" stopColor="#4a90e2" stopOpacity={0} />
+          </LinearGradient>
+        </Defs>
+        <Grid {...gridProps} />
+        <Decorator />
+        <Labels />
+        {children}
+      </LineChart>
+      <XAxis
+        style={styles.xAxis}
+        data={data}
+        formatLabel={(value, index) => LABELS[index]}
+        contentInset={contentInset}
+        svg={{ fontSize: 12, fill: '#4a4a4a' }}
+      />
+    </View>
   );
 };
 
 export default memo(ChildAttendanceLineChart);
 export { DEFAULT_DATA };
+
+const styles = StyleSheet.create({
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 12,
+    color: '#1f2937',
+  },
+  xAxis: {
+    marginTop: 12,
+  },
+});


### PR DESCRIPTION
## Summary
- wrap the child attendance line chart with a titled container for context
- add blue line styling with gradient fill, circular decorators, and percentage labels on each point
- render an aligned XAxis with month labels to match the attendance trend data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1feedd8688323b354acf06a5703c2