### PR TITLE
Add conditional chart rendering for child attendance report

### DIFF
--- a/frontend/src/features/adminCabang/components/reports/ChartFullScreenScreen.js
+++ b/frontend/src/features/adminCabang/components/reports/ChartFullScreenScreen.js
@@ -117,6 +117,7 @@ const ChartFullScreenScreen = () => {
               data={chartData}
               mode="fullscreen"
               containerStyle={styles.chartContainer}
+              categories={resolvedCategories}
               {...barChartProps}
             />
           ) : (

--- a/frontend/src/features/adminCabang/components/reports/ChildAttendanceBarChart.js
+++ b/frontend/src/features/adminCabang/components/reports/ChildAttendanceBarChart.js
@@ -44,7 +44,13 @@ const Labels = ({ x, y, bandwidth, data }) =>
     );
   });
 
-const ChildAttendanceBarChart = ({ data = [], mode = 'compact', containerStyle, contentInset = DEFAULT_CONTENT_INSET }) => {
+const ChildAttendanceBarChart = ({
+  data = [],
+  mode = 'compact',
+  containerStyle,
+  contentInset = DEFAULT_CONTENT_INSET,
+  categories: categoriesProp,
+}) => {
   const normalizedData = useMemo(() => {
     if (!Array.isArray(data) || data.length === 0) {
       return [];
@@ -57,7 +63,13 @@ const ChildAttendanceBarChart = ({ data = [], mode = 'compact', containerStyle, 
   }, [data]);
 
   const values = useMemo(() => normalizedData.map((item) => item.value), [normalizedData]);
-  const categories = useMemo(() => normalizedData.map((item) => item.shelter || ''), [normalizedData]);
+  const categories = useMemo(() => {
+    if (Array.isArray(categoriesProp) && categoriesProp.length > 0) {
+      return categoriesProp.slice(0, normalizedData.length).map((category) => String(category ?? ''));
+    }
+
+    return normalizedData.map((item) => item.shelter || '');
+  }, [categoriesProp, normalizedData]);
 
   const chartData = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- render either the compact bar or line chart based on the selected chart type and share the same filtered dataset
- improve empty-state messaging and reset local chart filters when clearing report filters
- pass chart context into the fullscreen view and allow bar charts to honor provided categories

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e23b0146848323b8fdcedf433c0210