### PR TITLE
Update child report filter modal to use period selection

### DIFF
--- a/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
@@ -762,6 +762,7 @@ const AdminCabangChildReportScreen = () => {
         visible={filterModalVisible}
         onClose={() => setFilterModalVisible(false)}
         filters={filters}
+        periodOptions={PERIOD_OPTIONS}
         jenisOptions={filterOptions.jenisKegiatan}
         wilayahOptions={filterOptions.wilayahBinaan}
         shelterOptions={shelterOptions}


### PR DESCRIPTION
## Summary
- replace the date range UI in the child report filter modal with a period picker fed from provided options and add a chart type toggle
- default and reset filter state for period, activity type, shelter, and chart type while keeping local state in sync when reopening the modal
- pass the precomputed period options from the admin cabang child report screen down to the modal

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e24012e8c48323b1b3c6d8cba191c4