### PR TITLE
Add admin cabang attendance summary endpoint

### DIFF
--- a/backend/app/Http/Controllers/API/AdminCabang/Reports/AdminCabangAttendanceSummaryController.php
+++ b/backend/app/Http/Controllers/API/AdminCabang/Reports/AdminCabangAttendanceSummaryController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\API\AdminCabang\Reports;
+
+use App\Http\Controllers\Controller;
+use App\Models\Absen;
+use App\Models\Kacab;
+use App\Models\Shelter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AdminCabangAttendanceSummaryController extends Controller
+{
+    public function __invoke(Request $request, $cabang): JsonResponse
+    {
+        $validated = $request->validate([
+            'month' => ['required', 'integer', 'between:1,12'],
+            'year' => ['required', 'integer', 'min:2000', 'max:2100'],
+        ]);
+
+        $kacab = Kacab::find($cabang);
+
+        if (!$kacab) {
+            return response()->json([
+                'message' => 'Cabang tidak ditemukan',
+            ], 404);
+        }
+
+        $month = (int) $validated['month'];
+        $year = (int) $validated['year'];
+
+        $attendanceByShelter = Absen::query()
+            ->selectRaw('shelter.id_shelter as shelter_id, AVG(CASE WHEN absen.absen IN (\'Ya\', \'Terlambat\') THEN 1 ELSE 0 END) * 100 as attendance_avg')
+            ->join('aktivitas', 'aktivitas.id_aktivitas', '=', 'absen.id_aktivitas')
+            ->join('shelter', 'shelter.id_shelter', '=', 'aktivitas.id_shelter')
+            ->join('wilbin', 'wilbin.id_wilbin', '=', 'shelter.id_wilbin')
+            ->where('wilbin.id_kacab', $kacab->id_kacab)
+            ->whereYear('aktivitas.tanggal', $year)
+            ->whereMonth('aktivitas.tanggal', $month)
+            ->groupBy('shelter.id_shelter')
+            ->pluck('attendance_avg', 'shelter_id');
+
+        $shelterCollection = Shelter::query()
+            ->select('shelter.id_shelter', 'shelter.nama_shelter')
+            ->join('wilbin', 'wilbin.id_wilbin', '=', 'shelter.id_wilbin')
+            ->where('wilbin.id_kacab', $kacab->id_kacab)
+            ->orderBy('shelter.nama_shelter')
+            ->get()
+            ->map(function ($shelter) use ($attendanceByShelter) {
+                $average = $attendanceByShelter[$shelter->id_shelter] ?? 0;
+
+                return [
+                    'id' => $shelter->id_shelter,
+                    'name' => $shelter->nama_shelter,
+                    'attendance_avg' => round((float) $average, 2),
+                ];
+            });
+
+        return response()->json([
+            'month' => sprintf('%04d-%02d', $year, $month),
+            'shelters' => $shelterCollection,
+        ]);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -191,6 +191,8 @@ Route::middleware('auth:sanctum')->group(function () {
             return response()->json(['message' => 'Semester routes are working!', 'time' => now()]);
         });
 
+        Route::get('{cabang}/attendance-summary', App\Http\Controllers\API\AdminCabang\Reports\AdminCabangAttendanceSummaryController::class);
+
         Route::prefix('laporan')->group(function () {
             Route::get('/summary', [App\Http\Controllers\API\AdminCabang\Reports\AdminCabangReportSummaryController::class, 'getSummary']);
             Route::get('/anak-binaan', [App\Http\Controllers\API\AdminCabang\Reports\AdminCabangLaporanAnakController::class, 'index']);

--- a/backend/tests/Feature/AdminCabang/AdminCabangAttendanceSummaryTest.php
+++ b/backend/tests/Feature/AdminCabang/AdminCabangAttendanceSummaryTest.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace Tests\Feature\AdminCabang;
+
+use App\Models\Absen;
+use App\Models\AbsenUser;
+use App\Models\AdminCabang;
+use App\Models\Aktivitas;
+use App\Models\Kacab;
+use App\Models\Shelter;
+use App\Models\User;
+use App\Models\Wilbin;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AdminCabangAttendanceSummaryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        DB::purge('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::dropIfExists('absen');
+        Schema::dropIfExists('absen_user');
+        Schema::dropIfExists('aktivitas');
+        Schema::dropIfExists('shelter');
+        Schema::dropIfExists('wilbin');
+        Schema::dropIfExists('admin_cabang');
+        Schema::dropIfExists('kacab');
+        Schema::dropIfExists('users');
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->id('id_users');
+            $table->string('username');
+            $table->string('email')->nullable();
+            $table->string('password');
+            $table->string('level');
+            $table->timestamps();
+        });
+
+        Schema::create('kacab', function (Blueprint $table) {
+            $table->id('id_kacab');
+            $table->string('nama_kacab');
+            $table->string('status')->default('aktif');
+            $table->timestamps();
+        });
+
+        Schema::create('admin_cabang', function (Blueprint $table) {
+            $table->id('id_admin_cabang');
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('id_kacab');
+            $table->string('nama_lengkap')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('wilbin', function (Blueprint $table) {
+            $table->id('id_wilbin');
+            $table->unsignedBigInteger('id_kacab');
+            $table->string('nama_wilbin');
+            $table->timestamps();
+        });
+
+        Schema::create('shelter', function (Blueprint $table) {
+            $table->id('id_shelter');
+            $table->unsignedBigInteger('id_wilbin');
+            $table->string('nama_shelter');
+            $table->timestamps();
+        });
+
+        Schema::create('aktivitas', function (Blueprint $table) {
+            $table->id('id_aktivitas');
+            $table->unsignedBigInteger('id_shelter');
+            $table->date('tanggal');
+            $table->timestamps();
+        });
+
+        Schema::create('absen_user', function (Blueprint $table) {
+            $table->id('id_absen_user');
+            $table->unsignedBigInteger('id_anak')->nullable();
+            $table->unsignedBigInteger('id_tutor')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('absen', function (Blueprint $table) {
+            $table->id('id_absen');
+            $table->unsignedBigInteger('id_absen_user')->nullable();
+            $table->unsignedBigInteger('id_aktivitas');
+            $table->string('absen');
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('absen');
+        Schema::dropIfExists('absen_user');
+        Schema::dropIfExists('aktivitas');
+        Schema::dropIfExists('shelter');
+        Schema::dropIfExists('wilbin');
+        Schema::dropIfExists('admin_cabang');
+        Schema::dropIfExists('kacab');
+        Schema::dropIfExists('users');
+
+        parent::tearDown();
+    }
+
+    public function test_it_returns_attendance_summary_for_cabang(): void
+    {
+        $user = User::create([
+            'username' => 'admin-cabang',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('secret'),
+            'level' => 'admin_cabang',
+        ]);
+
+        $kacab = Kacab::create([
+            'nama_kacab' => 'Cabang A',
+            'status' => 'aktif',
+        ]);
+
+        AdminCabang::create([
+            'user_id' => $user->id_users,
+            'id_kacab' => $kacab->id_kacab,
+            'nama_lengkap' => 'Admin Cabang',
+        ]);
+
+        $wilbinOne = Wilbin::create([
+            'id_kacab' => $kacab->id_kacab,
+            'nama_wilbin' => 'Wilbin 1',
+        ]);
+
+        $wilbinTwo = Wilbin::create([
+            'id_kacab' => $kacab->id_kacab,
+            'nama_wilbin' => 'Wilbin 2',
+        ]);
+
+        $shelterOne = Shelter::create([
+            'id_wilbin' => $wilbinOne->id_wilbin,
+            'nama_shelter' => 'Shelter Alpha',
+        ]);
+
+        $shelterTwo = Shelter::create([
+            'id_wilbin' => $wilbinTwo->id_wilbin,
+            'nama_shelter' => 'Shelter Beta',
+        ]);
+
+        $shelterThree = Shelter::create([
+            'id_wilbin' => $wilbinTwo->id_wilbin,
+            'nama_shelter' => 'Shelter Gamma',
+        ]);
+
+        $activityOne = Aktivitas::create([
+            'id_shelter' => $shelterOne->id_shelter,
+            'tanggal' => '2024-05-10',
+        ]);
+
+        $activityTwo = Aktivitas::create([
+            'id_shelter' => $shelterOne->id_shelter,
+            'tanggal' => '2024-05-12',
+        ]);
+
+        $activityThree = Aktivitas::create([
+            'id_shelter' => $shelterTwo->id_shelter,
+            'tanggal' => '2024-05-15',
+        ]);
+
+        $activityOutsideMonth = Aktivitas::create([
+            'id_shelter' => $shelterTwo->id_shelter,
+            'tanggal' => '2024-04-20',
+        ]);
+
+        $absenUserOne = AbsenUser::create(['id_anak' => null, 'id_tutor' => null]);
+        $absenUserTwo = AbsenUser::create(['id_anak' => null, 'id_tutor' => null]);
+
+        Absen::create([
+            'id_absen_user' => $absenUserOne->id_absen_user,
+            'id_aktivitas' => $activityOne->id_aktivitas,
+            'absen' => 'Ya',
+        ]);
+
+        Absen::create([
+            'id_absen_user' => $absenUserOne->id_absen_user,
+            'id_aktivitas' => $activityTwo->id_aktivitas,
+            'absen' => 'Tidak',
+        ]);
+
+        Absen::create([
+            'id_absen_user' => $absenUserTwo->id_absen_user,
+            'id_aktivitas' => $activityThree->id_aktivitas,
+            'absen' => 'Terlambat',
+        ]);
+
+        Absen::create([
+            'id_absen_user' => $absenUserTwo->id_absen_user,
+            'id_aktivitas' => $activityOutsideMonth->id_aktivitas,
+            'absen' => 'Ya',
+        ]);
+
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->getJson("/api/admin-cabang/{$kacab->id_kacab}/attendance-summary?month=5&year=2024");
+
+        $response->assertOk();
+
+        $payload = $response->json();
+
+        $this->assertSame('2024-05', $payload['month']);
+        $this->assertCount(3, $payload['shelters']);
+
+        $this->assertSame($shelterOne->id_shelter, $payload['shelters'][0]['id']);
+        $this->assertSame('Shelter Alpha', $payload['shelters'][0]['name']);
+        $this->assertSame(50.0, $payload['shelters'][0]['attendance_avg']);
+
+        $this->assertSame($shelterTwo->id_shelter, $payload['shelters'][1]['id']);
+        $this->assertSame('Shelter Beta', $payload['shelters'][1]['name']);
+        $this->assertSame(100.0, $payload['shelters'][1]['attendance_avg']);
+
+        $this->assertSame($shelterThree->id_shelter, $payload['shelters'][2]['id']);
+        $this->assertSame('Shelter Gamma', $payload['shelters'][2]['name']);
+        $this->assertSame(0.0, $payload['shelters'][2]['attendance_avg']);
+    }
+
+    public function test_it_returns_404_when_cabang_not_found(): void
+    {
+        $user = User::create([
+            'username' => 'admin-cabang',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('secret'),
+            'level' => 'admin_cabang',
+        ]);
+
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->getJson('/api/admin-cabang/999/attendance-summary?month=5&year=2024');
+
+        $response->assertStatus(404);
+        $response->assertJson([
+            'message' => 'Cabang tidak ditemukan',
+        ]);
+    }
+
+    public function test_it_returns_validation_errors_for_invalid_month_or_year(): void
+    {
+        $user = User::create([
+            'username' => 'admin-cabang',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('secret'),
+            'level' => 'admin_cabang',
+        ]);
+
+        $kacab = Kacab::create([
+            'nama_kacab' => 'Cabang A',
+            'status' => 'aktif',
+        ]);
+
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->getJson("/api/admin-cabang/{$kacab->id_kacab}/attendance-summary?month=13&year=2024");
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['month']);
+
+        $response = $this->getJson("/api/admin-cabang/{$kacab->id_kacab}/attendance-summary?month=5&year=1999");
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['year']);
+    }
+}


### PR DESCRIPTION
## Summary
- add an admin cabang attendance summary route for branch-level reporting
- implement a controller that validates month/year filters and aggregates shelter attendance averages
- add feature coverage for success, missing cabang, and validation failure scenarios

## Testing
- php artisan test --filter=AdminCabangAttendanceSummaryTest *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68e27c27451c8323b06dcda20ff32d0a