### PR TITLE
Add logging for attendance summary API responses

### DIFF
--- a/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
@@ -255,6 +255,7 @@ const AdminCabangChildReportScreen = () => {
           month: activePeriodMonth,
           year: activePeriodYear,
         });
+        console.log('Attendance summary API response:', response?.data);
         const payload = response?.data?.data || response?.data || {};
         const shelters = Array.isArray(payload.shelters) ? payload.shelters : [];
         const normalizedShelters = shelters.map((item) => ({


### PR DESCRIPTION
## Summary
- log the attendance summary API response after successful fetches on the admin cabang child report screen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e28a854790832398882a64679dfd94