### PR TITLE
Fix attendance summary empty-state logic

### DIFF
--- a/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
@@ -321,6 +321,8 @@ const AdminCabangChildReportScreen = () => {
     }));
   }, [attendanceSummaryData]);
 
+  const hasShelterData = attendanceSummaryData.length > 0;
+
   const filteredAttendanceData = useMemo(() => {
     if (!activePeriod) {
       return [];
@@ -745,9 +747,13 @@ const AdminCabangChildReportScreen = () => {
             <View style={styles.chartPlaceholder}>
               <Text style={styles.chartPlaceholderTitle}>Gagal memuat data</Text>
             </View>
-          ) : filteredAttendanceData.length === 0 ? (
+          ) : !hasShelterData ? (
             <View style={styles.chartPlaceholder}>
               <Text style={styles.chartPlaceholderTitle}>Data tidak tersedia untuk bulan ini</Text>
+            </View>
+          ) : filteredAttendanceData.length === 0 ? (
+            <View style={styles.chartPlaceholder}>
+              <Text style={styles.chartPlaceholderTitle}>Tidak ada data untuk filter yang dipilih</Text>
             </View>
           ) : activeChartType === 'line' ? (
             <ChildAttendanceLineChart


### PR DESCRIPTION
## Summary
- add a hasShelterData flag after normalizing attendance data
- adjust the chart empty states to differentiate between missing shelter data and filter-only results

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e28b39287483238fe46a876cd891db