### PR TITLE
Handle zero attendance states in admin cabang child report charts

### DIFF
--- a/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
@@ -379,12 +379,26 @@ const AdminCabangChildReportScreen = () => {
     });
   }, [activePeriod, activeShelter, attendanceByShelter, selectedShelterLabel]);
 
+  const hasPositiveAttendance = useMemo(
+    () =>
+      filteredAttendanceData.some((item) => {
+        const value = Number(item?.value ?? item?.attendance_avg ?? 0);
+
+        return Number.isFinite(value) && value > 0;
+      }),
+    [filteredAttendanceData],
+  );
+
   const attendanceCategories = useMemo(
     () => filteredAttendanceData.map((item) => String(item?.shelter || '')),
     [filteredAttendanceData],
   );
 
   const handleOpenChartFullScreen = useCallback(() => {
+    if (!hasPositiveAttendance) {
+      return;
+    }
+
     navigation.navigate('ChartFullScreen', {
       chartType: activeChartType,
       periodLabel: selectedPeriodLabel,
@@ -392,7 +406,14 @@ const AdminCabangChildReportScreen = () => {
       data: filteredAttendanceData,
       year: selectedPeriodLabel,
     });
-  }, [activeChartType, attendanceCategories, filteredAttendanceData, navigation, selectedPeriodLabel]);
+  }, [
+    activeChartType,
+    attendanceCategories,
+    filteredAttendanceData,
+    hasPositiveAttendance,
+    navigation,
+    selectedPeriodLabel,
+  ]);
 
   const clearSearchDebounce = useCallback(() => {
     if (searchDebounceRef.current) {
@@ -785,6 +806,12 @@ const AdminCabangChildReportScreen = () => {
           ) : filteredAttendanceData.length === 0 ? (
             <View style={styles.chartPlaceholder}>
               <Text style={styles.chartPlaceholderTitle}>Tidak ada data untuk filter yang dipilih</Text>
+            </View>
+          ) : !hasPositiveAttendance ? (
+            <View style={styles.chartPlaceholder}>
+              <Text style={styles.chartPlaceholderTitle}>
+                Belum ada data kehadiran untuk periode ini
+              </Text>
             </View>
           ) : activeChartType === 'line' ? (
             <ChildAttendanceLineChart


### PR DESCRIPTION
## Summary
- add a memoized helper to detect positive attendance values in the filtered dataset
- render a placeholder message when only zero-value attendance data is available
- prevent fullscreen navigation when no positive attendance data is present

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3162eda08832387c57a8a91d72637