### PR TITLE
Improve compact child attendance bar chart view

### DIFF
--- a/frontend/src/features/adminCabang/components/reports/ChartFullScreenScreen.js
+++ b/frontend/src/features/adminCabang/components/reports/ChartFullScreenScreen.js
@@ -90,6 +90,10 @@ const ChartFullScreenScreen = () => {
       props.contentInset = resolvedContentInset;
     }
 
+    if (Object.prototype.hasOwnProperty.call(props, 'maxItems')) {
+      delete props.maxItems;
+    }
+
     return props;
   }, [chartProps, resolvedContentInset]);
 

--- a/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/AdminCabangChildReportScreen.js
@@ -823,14 +823,27 @@ const AdminCabangChildReportScreen = () => {
             />
           ) : (
             <View style={styles.barChartCard}>
-              <Text style={styles.chartCardTitle}>
-                Distribusi Kehadiran
-                {selectedPeriodLabel ? ` ${selectedPeriodLabel}` : ''}
-              </Text>
+              <View style={styles.chartCardHeader}>
+                <Text style={styles.chartCardTitle}>
+                  Distribusi Kehadiran
+                  {selectedPeriodLabel ? ` ${selectedPeriodLabel}` : ''}
+                </Text>
+                <TouchableOpacity
+                  style={[
+                    styles.chartCardAction,
+                    !hasPositiveAttendance && styles.chartCardActionDisabled,
+                  ]}
+                  onPress={handleOpenChartFullScreen}
+                  disabled={!hasPositiveAttendance}
+                >
+                  <Text style={styles.chartCardActionText}>Lihat Semua</Text>
+                </TouchableOpacity>
+              </View>
               <ChildAttendanceBarChart
                 mode="compact"
                 data={filteredAttendanceData}
                 categories={attendanceCategories}
+                onOpenFullScreen={handleOpenChartFullScreen}
               />
             </View>
           )}
@@ -1021,11 +1034,32 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: '#ecf0f1',
   },
+  chartCardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
   chartCardTitle: {
     fontSize: 16,
     fontWeight: '600',
     color: '#2c3e50',
-    marginBottom: 12,
+    flex: 1,
+  },
+  chartCardAction: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    backgroundColor: '#eff6ff',
+    marginLeft: 12,
+  },
+  chartCardActionText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#2563eb',
+  },
+  chartCardActionDisabled: {
+    opacity: 0.5,
   },
   chartPlaceholder: {
     padding: 20,


### PR DESCRIPTION
## Summary
- sort the compact child attendance bar chart by value, cap the output to a configurable top list, and ellipsize long labels before rendering them on the axis
- ensure the full screen bar chart receives the complete dataset without the compact limit while keeping horizontal space for long labels
- add a "Lihat Semua" action to the bar chart card on the admin cabang report screen to open the full screen chart

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e31a0afa948323a675ffaf618da893