### PR TITLE
feat: redesign child attendance bar chart layout

### DIFF
--- a/frontend/src/features/adminCabang/components/reports/ChildAttendanceBarChart.js
+++ b/frontend/src/features/adminCabang/components/reports/ChildAttendanceBarChart.js
@@ -3,11 +3,24 @@ import { View, StyleSheet, ScrollView } from 'react-native';
 import { BarChart, XAxis, YAxis } from 'react-native-svg-charts';
 import { Text as SvgText } from 'react-native-svg';
 
-const DEFAULT_CONTENT_INSET = { top: 16, bottom: 16 };
-const Y_AXIS_WIDTH = 44;
+const DEFAULT_CONTENT_INSET = { top: 16, bottom: 16, left: 12, right: 16 };
 const MODE_STYLES = {
-  compact: { height: 200, paddingHorizontal: 16, xAxisHeight: 120, rotation: -45 },
-  fullscreen: { height: 280, paddingHorizontal: 24, xAxisHeight: 140, rotation: -35 },
+  compact: {
+    itemHeight: 44,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    chartWidth: 280,
+    categoryAxisWidth: 160,
+    minChartHeight: 220,
+  },
+  fullscreen: {
+    itemHeight: 52,
+    paddingHorizontal: 24,
+    paddingVertical: 16,
+    chartWidth: 360,
+    categoryAxisWidth: 200,
+    minChartHeight: 320,
+  },
 };
 
 const DEFAULT_MAX_ITEMS = 5;
@@ -42,22 +55,28 @@ const formatPercentage = (value) => {
   return `${rounded}%`;
 };
 
-const Labels = ({ x, y, bandwidth, data }) =>
+const Labels = ({ x, y, bandwidth, data, chartWidth }) =>
   data.map((item, index) => {
     const value = Number(item?.value ?? item ?? 0);
     if (!Number.isFinite(value)) {
       return null;
     }
 
+    const valueX = x(value);
+    const valueY = y(index) + bandwidth / 2;
+    const isValueLarge = valueX > chartWidth * 0.7;
+    const textAnchor = isValueLarge ? 'end' : 'start';
+    const horizontalOffset = isValueLarge ? -8 : 8;
+
     return (
       <SvgText
         key={`label-${index}`}
-        x={x(index) + bandwidth / 2}
-        y={y(value) - 8}
+        x={valueX + horizontalOffset}
+        y={valueY}
         fontSize={12}
         fill="#1f2937"
-        alignmentBaseline="baseline"
-        textAnchor="middle"
+        alignmentBaseline="middle"
+        textAnchor={textAnchor}
       >
         {formatPercentage(value)}
       </SvgText>
@@ -138,59 +157,84 @@ const ChildAttendanceBarChart = ({
     [effectiveData]
   );
 
-  const { height, paddingHorizontal, xAxisHeight, rotation } =
-    MODE_STYLES[mode] || MODE_STYLES.compact;
-  const itemWidth = isCompactMode ? 60 : 88;
-  const minWidth = isCompactMode ? 240 : 360;
-  const chartWidth = Math.max((effectiveData.length || 1) * itemWidth, minWidth);
-  const resolvedRotation = typeof rotation === 'number' ? rotation : isCompactMode ? -40 : -28;
-  const resolvedXAxisHeight = Number.isFinite(xAxisHeight) ? xAxisHeight : isCompactMode ? 72 : 88;
-  const labelYOffset = Math.max(24, resolvedXAxisHeight - 20);
-  const totalHeight = height + resolvedXAxisHeight + 40;
+  const {
+    itemHeight,
+    paddingHorizontal,
+    paddingVertical,
+    chartWidth: baseChartWidth,
+    categoryAxisWidth,
+    minChartHeight,
+  } = MODE_STYLES[mode] || MODE_STYLES.compact;
+
+  const chartHeight = Math.max((effectiveData.length || 1) * itemHeight, minChartHeight);
+  const chartWidth = Math.max(baseChartWidth, 220);
+  const totalHeight = chartHeight + paddingVertical * 2 + 48;
+  const yAxisData = useMemo(
+    () => (effectiveData.length > 0 ? effectiveData.map((_, index) => index + 1) : [0]),
+    [effectiveData]
+  );
+  const maxValue = useMemo(
+    () => (values.length > 0 ? Math.max(...values.map((value) => Number(value) || 0)) : 0),
+    [values]
+  );
+
+  const axisUpperBound = useMemo(() => {
+    const safeMax = Number.isFinite(maxValue) && maxValue > 0 ? maxValue : 100;
+    return Math.max(100, Math.ceil(safeMax / 10) * 10);
+  }, [maxValue]);
+
+  const xAxisTicks = useMemo(() => {
+    const step = axisUpperBound / 5;
+    return Array.from({ length: 6 }, (_, index) => Number((index * step).toFixed(0)));
+  }, [axisUpperBound]);
 
   return (
     <View style={[containerStyle, { minHeight: totalHeight }]}>
       <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={mode === 'fullscreen'}
-        contentContainerStyle={[styles.scrollContent, { paddingHorizontal }]}
+        showsVerticalScrollIndicator={mode === 'fullscreen'}
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingHorizontal, paddingVertical, minWidth: categoryAxisWidth + chartWidth + 24 },
+        ]}
         accessibilityRole={canOpenFullScreen ? 'button' : undefined}
         accessibilityHint={canOpenFullScreen ? 'Buka tampilan grafik layar penuh' : undefined}
         onAccessibilityTap={canOpenFullScreen ? onOpenFullScreen : undefined}
       >
-        <View style={[styles.chartWrapper, { width: chartWidth + Y_AXIS_WIDTH }]}
+        <View
+          style={[
+            styles.chartWrapper,
+            { width: categoryAxisWidth + chartWidth, minHeight: chartHeight },
+          ]}
         >
           <View style={styles.chartRow}>
             <YAxis
-              style={[styles.yAxis, { height }]}
-              data={values.length > 0 ? values : [0]}
+              style={[styles.yAxis, { width: categoryAxisWidth, height: chartHeight }]}
+              data={yAxisData}
               contentInset={contentInset}
-              svg={{ fill: '#2563eb', fontSize: 12 }}
-              formatLabel={formatPercentage}
+              numberOfTicks={effectiveData.length || 1}
+              svg={{ fill: '#1f2937', fontSize: 12 }}
+              formatLabel={(value, index) => displayCategories[index] ?? ''}
             />
             <View>
               <BarChart
-                style={{ height, width: chartWidth }}
+                style={{ height: chartHeight, width: chartWidth }}
                 data={chartData}
                 yAccessor={({ item }) => item.value}
                 contentInset={contentInset}
                 spacingInner={0.3}
                 spacingOuter={0.2}
+                yMax={axisUpperBound}
+                horizontal
               >
-                <Labels />
+                <Labels chartWidth={chartWidth} />
               </BarChart>
               <XAxis
-                style={[styles.xAxis, { width: chartWidth, height: resolvedXAxisHeight }]}
-                data={values.length > 0 ? values : [0]}
-                formatLabel={(value, index) => displayCategories[index] ?? ''}
-                svg={{
-                  fontSize: 12,
-                  fill: '#4b5563',
-                  rotation: resolvedRotation,
-                  originY: 12,  // Pivot point tetap dekat dengan chart
-                  y: 12,        // Posisi awal text dekat dengan chart
-                  textAnchor: 'end',
-                }}
+                style={[styles.xAxis, { width: chartWidth, marginLeft: categoryAxisWidth }]}
+                data={xAxisTicks}
+                contentInset={{ left: contentInset.left ?? 0, right: contentInset.right ?? 0 }}
+                numberOfTicks={xAxisTicks.length}
+                svg={{ fontSize: 12, fill: '#4b5563' }}
+                formatLabel={(value) => `${value}%`}
               />
             </View>
           </View>
@@ -204,7 +248,7 @@ export default memo(ChildAttendanceBarChart);
 
 const styles = StyleSheet.create({
   scrollContent: {
-    paddingBottom: 16,
+    flexGrow: 1,
   },
   chartWrapper: {
     flexGrow: 1,
@@ -215,10 +259,9 @@ const styles = StyleSheet.create({
     alignItems: 'stretch',
   },
   yAxis: {
-    width: Y_AXIS_WIDTH,
-    marginRight: 8,
+    marginRight: 12,
   },
   xAxis: {
-    marginTop: 8,
+    marginTop: 12,
   },
 });


### PR DESCRIPTION
## Summary
- rework the child attendance bar chart into a horizontal layout so shelter names stay horizontal
- add dynamic sizing, padding, and percentage tick labels for the horizontal axis to improve readability
- update value labels to render beside each bar with adaptive positioning

## Testing
- npm --prefix frontend run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e32d6da3d883238bdbdb7fa3564617