### PR TITLE
Use fetch with timeout for donation ads

### DIFF
--- a/frontend/src/features/donatur/screen/DonaturDashboardScreen.js
+++ b/frontend/src/features/donatur/screen/DonaturDashboardScreen.js
@@ -47,9 +47,26 @@ const DonaturDashboardScreen = () => {
   };
 
   const fetchDonationAd = async () => {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 30000);
+
     try {
-      const response = await donaturApi.getDonationAds();
-      const ads = response?.data?.data || [];
+      const response = await fetch('https://home.kilauindonesia.org/api/iklandonasi', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const result = await response.json();
+      console.log('Donation ads response:', result);
+
+      const ads = result?.data || [];
       const activeAd = Array.isArray(ads)
         ? ads.find((item) => item?.status === '1')
         : null;
@@ -57,7 +74,9 @@ const DonaturDashboardScreen = () => {
       setDonationAd(activeAd || null);
       setAdVisible(!adDismissed && !!activeAd);
     } catch (err) {
-      console.error('Error fetching donation ads:', err);
+      console.error('Error fetching donation ads:', err, err?.message);
+    } finally {
+      clearTimeout(timeoutId);
     }
   };
 


### PR DESCRIPTION
## Summary
- replace the donation ad request with a fetch call that mirrors the CampaignShareModal timeout pattern
- log the API response before selecting the active advertisement and include the error message in console errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e48e2516248323aa835f886735d2f4