### PR TITLE
Fix asset base handling in DonationAdModal

### DIFF
--- a/frontend/src/features/donatur/components/DonationAdModal.js
+++ b/frontend/src/features/donatur/components/DonationAdModal.js
@@ -15,6 +15,8 @@ import Button from '../../../common/components/Button';
 import { API_BASE_URL } from '../../../constants/config';
 
 const DonationAdModal = ({ visible, ad, onClose, onActionPress }) => {
+  const assetBase = API_BASE_URL.replace(/\/api\/?$/, '');
+
   const getFullUrl = (path) => {
     if (!path) {
       return null;
@@ -24,7 +26,7 @@ const DonationAdModal = ({ visible, ad, onClose, onActionPress }) => {
       return path;
     }
 
-    const base = API_BASE_URL.replace(/\/$/, '');
+    const base = assetBase.replace(/\/$/, '');
     const cleanedPath = path.replace(/^\//, '');
     return `${base}/${cleanedPath}`;
   };


### PR DESCRIPTION
## Summary
- derive the asset base URL from API_BASE_URL by stripping the /api suffix
- update donation ad asset URL helper to use the asset base for relative paths

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e48f4032d4832383f456db4a697a14