### PR TITLE
Add logging for donation ad fetch

### DIFF
--- a/frontend/src/features/donatur/screen/DonaturDashboardScreen.js
+++ b/frontend/src/features/donatur/screen/DonaturDashboardScreen.js
@@ -67,14 +67,20 @@ const DonaturDashboardScreen = () => {
       console.log('Donation ads response:', result);
 
       const ads = result?.data || [];
+      console.log('Donation ads data:', ads);
       const activeAd = Array.isArray(ads)
         ? ads.find((item) => item?.status === '1')
         : null;
+      console.log('Active donation ad:', activeAd);
 
       setDonationAd(activeAd || null);
       setAdVisible(!adDismissed && !!activeAd);
     } catch (err) {
-      console.error('Error fetching donation ads:', err, err?.message);
+      console.error('Donation ads request failed:', err);
+      const errorResponse = await err.response?.text?.();
+      if (errorResponse) {
+        console.log('Error response:', errorResponse);
+      }
     } finally {
       clearTimeout(timeoutId);
     }


### PR DESCRIPTION
## Summary
- add console logging for donation ads data and active ad selection in the donor dashboard
- improve error handling by logging failures and optional response text when donation ad fetch fails

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e490e715c88323a9860d579aece432