### PR TITLE
Use dedicated donation asset base URL

### DIFF
--- a/frontend/src/constants/config.js
+++ b/frontend/src/constants/config.js
@@ -3,6 +3,20 @@ export const API_BASE_URL = 'http://10.132.12.166:8000/api';
 //export const API_BASE_URL = 'http://192.168.8.105:8000/api';
 //export const API_BASE_URL = 'https://bp.berbagipendidikan.org/api';
 
+// Asset URLs
+const resolveDonationAssetBaseUrl = () => {
+  const env =
+    (typeof process !== 'undefined' && process?.env) ?
+      process.env.EXPO_PUBLIC_DONATION_ASSET_BASE_URL ||
+      process.env.DONATION_ASSET_BASE_URL :
+      null;
+
+  const value = typeof env === 'string' ? env.trim() : '';
+  return value || 'https://home.kilauindonesia.org';
+};
+
+export const DONATION_ASSET_BASE_URL = resolveDonationAssetBaseUrl();
+
 // Storage keys
 export const STORAGE_TOKEN_KEY = 'berbagipendidikan_token';
 export const STORAGE_USER_KEY = 'berbagipendidikan_user';

--- a/frontend/src/features/donatur/components/DonationAdModal.js
+++ b/frontend/src/features/donatur/components/DonationAdModal.js
@@ -12,10 +12,10 @@ import {
 import { Ionicons, FontAwesome5 } from '@expo/vector-icons';
 
 import Button from '../../../common/components/Button';
-import { API_BASE_URL } from '../../../constants/config';
+import { DONATION_ASSET_BASE_URL } from '../../../constants/config';
 
 const DonationAdModal = ({ visible, ad, onClose, onActionPress }) => {
-  const assetBase = API_BASE_URL.replace(/\/api\/?$/, '');
+  const assetBase = DONATION_ASSET_BASE_URL.replace(/\/$/, '');
 
   const getFullUrl = (path) => {
     if (!path) {
@@ -26,9 +26,8 @@ const DonationAdModal = ({ visible, ad, onClose, onActionPress }) => {
       return path;
     }
 
-    const base = assetBase.replace(/\/$/, '');
     const cleanedPath = path.replace(/^\//, '');
-    return `${base}/${cleanedPath}`;
+    return `${assetBase}/${cleanedPath}`;
   };
 
   const imageUrl = getFullUrl(ad?.file_url);


### PR DESCRIPTION
## Summary
- add a donation asset base URL constant that can be overridden via Expo environment variables
- update the donation ad modal to resolve file and icon assets with the new base URL

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e49831e7dc832399078347f785dfde