### PR TITLE
Adjust donation ad modal background transparency

### DIFF
--- a/frontend/src/features/donatur/components/DonationAdModal.js
+++ b/frontend/src/features/donatur/components/DonationAdModal.js
@@ -233,7 +233,6 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
   },
   surface: {
-    backgroundColor: '#ffffff',
     borderRadius: 20,
     overflow: 'hidden',
     shadowColor: '#000',


### PR DESCRIPTION
## Summary
- remove the modal surface background color so the surrounding overlay can show through while keeping the content panel styling intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4cbe6a79c8323a192aa4cb0f38699