### PR TITLE
Handle server-provided auth field errors

### DIFF
--- a/frontend/src/common/hooks/useAuth.js
+++ b/frontend/src/common/hooks/useAuth.js
@@ -7,8 +7,9 @@ import {
   selectUserProfile,
   selectAuthLoading,
   selectAuthError,
+  selectAuthFieldErrors,
   selectIsInitializing,
-  resetAuthError 
+  resetAuthError
 } from '../../features/auth/redux/authSlice';
 import { 
   loginUser, 
@@ -31,6 +32,7 @@ export const useAuth = () => {
   const profile = useSelector(selectUserProfile);
   const loading = useSelector(selectAuthLoading);
   const error = useSelector(selectAuthError);
+  const fieldErrors = useSelector(selectAuthFieldErrors);
   const initializing = useSelector(selectIsInitializing);
 
   // Initialize auth on first render
@@ -79,6 +81,7 @@ export const useAuth = () => {
     profile,
     loading,
     error,
+    fieldErrors,
     initializing,
     
     // Auth actions

--- a/frontend/src/features/auth/components/LoginForm.js
+++ b/frontend/src/features/auth/components/LoginForm.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, StyleSheet, Keyboard, TouchableWithoutFeedback } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '../../../common/hooks/useAuth';
@@ -21,7 +21,40 @@ const LoginForm = ({ onLoginSuccess }) => {
   const [validationErrors, setValidationErrors] = useState({});
 
   // Get auth related functions and state from useAuth hook
-  const { login, loading, error, clearError } = useAuth();
+  const { login, loading, error, fieldErrors, clearError } = useAuth();
+
+  useEffect(() => {
+    if (!fieldErrors) {
+      setValidationErrors(prev => {
+        const updatedErrors = { ...prev };
+        ['email', 'password'].forEach((field) => {
+          if (field in updatedErrors) {
+            delete updatedErrors[field];
+          }
+        });
+        return updatedErrors;
+      });
+      return;
+    }
+
+    setValidationErrors(prev => {
+      const updatedErrors = { ...prev };
+
+      Object.entries(fieldErrors).forEach(([field, value]) => {
+        if (['email', 'password'].includes(field)) {
+          updatedErrors[field] = Array.isArray(value) ? value.join(' ') : value;
+        }
+      });
+
+      ['email', 'password'].forEach((field) => {
+        if (!Object.prototype.hasOwnProperty.call(fieldErrors, field) && field in updatedErrors) {
+          delete updatedErrors[field];
+        }
+      });
+
+      return updatedErrors;
+    });
+  }, [fieldErrors]);
 
   // Validate form inputs
   const validateForm = () => {

--- a/frontend/src/features/auth/redux/authSlice.js
+++ b/frontend/src/features/auth/redux/authSlice.js
@@ -11,7 +11,8 @@ const initialState = {
   profile: null,              // User profile data based on role
   loading: false,             // Loading state
   initializing: true,         // App initialization state
-  error: null                 // Error message if any
+  error: null,                // Error message if any
+  fieldErrors: null           // Field-level validation errors
 };
 
 /**
@@ -24,6 +25,7 @@ const authSlice = createSlice({
     // Reset error state
     resetAuthError: (state) => {
       state.error = null;
+      state.fieldErrors = null;
     },
     
     // Manually set auth token (for restoring from storage)
@@ -41,8 +43,9 @@ const authSlice = createSlice({
     loginStart: (state) => {
       state.loading = true;
       state.error = null;
+      state.fieldErrors = null;
     },
-    
+
     loginSuccess: (state, action) => {
       state.loading = false;
       state.isAuthenticated = true;
@@ -54,11 +57,13 @@ const authSlice = createSlice({
       };
       state.userLevel = action.payload.user.level;
       state.profile = action.payload.user.profile;
+      state.fieldErrors = null;
     },
-    
+
     loginFailure: (state, action) => {
       state.loading = false;
       state.error = action.payload?.message || 'Login failed. Please check your credentials.';
+      state.fieldErrors = action.payload?.fieldErrors || null;
     },
 
     // Logout actions
@@ -152,6 +157,7 @@ export const selectUser = (state) => state.auth.user;
 export const selectUserProfile = (state) => state.auth.profile;
 export const selectAuthLoading = (state) => state.auth.loading;
 export const selectAuthError = (state) => state.auth.error;
+export const selectAuthFieldErrors = (state) => state.auth.fieldErrors;
 
 // Export reducer
 export default authSlice.reducer;

--- a/frontend/src/features/auth/redux/authThunks.js
+++ b/frontend/src/features/auth/redux/authThunks.js
@@ -73,17 +73,22 @@ export const loginUser = (credentials) => async (dispatch) => {
     return data;
   } catch (error) {
     // Extract error message for better UX
-    const errorMsg = error.response?.data?.message || 
-                     error.response?.data?.errors || 
-                     error.message || 
-                     'Login failed';
-    
-    const formattedError = { 
-      message: typeof errorMsg === 'object' 
-        ? Object.values(errorMsg).flat().join(', ') 
-        : errorMsg 
+    const fieldErrors = error.response?.data?.errors;
+    const rawMessage = error.response?.data?.message || error.message || 'Login failed';
+
+    const fallbackFieldMessage = fieldErrors && typeof fieldErrors === 'object'
+      ? Object.values(fieldErrors).flat().join(', ')
+      : null;
+
+    const message = typeof rawMessage === 'string'
+      ? rawMessage
+      : fallbackFieldMessage || 'Login failed';
+
+    const formattedError = {
+      message,
+      fieldErrors: fieldErrors || null
     };
-    
+
     dispatch(loginFailure(formattedError));
     throw formattedError;
   }


### PR DESCRIPTION
## Summary
- add persistent fieldErrors state in the auth slice and expose a selector
- retain structured fieldErrors returned by the login thunk while still surfacing a friendly message
- surface server field validation feedback in the login form while keeping the banner error message

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e509aaa2748323be8171d3fe2d6301