### PR TITLE
Localize auth error messaging

### DIFF
--- a/backend/app/Http/Controllers/API/AuthController.php
+++ b/backend/app/Http/Controllers/API/AuthController.php
@@ -32,7 +32,7 @@ class AuthController extends Controller
 
         if (!$user || !Hash::check($request->password, $user->password)) {
             return response()->json([
-                'message' => 'Invalid credentials'
+                'message' => 'Email atau kata sandi tidak sesuai'
             ], 401);
         }
 

--- a/frontend/src/features/auth/components/LoginForm.js
+++ b/frontend/src/features/auth/components/LoginForm.js
@@ -163,11 +163,11 @@ const LoginForm = ({ onLoginSuccess }) => {
 
         {/* Error Message */}
         {error && (
-          <ErrorMessage 
-            message={error} 
+          <ErrorMessage
+            message={error}
             visible={!!error}
             onRetry={clearError}
-            retryText="Clear"
+            retryText="Tutup"
           />
         )}
 

--- a/frontend/src/features/auth/redux/authSlice.js
+++ b/frontend/src/features/auth/redux/authSlice.js
@@ -62,7 +62,7 @@ const authSlice = createSlice({
 
     loginFailure: (state, action) => {
       state.loading = false;
-      state.error = action.payload?.message || 'Login failed. Please check your credentials.';
+      state.error = action.payload?.message || 'Email atau kata sandi tidak sesuai.';
       state.fieldErrors = action.payload?.fieldErrors || null;
     },
 
@@ -106,7 +106,7 @@ const authSlice = createSlice({
     fetchUserFailure: (state, action) => {
       state.loading = false;
       state.isAuthenticated = false;
-      state.error = action.payload?.message || 'Failed to fetch user data';
+      state.error = action.payload?.message || 'Gagal mengambil data pengguna';
       state.user = null;
       state.userLevel = null;
       state.profile = null;

--- a/frontend/src/features/auth/redux/authThunks.js
+++ b/frontend/src/features/auth/redux/authThunks.js
@@ -42,7 +42,7 @@ export const initializeAuth = () => async (dispatch) => {
         await removeToken();
         await removeUser();
         dispatch(setAuthToken(null));
-        dispatch(fetchUserFailure({ message: 'Session expired. Please login again.' }));
+        dispatch(fetchUserFailure({ message: 'Sesi berakhir. Silakan masuk kembali.' }));
       }
     }
     
@@ -74,7 +74,7 @@ export const loginUser = (credentials) => async (dispatch) => {
   } catch (error) {
     // Extract error message for better UX
     const fieldErrors = error.response?.data?.errors;
-    const rawMessage = error.response?.data?.message || error.message || 'Login failed';
+    const rawMessage = error.response?.data?.message || error.message || 'Email atau kata sandi tidak sesuai';
 
     const fallbackFieldMessage = fieldErrors && typeof fieldErrors === 'object'
       ? Object.values(fieldErrors).flat().join(', ')
@@ -82,7 +82,7 @@ export const loginUser = (credentials) => async (dispatch) => {
 
     const message = typeof rawMessage === 'string'
       ? rawMessage
-      : fallbackFieldMessage || 'Login failed';
+      : fallbackFieldMessage || 'Email atau kata sandi tidak sesuai';
 
     const formattedError = {
       message,
@@ -141,7 +141,7 @@ export const fetchCurrentUser = () => async (dispatch) => {
   } catch (error) {
     console.error('Error fetching current user:', error);
     
-    const errorMsg = error.response?.data?.message || 'Failed to fetch user data';
+    const errorMsg = error.response?.data?.message || 'Gagal mengambil data pengguna';
     dispatch(fetchUserFailure({ message: errorMsg }));
     throw error;
   }


### PR DESCRIPTION
## Summary
- localize the login failure response in the authentication controller
- align frontend auth thunks and slice fallback messages with the localized API response
- update the login form error action label to use an Indonesian term

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e50d0cf0a8832391d2ff0c520b05fe