### PR TITLE
Add admin cabang weekly shelter attendance reporting endpoint

### DIFF
--- a/backend/app/Http/Controllers/API/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterController.php
+++ b/backend/app/Http/Controllers/API/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers\API\AdminCabang\Reports\Attendance;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\AdminCabang\Reports\Attendance\AttendanceWeeklyShelterResource;
+use App\Services\AdminCabang\Reports\Attendance\WeeklyAttendanceService;
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class AttendanceWeeklyShelterController extends Controller
+{
+    public function __invoke(Request $request, WeeklyAttendanceService $service): JsonResponse
+    {
+        $user = $request->user();
+        $adminCabang = $user?->adminCabang;
+
+        if (!$adminCabang) {
+            return response()->json([
+                'message' => __('Anda tidak memiliki akses sebagai admin cabang.'),
+            ], 403);
+        }
+
+        $kacab = $adminCabang->loadMissing('kacab')->kacab;
+        $accessibleShelterIds = $kacab
+            ? $kacab->shelters()->pluck('shelter.id_shelter')->all()
+            : [];
+
+        $validator = Validator::make($request->all(), [
+            'start_date' => ['nullable', 'date'],
+            'end_date' => ['nullable', 'date'],
+            'shelter_ids' => ['nullable', 'array'],
+            'shelter_ids.*' => ['integer'],
+        ]);
+
+        $validator->after(function ($validator) use ($request, $accessibleShelterIds) {
+            $start = $request->input('start_date');
+            $end = $request->input('end_date');
+
+            if ($start && $end && Carbon::parse($end)->lt(Carbon::parse($start))) {
+                $validator->errors()->add('end_date', __('validation.after_or_equal', [
+                    'attribute' => 'end date',
+                    'date' => 'start date',
+                ]));
+            }
+
+            $shelterIds = $request->input('shelter_ids', []);
+            if (!empty($shelterIds)) {
+                $invalidShelters = collect($shelterIds)
+                    ->filter(fn ($id) => !in_array((int) $id, $accessibleShelterIds, true));
+
+                if ($invalidShelters->isNotEmpty()) {
+                    $validator->errors()->add('shelter_ids', __('Salah satu shelter tidak dapat diakses.'));
+                }
+            }
+        });
+
+        $validated = $validator->validate();
+
+        $startDate = isset($validated['start_date'])
+            ? Carbon::parse($validated['start_date'])->startOfDay()
+            : Carbon::now()->startOfMonth();
+
+        $endDate = isset($validated['end_date'])
+            ? Carbon::parse($validated['end_date'])->endOfDay()
+            : Carbon::now()->endOfMonth();
+
+        $requestedShelterIds = array_map('intval', $validated['shelter_ids'] ?? []);
+        $filteredShelterIds = !empty($requestedShelterIds)
+            ? array_values(array_intersect($requestedShelterIds, $accessibleShelterIds))
+            : $accessibleShelterIds;
+
+        $report = $service->buildShelterReport($adminCabang, [
+            'start_date' => $startDate,
+            'end_date' => $endDate,
+            'shelter_ids' => $filteredShelterIds,
+        ]);
+
+        return AttendanceWeeklyShelterResource::make($report)->additional([
+            'message' => __('Laporan kehadiran mingguan per shelter berhasil diambil.'),
+        ]);
+    }
+}

--- a/backend/app/Http/Resources/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterResource.php
+++ b/backend/app/Http/Resources/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterResource.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Resources\AdminCabang\Reports\Attendance;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class AttendanceWeeklyShelterResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        $data = (array) $this->resource;
+
+        $formatRate = static fn ($value): string => number_format((float) ($value ?? 0), 2, '.', '');
+
+        $formatVerification = static fn (array $verification): array => [
+            'pending' => (int) ($verification['pending'] ?? 0),
+            'verified' => (int) ($verification['verified'] ?? 0),
+            'rejected' => (int) ($verification['rejected'] ?? 0),
+            'manual' => (int) ($verification['manual'] ?? 0),
+        ];
+
+        $shelters = collect($data['shelters'] ?? [])->map(function ($shelter) use ($formatRate, $formatVerification) {
+            $metrics = $shelter['metrics'] ?? [];
+
+            return [
+                'id' => $shelter['id'] ?? null,
+                'name' => $shelter['name'] ?? null,
+                'metrics' => [
+                    'present_count' => (int) ($metrics['present_count'] ?? 0),
+                    'late_count' => (int) ($metrics['late_count'] ?? 0),
+                    'absent_count' => (int) ($metrics['absent_count'] ?? 0),
+                    'attendance_rate' => $formatRate($metrics['attendance_rate'] ?? 0),
+                    'late_rate' => $formatRate($metrics['late_rate'] ?? 0),
+                    'total_sessions' => (int) ($metrics['total_sessions'] ?? 0),
+                    'total_activities' => (int) ($metrics['total_activities'] ?? 0),
+                    'unique_children' => (int) ($metrics['unique_children'] ?? 0),
+                    'verification' => $formatVerification($metrics['verification'] ?? []),
+                ],
+            ];
+        })->values()->all();
+
+        $filters = $data['filters'] ?? [];
+        $metadata = $data['metadata'] ?? [];
+
+        return [
+            'filters' => [
+                'start_date' => $filters['start_date'] ?? null,
+                'end_date' => $filters['end_date'] ?? null,
+                'shelter_ids' => array_values($filters['shelter_ids'] ?? []),
+            ],
+            'metadata' => [
+                'total_shelters' => (int) ($metadata['total_shelters'] ?? count($shelters)),
+                'total_sessions' => (int) ($metadata['total_sessions'] ?? 0),
+                'total_activities' => (int) ($metadata['total_activities'] ?? 0),
+                'present_count' => (int) ($metadata['present_count'] ?? 0),
+                'late_count' => (int) ($metadata['late_count'] ?? 0),
+                'absent_count' => (int) ($metadata['absent_count'] ?? 0),
+                'attendance_rate' => $formatRate($metadata['attendance_rate'] ?? 0),
+                'late_rate' => $formatRate($metadata['late_rate'] ?? 0),
+                'unique_children' => (int) ($metadata['unique_children'] ?? 0),
+                'verification' => $formatVerification($metadata['verification'] ?? []),
+            ],
+            'shelters' => $shelters,
+            'generated_at' => $data['generated_at'] ?? null,
+        ];
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -2,6 +2,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceWeeklyController;
+use App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceWeeklyShelterController;
 
 
 Route::post('/auth/login', [App\Http\Controllers\API\AuthController::class, 'login']);
@@ -201,6 +202,7 @@ Route::middleware('auth:sanctum')->group(function () {
             Route::get('/anak-binaan/filter-options', [App\Http\Controllers\API\AdminCabang\Reports\AdminCabangLaporanAnakController::class, 'filterOptions']);
             Route::prefix('attendance')->group(function () {
                 Route::get('/weekly', AttendanceWeeklyController::class);
+                Route::get('/weekly/shelters', AttendanceWeeklyShelterController::class);
                 Route::get('/monthly-shelter', App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceMonthlyShelterController::class);
                 Route::get('/monthly-branch', App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceMonthlyBranchController::class);
             });

--- a/backend/tests/Feature/AdminCabang/AttendanceWeeklyShelterReportTest.php
+++ b/backend/tests/Feature/AdminCabang/AttendanceWeeklyShelterReportTest.php
@@ -1,0 +1,343 @@
+<?php
+
+namespace Tests\Feature\AdminCabang;
+
+use App\Models\Absen;
+use App\Models\AbsenUser;
+use App\Models\AdminCabang;
+use App\Models\Aktivitas;
+use App\Models\Kacab;
+use App\Models\Shelter;
+use App\Models\User;
+use App\Models\Wilbin;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AttendanceWeeklyShelterReportTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        DB::purge('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::dropIfExists('absen');
+        Schema::dropIfExists('absen_user');
+        Schema::dropIfExists('aktivitas');
+        Schema::dropIfExists('shelter');
+        Schema::dropIfExists('wilbin');
+        Schema::dropIfExists('admin_cabang');
+        Schema::dropIfExists('kacab');
+        Schema::dropIfExists('users');
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->id('id_users');
+            $table->string('username');
+            $table->string('email')->nullable();
+            $table->string('password');
+            $table->string('level');
+            $table->timestamps();
+        });
+
+        Schema::create('kacab', function (Blueprint $table) {
+            $table->id('id_kacab');
+            $table->string('nama_kacab');
+            $table->string('status')->default('aktif');
+            $table->timestamps();
+        });
+
+        Schema::create('admin_cabang', function (Blueprint $table) {
+            $table->id('id_admin_cabang');
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('id_kacab');
+            $table->string('nama_lengkap')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('wilbin', function (Blueprint $table) {
+            $table->id('id_wilbin');
+            $table->unsignedBigInteger('id_kacab');
+            $table->string('nama_wilbin');
+            $table->timestamps();
+        });
+
+        Schema::create('shelter', function (Blueprint $table) {
+            $table->id('id_shelter');
+            $table->unsignedBigInteger('id_wilbin');
+            $table->string('nama_shelter');
+            $table->timestamps();
+        });
+
+        Schema::create('aktivitas', function (Blueprint $table) {
+            $table->id('id_aktivitas');
+            $table->unsignedBigInteger('id_shelter');
+            $table->date('tanggal');
+            $table->timestamps();
+        });
+
+        Schema::create('absen_user', function (Blueprint $table) {
+            $table->id('id_absen_user');
+            $table->unsignedBigInteger('id_anak')->nullable();
+            $table->unsignedBigInteger('id_tutor')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('absen', function (Blueprint $table) {
+            $table->id('id_absen');
+            $table->unsignedBigInteger('id_absen_user')->nullable();
+            $table->unsignedBigInteger('id_aktivitas');
+            $table->string('absen');
+            $table->boolean('is_verified')->default(false);
+            $table->string('verification_status')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('absen');
+        Schema::dropIfExists('absen_user');
+        Schema::dropIfExists('aktivitas');
+        Schema::dropIfExists('shelter');
+        Schema::dropIfExists('wilbin');
+        Schema::dropIfExists('admin_cabang');
+        Schema::dropIfExists('kacab');
+        Schema::dropIfExists('users');
+
+        parent::tearDown();
+    }
+
+    public function test_it_returns_weekly_shelter_attendance_report(): void
+    {
+        $user = User::create([
+            'username' => 'admin-cabang',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('secret'),
+            'level' => 'admin_cabang',
+        ]);
+
+        $kacab = Kacab::create([
+            'nama_kacab' => 'Cabang A',
+            'status' => 'aktif',
+        ]);
+
+        AdminCabang::create([
+            'user_id' => $user->id_users,
+            'id_kacab' => $kacab->id_kacab,
+            'nama_lengkap' => 'Admin Cabang',
+        ]);
+
+        $wilbin = Wilbin::create([
+            'id_kacab' => $kacab->id_kacab,
+            'nama_wilbin' => 'Wilbin 1',
+        ]);
+
+        $shelterAlpha = Shelter::create([
+            'id_wilbin' => $wilbin->id_wilbin,
+            'nama_shelter' => 'Shelter Alpha',
+        ]);
+
+        $shelterBeta = Shelter::create([
+            'id_wilbin' => $wilbin->id_wilbin,
+            'nama_shelter' => 'Shelter Beta',
+        ]);
+
+        $activityAlpha = Aktivitas::create([
+            'id_shelter' => $shelterAlpha->id_shelter,
+            'tanggal' => '2024-01-03',
+        ]);
+
+        $activityBeta = Aktivitas::create([
+            'id_shelter' => $shelterBeta->id_shelter,
+            'tanggal' => '2024-01-10',
+        ]);
+
+        $attendanceUsers = [
+            AbsenUser::create(['id_anak' => 201]),
+            AbsenUser::create(['id_anak' => 202]),
+            AbsenUser::create(['id_anak' => 203]),
+            AbsenUser::create(['id_anak' => 204]),
+            AbsenUser::create(['id_anak' => 205]),
+        ];
+
+        Absen::create([
+            'id_absen_user' => $attendanceUsers[0]->id_absen_user,
+            'id_aktivitas' => $activityAlpha->id_aktivitas,
+            'absen' => Absen::TEXT_YA,
+            'verification_status' => Absen::VERIFICATION_VERIFIED,
+        ]);
+
+        Absen::create([
+            'id_absen_user' => $attendanceUsers[1]->id_absen_user,
+            'id_aktivitas' => $activityAlpha->id_aktivitas,
+            'absen' => Absen::TEXT_TERLAMBAT,
+            'verification_status' => Absen::VERIFICATION_MANUAL,
+        ]);
+
+        Absen::create([
+            'id_absen_user' => $attendanceUsers[2]->id_absen_user,
+            'id_aktivitas' => $activityAlpha->id_aktivitas,
+            'absen' => Absen::TEXT_TIDAK,
+            'verification_status' => Absen::VERIFICATION_REJECTED,
+        ]);
+
+        Absen::create([
+            'id_absen_user' => $attendanceUsers[3]->id_absen_user,
+            'id_aktivitas' => $activityBeta->id_aktivitas,
+            'absen' => Absen::TEXT_YA,
+            'verification_status' => Absen::VERIFICATION_PENDING,
+        ]);
+
+        Absen::create([
+            'id_absen_user' => $attendanceUsers[4]->id_absen_user,
+            'id_aktivitas' => $activityBeta->id_aktivitas,
+            'absen' => Absen::TEXT_TERLAMBAT,
+            'verification_status' => Absen::VERIFICATION_PENDING,
+        ]);
+
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->getJson('/api/admin-cabang/laporan/attendance/weekly/shelters?start_date=2024-01-01&end_date=2024-01-31');
+
+        $response->assertOk();
+
+        $payload = $response->json('data');
+
+        $this->assertSame('2024-01-01', $payload['filters']['start_date']);
+        $this->assertSame('2024-01-31', $payload['filters']['end_date']);
+        $this->assertCount(2, $payload['filters']['shelter_ids']);
+
+        $this->assertSame(2, $payload['metadata']['total_shelters']);
+        $this->assertSame(2, $payload['metadata']['total_activities']);
+        $this->assertSame(5, $payload['metadata']['total_sessions']);
+        $this->assertSame(2, $payload['metadata']['present_count']);
+        $this->assertSame(2, $payload['metadata']['late_count']);
+        $this->assertSame(1, $payload['metadata']['absent_count']);
+        $this->assertSame('80.00', $payload['metadata']['attendance_rate']);
+        $this->assertSame('40.00', $payload['metadata']['late_rate']);
+        $this->assertSame(5, $payload['metadata']['unique_children']);
+        $this->assertSame(2, $payload['metadata']['verification']['pending']);
+        $this->assertSame(1, $payload['metadata']['verification']['verified']);
+        $this->assertSame(1, $payload['metadata']['verification']['manual']);
+        $this->assertSame(1, $payload['metadata']['verification']['rejected']);
+
+        $shelters = collect($payload['shelters']);
+        $this->assertCount(2, $shelters);
+
+        $alpha = $shelters->firstWhere('name', 'Shelter Alpha');
+        $this->assertSame(3, $alpha['metrics']['total_sessions']);
+        $this->assertSame(1, $alpha['metrics']['present_count']);
+        $this->assertSame(1, $alpha['metrics']['late_count']);
+        $this->assertSame(1, $alpha['metrics']['absent_count']);
+        $this->assertSame('66.67', $alpha['metrics']['attendance_rate']);
+        $this->assertSame('33.33', $alpha['metrics']['late_rate']);
+        $this->assertSame(3, $alpha['metrics']['unique_children']);
+        $this->assertSame(1, $alpha['metrics']['verification']['verified']);
+        $this->assertSame(1, $alpha['metrics']['verification']['manual']);
+        $this->assertSame(1, $alpha['metrics']['verification']['rejected']);
+
+        $beta = $shelters->firstWhere('name', 'Shelter Beta');
+        $this->assertSame(2, $beta['metrics']['total_sessions']);
+        $this->assertSame(1, $beta['metrics']['present_count']);
+        $this->assertSame(1, $beta['metrics']['late_count']);
+        $this->assertSame(0, $beta['metrics']['absent_count']);
+        $this->assertSame('100.00', $beta['metrics']['attendance_rate']);
+        $this->assertSame('50.00', $beta['metrics']['late_rate']);
+        $this->assertSame(2, $beta['metrics']['unique_children']);
+        $this->assertSame(2, $beta['metrics']['verification']['pending']);
+    }
+
+    public function test_it_rejects_requesting_shelters_outside_of_cabang(): void
+    {
+        $user = User::create([
+            'username' => 'admin-cabang',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('secret'),
+            'level' => 'admin_cabang',
+        ]);
+
+        $kacab = Kacab::create([
+            'nama_kacab' => 'Cabang A',
+            'status' => 'aktif',
+        ]);
+
+        AdminCabang::create([
+            'user_id' => $user->id_users,
+            'id_kacab' => $kacab->id_kacab,
+            'nama_lengkap' => 'Admin Cabang',
+        ]);
+
+        $wilbin = Wilbin::create([
+            'id_kacab' => $kacab->id_kacab,
+            'nama_wilbin' => 'Wilbin 1',
+        ]);
+
+        $allowedShelter = Shelter::create([
+            'id_wilbin' => $wilbin->id_wilbin,
+            'nama_shelter' => 'Shelter Alpha',
+        ]);
+
+        $otherKacab = Kacab::create([
+            'nama_kacab' => 'Cabang B',
+            'status' => 'aktif',
+        ]);
+
+        $otherWilbin = Wilbin::create([
+            'id_kacab' => $otherKacab->id_kacab,
+            'nama_wilbin' => 'Wilbin 2',
+        ]);
+
+        $outsideShelter = Shelter::create([
+            'id_wilbin' => $otherWilbin->id_wilbin,
+            'nama_shelter' => 'Shelter Outside',
+        ]);
+
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->getJson('/api/admin-cabang/laporan/attendance/weekly/shelters?shelter_ids[]=' . $allowedShelter->id_shelter . '&shelter_ids[]=' . $outsideShelter->id_shelter);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['shelter_ids']);
+    }
+
+    public function test_it_handles_empty_shelter_collection_gracefully(): void
+    {
+        $user = User::create([
+            'username' => 'admin-cabang',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('secret'),
+            'level' => 'admin_cabang',
+        ]);
+
+        $kacab = Kacab::create([
+            'nama_kacab' => 'Cabang A',
+            'status' => 'aktif',
+        ]);
+
+        AdminCabang::create([
+            'user_id' => $user->id_users,
+            'id_kacab' => $kacab->id_kacab,
+            'nama_lengkap' => 'Admin Cabang',
+        ]);
+
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->getJson('/api/admin-cabang/laporan/attendance/weekly/shelters?start_date=2024-01-01&end_date=2024-01-31');
+
+        $response->assertOk();
+
+        $payload = $response->json('data');
+
+        $this->assertSame(0, $payload['metadata']['total_shelters']);
+        $this->assertSame(0, $payload['metadata']['total_sessions']);
+        $this->assertSame('0.00', $payload['metadata']['attendance_rate']);
+        $this->assertSame([], $payload['shelters']);
+    }
+}


### PR DESCRIPTION
## Summary
- register the weekly shelter attendance endpoint for admin cabang and return a dedicated resource payload
- extend the weekly attendance service to aggregate shelter-level metrics scoped to the authenticated cabang
- cover the new endpoint with feature tests for success, unauthorized filters, and empty datasets

## Testing
- ⚠️ `./vendor/bin/phpunit --filter AttendanceWeeklyShelterReportTest` *(fails: binary not present in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5237ecb1483238f7d32c2c480ee66