### PR TITLE
Add admin cabang shelter weekly attendance detail endpoint

### DIFF
--- a/backend/app/Http/Controllers/API/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterDetailController.php
+++ b/backend/app/Http/Controllers/API/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterDetailController.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Http\Controllers\API\AdminCabang\Reports\Attendance;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\AdminCabang\Reports\Attendance\AttendanceWeeklyShelterDetailResource;
+use App\Models\Shelter;
+use App\Services\AdminCabang\Reports\Attendance\WeeklyAttendanceService;
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use InvalidArgumentException;
+
+class AttendanceWeeklyShelterDetailController extends Controller
+{
+    public function __invoke(
+        Request $request,
+        Shelter $shelter,
+        WeeklyAttendanceService $service
+    ): JsonResponse {
+        $user = $request->user();
+        $adminCabang = $user?->adminCabang;
+
+        if (!$adminCabang) {
+            return response()->json([
+                'message' => __('Anda tidak memiliki akses sebagai admin cabang.'),
+            ], 403);
+        }
+
+        $kacab = $adminCabang->loadMissing('kacab')->kacab;
+        $accessibleShelterIds = $kacab
+            ? $kacab->shelters()->pluck('shelter.id_shelter')->all()
+            : [];
+
+        if (!in_array($shelter->id_shelter, $accessibleShelterIds, true)) {
+            return response()->json([
+                'message' => __('Anda tidak memiliki akses ke shelter ini.'),
+            ], 403);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'week' => ['nullable', 'string', 'regex:/^\d{4}-W\d{2}$/'],
+            'start_date' => ['nullable', 'date'],
+            'end_date' => ['nullable', 'date'],
+        ]);
+
+        $validator->after(function ($validator) use ($request) {
+            $week = $request->input('week');
+            if ($week) {
+                [$year, $weekNumber] = array_pad(explode('-W', $week), 2, null);
+                if (!is_numeric($year) || !is_numeric($weekNumber)) {
+                    $validator->errors()->add('week', __('Format minggu tidak valid.'));
+                    return;
+                }
+
+                try {
+                    Carbon::now()->setISODate((int) $year, (int) $weekNumber);
+                } catch (InvalidArgumentException $exception) {
+                    $validator->errors()->add('week', __('Format minggu tidak valid.'));
+                    return;
+                }
+            }
+
+            $start = $request->input('start_date');
+            $end = $request->input('end_date');
+
+            if ($start && $end && Carbon::parse($end)->lt(Carbon::parse($start))) {
+                $validator->errors()->add('end_date', __('validation.after_or_equal', [
+                    'attribute' => 'end date',
+                    'date' => 'start date',
+                ]));
+            }
+        });
+
+        $validated = $validator->validate();
+
+        $weekKey = $validated['week'] ?? null;
+
+        if ($weekKey) {
+            [$year, $weekNumber] = array_pad(explode('-W', $weekKey), 2, null);
+            $startDate = Carbon::now()->setISODate((int) $year, (int) $weekNumber)->startOfDay();
+            $endDate = $startDate->copy()->endOfWeek(Carbon::SUNDAY)->endOfDay();
+        } else {
+            $startDate = isset($validated['start_date'])
+                ? Carbon::parse($validated['start_date'])->startOfDay()
+                : Carbon::now()->startOfWeek(Carbon::MONDAY);
+
+            $endDate = isset($validated['end_date'])
+                ? Carbon::parse($validated['end_date'])->endOfDay()
+                : $startDate->copy()->endOfWeek(Carbon::SUNDAY)->endOfDay();
+        }
+
+        if ($endDate->lt($startDate)) {
+            $endDate = $startDate->copy()->endOfWeek(Carbon::SUNDAY)->endOfDay();
+        }
+
+        $report = $service->buildShelterWeeklyDetail(
+            $adminCabang,
+            $shelter,
+            $startDate,
+            $endDate,
+            [
+                'week' => $weekKey,
+            ]
+        );
+
+        return AttendanceWeeklyShelterDetailResource::make($report)->additional([
+            'message' => __('Detail laporan kehadiran mingguan shelter berhasil diambil.'),
+        ]);
+    }
+}

--- a/backend/app/Http/Resources/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterDetailResource.php
+++ b/backend/app/Http/Resources/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterDetailResource.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Http\Resources\AdminCabang\Reports\Attendance;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class AttendanceWeeklyShelterDetailResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        $data = (array) $this->resource;
+
+        $formatRate = static fn ($value): string => number_format((float) ($value ?? 0), 2, '.', '');
+
+        $formatVerification = static fn (array $verification): array => [
+            'pending' => (int) ($verification['pending'] ?? 0),
+            'verified' => (int) ($verification['verified'] ?? 0),
+            'rejected' => (int) ($verification['rejected'] ?? 0),
+            'manual' => (int) ($verification['manual'] ?? 0),
+        ];
+
+        $formatMetrics = function (array $metrics) use ($formatRate, $formatVerification): array {
+            return [
+                'present_count' => (int) ($metrics['present_count'] ?? 0),
+                'late_count' => (int) ($metrics['late_count'] ?? 0),
+                'absent_count' => (int) ($metrics['absent_count'] ?? 0),
+                'attendance_rate' => $formatRate($metrics['attendance_rate'] ?? 0),
+                'late_rate' => $formatRate($metrics['late_rate'] ?? 0),
+                'total_sessions' => (int) ($metrics['total_sessions'] ?? 0),
+                'total_activities' => (int) ($metrics['total_activities'] ?? 0),
+                'unique_children' => (int) ($metrics['unique_children'] ?? 0),
+                'verification' => $formatVerification($metrics['verification'] ?? []),
+            ];
+        };
+
+        $groups = collect($data['groups'] ?? [])->map(function ($group) use ($formatMetrics) {
+            $activities = collect($group['activities'] ?? [])->map(function ($activity) use ($formatMetrics) {
+                $metrics = $formatMetrics($activity['metrics'] ?? []);
+
+                return [
+                    'id' => $activity['id'] ?? null,
+                    'date' => $activity['date'] ?? null,
+                    'week' => $activity['week'] ?? null,
+                    'group_name' => $activity['group_name'] ?? null,
+                    'jenis_kegiatan' => $activity['jenis_kegiatan'] ?? null,
+                    'materi' => $activity['materi'] ?? null,
+                    'metrics' => $metrics,
+                ];
+            })->values()->all();
+
+            return [
+                'id' => $group['id'] ?? null,
+                'name' => $group['name'] ?? null,
+                'member_count' => isset($group['member_count']) ? (int) $group['member_count'] : null,
+                'metrics' => $formatMetrics($group['metrics'] ?? []),
+                'activities' => $activities,
+            ];
+        })->values()->all();
+
+        $activities = collect($data['activities'] ?? [])->map(function ($activity) use ($formatMetrics) {
+            return [
+                'id' => $activity['id'] ?? null,
+                'date' => $activity['date'] ?? null,
+                'week' => $activity['week'] ?? null,
+                'group_name' => $activity['group_name'] ?? null,
+                'jenis_kegiatan' => $activity['jenis_kegiatan'] ?? null,
+                'materi' => $activity['materi'] ?? null,
+                'metrics' => $formatMetrics($activity['metrics'] ?? []),
+            ];
+        })->values()->all();
+
+        $notes = collect($data['notes'] ?? [])->filter(fn ($note) => filled($note))->values()->all();
+
+        $filters = $data['filters'] ?? [];
+        $metrics = $data['metrics'] ?? [];
+        $shelter = $data['shelter'] ?? [];
+
+        return [
+            'shelter' => [
+                'id' => $shelter['id'] ?? null,
+                'name' => $shelter['name'] ?? null,
+                'wilbin' => $shelter['wilbin'] ?? null,
+                'wilbin_id' => $shelter['wilbin_id'] ?? null,
+            ],
+            'filters' => [
+                'week' => $filters['week'] ?? null,
+                'start_date' => $filters['start_date'] ?? null,
+                'end_date' => $filters['end_date'] ?? null,
+            ],
+            'metrics' => $formatMetrics($metrics),
+            'groups' => $groups,
+            'activities' => $activities,
+            'notes' => $notes,
+            'generated_at' => $data['generated_at'] ?? null,
+        ];
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,6 +3,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceWeeklyController;
 use App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceWeeklyShelterController;
+use App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceWeeklyShelterDetailController;
 
 
 Route::post('/auth/login', [App\Http\Controllers\API\AuthController::class, 'login']);
@@ -203,6 +204,7 @@ Route::middleware('auth:sanctum')->group(function () {
             Route::prefix('attendance')->group(function () {
                 Route::get('/weekly', AttendanceWeeklyController::class);
                 Route::get('/weekly/shelters', AttendanceWeeklyShelterController::class);
+                Route::get('/weekly/shelters/{shelter}', AttendanceWeeklyShelterDetailController::class);
                 Route::get('/monthly-shelter', App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceMonthlyShelterController::class);
                 Route::get('/monthly-branch', App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceMonthlyBranchController::class);
             });

--- a/backend/tests/Feature/AdminCabang/AttendanceWeeklyShelterDetailReportTest.php
+++ b/backend/tests/Feature/AdminCabang/AttendanceWeeklyShelterDetailReportTest.php
@@ -1,0 +1,434 @@
+<?php
+
+namespace Tests\Feature\AdminCabang;
+
+use App\Models\Absen;
+use App\Models\AbsenUser;
+use App\Models\AdminCabang;
+use App\Models\Aktivitas;
+use App\Models\Kacab;
+use App\Models\Kelompok;
+use App\Models\Shelter;
+use App\Models\User;
+use App\Models\Wilbin;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AttendanceWeeklyShelterDetailReportTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        DB::purge('sqlite');
+        DB::reconnect('sqlite');
+
+        Schema::dropIfExists('absen');
+        Schema::dropIfExists('absen_user');
+        Schema::dropIfExists('aktivitas');
+        Schema::dropIfExists('kelompok');
+        Schema::dropIfExists('shelter');
+        Schema::dropIfExists('wilbin');
+        Schema::dropIfExists('admin_cabang');
+        Schema::dropIfExists('kacab');
+        Schema::dropIfExists('users');
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->id('id_users');
+            $table->string('username');
+            $table->string('email')->nullable();
+            $table->string('password');
+            $table->string('level');
+            $table->timestamps();
+        });
+
+        Schema::create('kacab', function (Blueprint $table) {
+            $table->id('id_kacab');
+            $table->string('nama_kacab');
+            $table->string('status')->default('aktif');
+            $table->timestamps();
+        });
+
+        Schema::create('admin_cabang', function (Blueprint $table) {
+            $table->id('id_admin_cabang');
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('id_kacab');
+            $table->string('nama_lengkap')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('wilbin', function (Blueprint $table) {
+            $table->id('id_wilbin');
+            $table->unsignedBigInteger('id_kacab');
+            $table->string('nama_wilbin');
+            $table->timestamps();
+        });
+
+        Schema::create('shelter', function (Blueprint $table) {
+            $table->id('id_shelter');
+            $table->unsignedBigInteger('id_wilbin');
+            $table->string('nama_shelter');
+            $table->timestamps();
+        });
+
+        Schema::create('kelompok', function (Blueprint $table) {
+            $table->id('id_kelompok');
+            $table->unsignedBigInteger('id_shelter');
+            $table->string('nama_kelompok');
+            $table->unsignedBigInteger('id_level_anak_binaan')->nullable();
+            $table->unsignedInteger('jumlah_anggota')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('aktivitas', function (Blueprint $table) {
+            $table->id('id_aktivitas');
+            $table->unsignedBigInteger('id_shelter');
+            $table->unsignedBigInteger('id_tutor')->nullable();
+            $table->string('nama_kelompok')->nullable();
+            $table->string('jenis_kegiatan')->nullable();
+            $table->string('materi')->nullable();
+            $table->date('tanggal');
+            $table->timestamps();
+        });
+
+        Schema::create('absen_user', function (Blueprint $table) {
+            $table->id('id_absen_user');
+            $table->unsignedBigInteger('id_anak')->nullable();
+            $table->unsignedBigInteger('id_tutor')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('absen', function (Blueprint $table) {
+            $table->id('id_absen');
+            $table->unsignedBigInteger('id_absen_user')->nullable();
+            $table->unsignedBigInteger('id_aktivitas');
+            $table->string('absen');
+            $table->string('verification_status')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('absen');
+        Schema::dropIfExists('absen_user');
+        Schema::dropIfExists('aktivitas');
+        Schema::dropIfExists('kelompok');
+        Schema::dropIfExists('shelter');
+        Schema::dropIfExists('wilbin');
+        Schema::dropIfExists('admin_cabang');
+        Schema::dropIfExists('kacab');
+        Schema::dropIfExists('users');
+
+        parent::tearDown();
+    }
+
+    public function test_it_returns_weekly_shelter_detail_report(): void
+    {
+        $user = User::create([
+            'username' => 'admin-cabang',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('secret'),
+            'level' => 'admin_cabang',
+        ]);
+
+        $kacab = Kacab::create([
+            'nama_kacab' => 'Cabang Utama',
+            'status' => 'aktif',
+        ]);
+
+        AdminCabang::create([
+            'user_id' => $user->id_users,
+            'id_kacab' => $kacab->id_kacab,
+            'nama_lengkap' => 'Admin Cabang',
+        ]);
+
+        $wilbin = Wilbin::create([
+            'id_kacab' => $kacab->id_kacab,
+            'nama_wilbin' => 'Wilbin 1',
+        ]);
+
+        $shelter = Shelter::create([
+            'id_wilbin' => $wilbin->id_wilbin,
+            'nama_shelter' => 'Shelter Alpha',
+        ]);
+
+        $kelompokAlpha = Kelompok::create([
+            'id_shelter' => $shelter->id_shelter,
+            'nama_kelompok' => 'Kelompok Alpha',
+            'jumlah_anggota' => 15,
+        ]);
+
+        $kelompokBeta = Kelompok::create([
+            'id_shelter' => $shelter->id_shelter,
+            'nama_kelompok' => 'Kelompok Beta',
+            'jumlah_anggota' => 12,
+        ]);
+
+        $activityAlpha = Aktivitas::create([
+            'id_shelter' => $shelter->id_shelter,
+            'nama_kelompok' => $kelompokAlpha->nama_kelompok,
+            'jenis_kegiatan' => 'Pertemuan Rutin',
+            'materi' => 'Matematika',
+            'tanggal' => '2024-01-03',
+        ]);
+
+        $activityBeta = Aktivitas::create([
+            'id_shelter' => $shelter->id_shelter,
+            'nama_kelompok' => $kelompokBeta->nama_kelompok,
+            'jenis_kegiatan' => 'Kelas Tambahan',
+            'materi' => 'Bahasa',
+            'tanggal' => '2024-01-04',
+        ]);
+
+        $activityOther = Aktivitas::create([
+            'id_shelter' => $shelter->id_shelter,
+            'nama_kelompok' => 'Kelompok Gamma',
+            'jenis_kegiatan' => 'Sesi Khusus',
+            'materi' => 'Seni',
+            'tanggal' => '2024-01-05',
+        ]);
+
+        $attendanceUsers = [
+            AbsenUser::create(['id_anak' => 501]),
+            AbsenUser::create(['id_anak' => 502]),
+            AbsenUser::create(['id_anak' => 503]),
+            AbsenUser::create(['id_anak' => 504]),
+            AbsenUser::create(['id_anak' => 505]),
+        ];
+
+        Absen::create([
+            'id_absen_user' => $attendanceUsers[0]->id_absen_user,
+            'id_aktivitas' => $activityAlpha->id_aktivitas,
+            'absen' => Absen::TEXT_YA,
+            'verification_status' => Absen::VERIFICATION_VERIFIED,
+        ]);
+
+        Absen::create([
+            'id_absen_user' => $attendanceUsers[1]->id_absen_user,
+            'id_aktivitas' => $activityAlpha->id_aktivitas,
+            'absen' => Absen::TEXT_TERLAMBAT,
+            'verification_status' => Absen::VERIFICATION_MANUAL,
+        ]);
+
+        Absen::create([
+            'id_absen_user' => $attendanceUsers[2]->id_absen_user,
+            'id_aktivitas' => $activityBeta->id_aktivitas,
+            'absen' => Absen::TEXT_YA,
+            'verification_status' => Absen::VERIFICATION_PENDING,
+        ]);
+
+        Absen::create([
+            'id_absen_user' => $attendanceUsers[3]->id_absen_user,
+            'id_aktivitas' => $activityBeta->id_aktivitas,
+            'absen' => Absen::TEXT_TIDAK,
+            'verification_status' => Absen::VERIFICATION_REJECTED,
+        ]);
+
+        Absen::create([
+            'id_absen_user' => $attendanceUsers[4]->id_absen_user,
+            'id_aktivitas' => $activityOther->id_aktivitas,
+            'absen' => Absen::TEXT_YA,
+            'verification_status' => Absen::VERIFICATION_VERIFIED,
+        ]);
+
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->getJson(sprintf(
+            '/api/admin-cabang/laporan/attendance/weekly/shelters/%d?week=2024-W01',
+            $shelter->id_shelter
+        ));
+
+        $response->assertOk();
+        $response->assertJsonFragment([
+            'message' => 'Detail laporan kehadiran mingguan shelter berhasil diambil.',
+        ]);
+
+        $payload = $response->json('data');
+
+        $this->assertSame($shelter->id_shelter, $payload['shelter']['id']);
+        $this->assertSame('2024-W01', $payload['filters']['week']);
+        $this->assertSame(5, $payload['metrics']['total_sessions']);
+        $this->assertSame(3, $payload['metrics']['present_count']);
+        $this->assertSame(1, $payload['metrics']['late_count']);
+        $this->assertSame(1, $payload['metrics']['absent_count']);
+        $this->assertSame(3, $payload['metrics']['total_activities']);
+        $this->assertSame(4, $payload['metrics']['unique_children']);
+
+        $alphaGroup = collect($payload['groups'])->firstWhere('id', $kelompokAlpha->id_kelompok);
+        $this->assertNotNull($alphaGroup);
+        $this->assertSame(1, $alphaGroup['metrics']['total_activities']);
+        $this->assertSame(2, $alphaGroup['metrics']['total_sessions']);
+        $this->assertSame(1, $alphaGroup['metrics']['present_count']);
+        $this->assertSame(1, $alphaGroup['metrics']['late_count']);
+        $this->assertSame(0, $alphaGroup['metrics']['absent_count']);
+
+        $betaGroup = collect($payload['groups'])->firstWhere('id', $kelompokBeta->id_kelompok);
+        $this->assertNotNull($betaGroup);
+        $this->assertSame(1, $betaGroup['metrics']['total_activities']);
+        $this->assertSame(2, $betaGroup['metrics']['total_sessions']);
+        $this->assertSame(1, $betaGroup['metrics']['present_count']);
+        $this->assertSame(0, $betaGroup['metrics']['late_count']);
+        $this->assertSame(1, $betaGroup['metrics']['absent_count']);
+
+        $unmappedGroup = collect($payload['groups'])->firstWhere('name', 'Kelompok Gamma');
+        $this->assertNotNull($unmappedGroup);
+        $this->assertNull($unmappedGroup['id']);
+        $this->assertSame(1, $unmappedGroup['metrics']['total_sessions']);
+        $this->assertSame(1, $unmappedGroup['metrics']['present_count']);
+
+        $this->assertCount(3, $payload['activities']);
+        $this->assertNotEmpty($payload['notes']);
+    }
+
+    public function test_it_denies_access_to_foreign_shelter(): void
+    {
+        $user = User::create([
+            'username' => 'admin-cabang',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('secret'),
+            'level' => 'admin_cabang',
+        ]);
+
+        $kacabA = Kacab::create([
+            'nama_kacab' => 'Cabang A',
+            'status' => 'aktif',
+        ]);
+
+        $kacabB = Kacab::create([
+            'nama_kacab' => 'Cabang B',
+            'status' => 'aktif',
+        ]);
+
+        AdminCabang::create([
+            'user_id' => $user->id_users,
+            'id_kacab' => $kacabA->id_kacab,
+            'nama_lengkap' => 'Admin Cabang',
+        ]);
+
+        $wilbinA = Wilbin::create([
+            'id_kacab' => $kacabA->id_kacab,
+            'nama_wilbin' => 'Wilbin A',
+        ]);
+
+        $wilbinB = Wilbin::create([
+            'id_kacab' => $kacabB->id_kacab,
+            'nama_wilbin' => 'Wilbin B',
+        ]);
+
+        $ownedShelter = Shelter::create([
+            'id_wilbin' => $wilbinA->id_wilbin,
+            'nama_shelter' => 'Shelter Milik',
+        ]);
+
+        $foreignShelter = Shelter::create([
+            'id_wilbin' => $wilbinB->id_wilbin,
+            'nama_shelter' => 'Shelter Lain',
+        ]);
+
+        Kelompok::create([
+            'id_shelter' => $ownedShelter->id_shelter,
+            'nama_kelompok' => 'Kelompok A',
+        ]);
+
+        Kelompok::create([
+            'id_shelter' => $foreignShelter->id_shelter,
+            'nama_kelompok' => 'Kelompok B',
+        ]);
+
+        Sanctum::actingAs($user, ['*']);
+
+        $this->getJson(sprintf(
+            '/api/admin-cabang/laporan/attendance/weekly/shelters/%d?week=2024-W01',
+            $foreignShelter->id_shelter
+        ))->assertForbidden()->assertJsonFragment([
+            'message' => 'Anda tidak memiliki akses ke shelter ini.',
+        ]);
+    }
+
+    public function test_it_returns_not_found_when_shelter_missing(): void
+    {
+        $user = User::create([
+            'username' => 'admin-cabang',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('secret'),
+            'level' => 'admin_cabang',
+        ]);
+
+        $kacab = Kacab::create([
+            'nama_kacab' => 'Cabang Utama',
+            'status' => 'aktif',
+        ]);
+
+        AdminCabang::create([
+            'user_id' => $user->id_users,
+            'id_kacab' => $kacab->id_kacab,
+            'nama_lengkap' => 'Admin Cabang',
+        ]);
+
+        Sanctum::actingAs($user, ['*']);
+
+        $this->getJson('/api/admin-cabang/laporan/attendance/weekly/shelters/999?week=2024-W01')
+            ->assertNotFound();
+    }
+
+    public function test_it_returns_empty_state_for_week_without_activities(): void
+    {
+        $user = User::create([
+            'username' => 'admin-cabang',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('secret'),
+            'level' => 'admin_cabang',
+        ]);
+
+        $kacab = Kacab::create([
+            'nama_kacab' => 'Cabang Utama',
+            'status' => 'aktif',
+        ]);
+
+        AdminCabang::create([
+            'user_id' => $user->id_users,
+            'id_kacab' => $kacab->id_kacab,
+            'nama_lengkap' => 'Admin Cabang',
+        ]);
+
+        $wilbin = Wilbin::create([
+            'id_kacab' => $kacab->id_kacab,
+            'nama_wilbin' => 'Wilbin 1',
+        ]);
+
+        $shelter = Shelter::create([
+            'id_wilbin' => $wilbin->id_wilbin,
+            'nama_shelter' => 'Shelter Alpha',
+        ]);
+
+        Kelompok::create([
+            'id_shelter' => $shelter->id_shelter,
+            'nama_kelompok' => 'Kelompok Alpha',
+        ]);
+
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->getJson(sprintf(
+            '/api/admin-cabang/laporan/attendance/weekly/shelters/%d?week=2024-W05',
+            $shelter->id_shelter
+        ));
+
+        $response->assertOk();
+
+        $payload = $response->json('data');
+        $this->assertSame(0, $payload['metrics']['total_sessions']);
+        $this->assertSame(0, $payload['metrics']['total_activities']);
+        $this->assertSame(0, $payload['metrics']['present_count']);
+        $this->assertSame(0, $payload['metrics']['late_count']);
+        $this->assertSame(0, $payload['metrics']['absent_count']);
+        $this->assertEmpty($payload['activities']);
+        $this->assertContains('Tidak ada aktivitas yang tercatat pada rentang tanggal ini.', $payload['notes']);
+    }
+}


### PR DESCRIPTION
## Summary
- register the new weekly shelter detail route for admin cabang attendance reports and add a controller to validate access and parse the requested week
- extend the weekly attendance service and introduce a resource to assemble and serialize per-group and per-activity metrics for the selected shelter
- cover the drill-down flow, unauthorized access, missing shelters, and empty-week cases with feature tests

## Testing
- `phpunit --filter AttendanceWeeklyShelterDetailReportTest` *(fails: vendor/bin/phpunit not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5bcb8a7c883239c49e0588a0f4e42