### PR TITLE
Ensure weekly attendance report returns JsonResponse

### DIFF
--- a/backend/app/Http/Controllers/API/AdminCabang/Reports/Attendance/AttendanceWeeklyController.php
+++ b/backend/app/Http/Controllers/API/AdminCabang/Reports/Attendance/AttendanceWeeklyController.php
@@ -52,8 +52,10 @@ class AttendanceWeeklyController extends Controller
             'end_date' => $endDate,
         ]);
 
-        return AttendanceWeeklyResource::make($report)->additional([
-            'message' => __('Laporan kehadiran mingguan berhasil diambil.'),
-        ]);
+        return AttendanceWeeklyResource::make($report)
+            ->additional([
+                'message' => __('Laporan kehadiran mingguan berhasil diambil.'),
+            ])
+            ->toResponse($request);
     }
 }


### PR DESCRIPTION
## Summary
- return the weekly attendance report resource as a proper JsonResponse

## Testing
- php artisan test --filter=AttendanceWeekly --stop-on-failure *(fails: missing vendor autoloader in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c414f9448323bcf3365d9cea7acc