### PR TITLE
Fix weekly shelter report response type

### DIFF
--- a/backend/app/Http/Controllers/API/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterController.php
+++ b/backend/app/Http/Controllers/API/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterController.php
@@ -78,8 +78,10 @@ class AttendanceWeeklyShelterController extends Controller
             'shelter_ids' => $filteredShelterIds,
         ]);
 
-        return AttendanceWeeklyShelterResource::make($report)->additional([
-            'message' => __('Laporan kehadiran mingguan per shelter berhasil diambil.'),
-        ]);
+        return AttendanceWeeklyShelterResource::make($report)
+            ->additional([
+                'message' => __('Laporan kehadiran mingguan per shelter berhasil diambil.'),
+            ])
+            ->toResponse($request);
     }
 }


### PR DESCRIPTION
## Summary
- ensure the weekly shelter attendance report resource returns a JsonResponse by invoking toResponse on the resource

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5c6a8192883238846292001e5327a