### PR TITLE
Ensure weekly shelter attendance detail returns JsonResponse

### DIFF
--- a/backend/app/Http/Controllers/API/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterDetailController.php
+++ b/backend/app/Http/Controllers/API/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterDetailController.php
@@ -105,8 +105,10 @@ class AttendanceWeeklyShelterDetailController extends Controller
             ]
         );
 
-        return AttendanceWeeklyShelterDetailResource::make($report)->additional([
-            'message' => __('Detail laporan kehadiran mingguan shelter berhasil diambil.'),
-        ]);
+        return AttendanceWeeklyShelterDetailResource::make($report)
+            ->additional([
+                'message' => __('Detail laporan kehadiran mingguan shelter berhasil diambil.'),
+            ])
+            ->toResponse($request);
     }
 }


### PR DESCRIPTION
## Summary
- ensure the weekly shelter attendance detail API resource converts to a JsonResponse before returning

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5c7d9460c832380b193e499e9f646