### PR TITLE
Integrate weekly attendance API and enhance breakdown UI

### DIFF
--- a/frontend/src/features/adminCabang/components/reports/attendance/WeeklyBreakdownList.js
+++ b/frontend/src/features/adminCabang/components/reports/attendance/WeeklyBreakdownList.js
@@ -1,15 +1,74 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 
-const WeeklyBreakdownList = ({ data }) => {
+const SummaryItem = ({ label, count, percentage, accentColor }) => {
+  const countLabel =
+    typeof count === 'number' ? count.toLocaleString('id-ID') : count ?? '-';
+  const percentageLabel =
+    typeof percentage === 'number' ? `${percentage}%` : percentage ?? null;
+
+  return (
+    <View style={styles.summaryItem}>
+      <Text style={styles.summaryLabel}>{label}</Text>
+      <Text style={[styles.summaryCount, accentColor ? { color: accentColor } : null]}>
+        {countLabel}
+      </Text>
+      {percentageLabel ? (
+        <Text style={styles.summaryPercentage}>{percentageLabel}</Text>
+      ) : null}
+    </View>
+  );
+};
+
+const StateMessage = ({ title, description, actionLabel, onAction, loading }) => (
+  <View style={styles.stateContainer}>
+    {loading ? (
+      <ActivityIndicator size="small" color="#0984e3" style={styles.stateIndicator} />
+    ) : null}
+    {title ? <Text style={styles.stateTitle}>{title}</Text> : null}
+    {description ? <Text style={styles.stateDescription}>{description}</Text> : null}
+    {actionLabel && onAction ? (
+      <TouchableOpacity onPress={onAction} style={styles.retryButton}>
+        <Text style={styles.retryButtonLabel}>{actionLabel}</Text>
+      </TouchableOpacity>
+    ) : null}
+  </View>
+);
+
+const WeeklyBreakdownList = ({ data, isLoading, error, onRetry }) => {
+  if (isLoading) {
+    return (
+      <StateMessage
+        loading
+        title="Memuat rekap mingguan"
+        description="Harap tunggu, kami sedang menyiapkan data terbaru."
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <StateMessage
+        title="Gagal memuat data"
+        description={error}
+        actionLabel="Coba lagi"
+        onAction={onRetry}
+      />
+    );
+  }
+
   if (!data || data.length === 0) {
     return (
-      <View style={styles.emptyState}>
-        <Text style={styles.emptyTitle}>Belum ada data mingguan</Text>
-        <Text style={styles.emptyDescription}>
-          Ringkasan mingguan akan muncul di sini setelah integrasi data selesai.
-        </Text>
-      </View>
+      <StateMessage
+        title="Belum ada data mingguan"
+        description="Ringkasan mingguan akan muncul di sini setelah data tersedia."
+      />
     );
   }
 
@@ -17,21 +76,88 @@ const WeeklyBreakdownList = ({ data }) => {
     <View>
       {data.map((item, index) => {
         const attendanceRate =
-          typeof item.attendanceRate === 'number' ? `${item.attendanceRate}%` : '-';
+          typeof item?.attendanceRate === 'number' ? `${item.attendanceRate}%` : '-';
+
+        const weekLabel = item?.label || item?.weekLabel || `Minggu ${index + 1}`;
+        const dateRangeLabel = item?.dates?.label ?? item?.dateRange ?? null;
+
+        const present = item?.summary?.present ?? {};
+        const late = item?.summary?.late ?? {};
+        const absent = item?.summary?.absent ?? {};
+
+        const pendingVerification = item?.verification?.pending ?? 0;
+        const hasPendingVerification = Number(pendingVerification) > 0;
+
+        const lateCount = Number.isFinite(late?.count) ? late.count : 0;
+        const hasLate = lateCount > 0;
+
+        const verifiedCount = item?.verification?.verified ?? 0;
+        const totalVerification = item?.verification?.total ?? null;
 
         return (
           <View
-            key={item.id || index}
+            key={item?.id || `week-${index}`}
             style={[styles.item, index === data.length - 1 && styles.lastItem]}
           >
             <View style={styles.itemHeader}>
-              <Text style={styles.itemTitle}>{item.weekLabel || `Minggu ${index + 1}`}</Text>
-              <Text style={styles.itemRate}>{attendanceRate}</Text>
+              <View style={styles.itemHeaderText}>
+                <Text style={styles.itemTitle}>{weekLabel}</Text>
+                {dateRangeLabel ? (
+                  <Text style={styles.itemSubtitle}>{dateRangeLabel}</Text>
+                ) : null}
+              </View>
+              <View style={styles.itemRateContainer}>
+                <Text style={styles.itemRate}>{attendanceRate}</Text>
+                <Text style={styles.itemRateCaption}>Rata-rata hadir</Text>
+              </View>
             </View>
-            <Text style={styles.itemDescription}>
-              {`${item.presentCount ?? '-'} hadir dari ${item.totalSessions ?? '-'} sesi`} ·
-              {` ${item.absentCount ?? '-'} absen`}
-            </Text>
+
+            {(hasLate || hasPendingVerification) && (
+              <View style={styles.badgesRow}>
+                {hasLate ? (
+                  <View style={[styles.badge, styles.badgeLate]}>
+                    <Text style={styles.badgeText}>{`${lateCount} terlambat`}</Text>
+                  </View>
+                ) : null}
+                {hasPendingVerification ? (
+                  <View style={[styles.badge, styles.badgePending]}>
+                    <Text style={styles.badgeText}>{`${pendingVerification} pending`}</Text>
+                  </View>
+                ) : null}
+              </View>
+            )}
+
+            <View style={styles.summaryRow}>
+              <SummaryItem
+                label="Hadir"
+                count={present?.count ?? '-'}
+                percentage={present?.percentage}
+                accentColor="#00b894"
+              />
+              <SummaryItem
+                label="Terlambat"
+                count={late?.count ?? '-'}
+                percentage={late?.percentage}
+                accentColor="#f39c12"
+              />
+              <SummaryItem
+                label="Absen"
+                count={absent?.count ?? '-'}
+                percentage={absent?.percentage}
+                accentColor="#d63031"
+              />
+            </View>
+
+            <View style={styles.verificationRow}>
+              <Text style={styles.verificationLabel}>Verifikasi</Text>
+              <Text style={styles.verificationValue}>
+                {`${verifiedCount} selesai`}
+                {hasPendingVerification ? ` · ${pendingVerification} menunggu` : ''}
+                {Number.isFinite(totalVerification) && totalVerification !== null
+                  ? ` · ${totalVerification} total`
+                  : ''}
+              </Text>
+            </View>
           </View>
         );
       })}
@@ -41,18 +167,25 @@ const WeeklyBreakdownList = ({ data }) => {
 
 WeeklyBreakdownList.defaultProps = {
   data: [],
+  isLoading: false,
+  error: null,
+  onRetry: undefined,
 };
 
 const styles = StyleSheet.create({
   item: {
-    paddingVertical: 8,
+    paddingVertical: 12,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: '#dfe6e9',
   },
   itemHeader: {
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     justifyContent: 'space-between',
+  },
+  itemHeaderText: {
+    flex: 1,
+    paddingRight: 12,
   },
   lastItem: {
     borderBottomWidth: 0,
@@ -62,28 +195,117 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#2d3436',
   },
+  itemSubtitle: {
+    marginTop: 2,
+    fontSize: 12,
+    color: '#636e72',
+  },
+  itemRateContainer: {
+    alignItems: 'flex-end',
+  },
   itemRate: {
-    fontSize: 15,
-    fontWeight: '600',
+    fontSize: 16,
+    fontWeight: '700',
     color: '#00b894',
   },
-  itemDescription: {
-    fontSize: 13,
+  itemRateCaption: {
+    fontSize: 11,
     color: '#636e72',
-    marginTop: 4,
+    marginTop: 2,
   },
-  emptyState: {
-    paddingVertical: 12,
+  badgesRow: {
+    flexDirection: 'row',
+    marginTop: 8,
+    flexWrap: 'wrap',
   },
-  emptyTitle: {
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 12,
+    marginRight: 8,
+    marginBottom: 4,
+  },
+  badgeLate: {
+    backgroundColor: 'rgba(243, 156, 18, 0.12)',
+  },
+  badgePending: {
+    backgroundColor: 'rgba(9, 132, 227, 0.12)',
+  },
+  badgeText: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#2d3436',
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 12,
+  },
+  summaryItem: {
+    flex: 1,
+    alignItems: 'flex-start',
+  },
+  summaryLabel: {
+    fontSize: 11,
+    color: '#636e72',
+    marginBottom: 4,
+  },
+  summaryCount: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#2d3436',
+  },
+  summaryPercentage: {
+    fontSize: 12,
+    color: '#636e72',
+    marginTop: 2,
+  },
+  verificationRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 12,
+  },
+  verificationLabel: {
+    fontSize: 12,
+    color: '#636e72',
+    fontWeight: '600',
+  },
+  verificationValue: {
+    fontSize: 12,
+    color: '#2d3436',
+  },
+  stateContainer: {
+    alignItems: 'center',
+    paddingVertical: 16,
+  },
+  stateIndicator: {
+    marginBottom: 8,
+  },
+  stateTitle: {
     fontSize: 15,
     fontWeight: '600',
     color: '#2d3436',
-    marginBottom: 4,
+    textAlign: 'center',
   },
-  emptyDescription: {
+  stateDescription: {
     fontSize: 13,
     color: '#636e72',
+    textAlign: 'center',
+    marginTop: 6,
+    paddingHorizontal: 8,
+  },
+  retryButton: {
+    marginTop: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    backgroundColor: '#0984e3',
+    borderRadius: 8,
+  },
+  retryButtonLabel: {
+    color: '#ffffff',
+    fontWeight: '600',
+    fontSize: 13,
   },
 });
 

--- a/frontend/src/features/adminCabang/hooks/reports/attendance/useAttendanceWeekly.js
+++ b/frontend/src/features/adminCabang/hooks/reports/attendance/useAttendanceWeekly.js
@@ -1,52 +1,317 @@
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-const DUMMY_WEEKLY = [
-  {
-    id: 'week-1',
-    weekLabel: 'Minggu 1 (1-7 Sep)',
-    attendanceRate: 90,
-    presentCount: 228,
-    totalSessions: 252,
-    absentCount: 24,
-  },
-  {
-    id: 'week-2',
-    weekLabel: 'Minggu 2 (8-14 Sep)',
-    attendanceRate: 93,
-    presentCount: 236,
-    totalSessions: 254,
-    absentCount: 18,
-  },
-  {
-    id: 'week-3',
-    weekLabel: 'Minggu 3 (15-21 Sep)',
-    attendanceRate: 89,
-    presentCount: 221,
-    totalSessions: 248,
-    absentCount: 27,
-  },
-  {
-    id: 'week-4',
-    weekLabel: 'Minggu 4 (22-30 Sep)',
-    attendanceRate: 95,
-    presentCount: 243,
-    totalSessions: 256,
-    absentCount: 13,
-  },
-];
+import { adminCabangReportApi } from '../../../api/adminCabangReportApi';
 
-export const useAttendanceWeekly = () => {
-  const state = useMemo(
-    () => ({
-      data: DUMMY_WEEKLY,
-      isLoading: false,
-      error: null,
-      refetch: () => {},
-    }),
+const clampPercentage = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const numberValue = Number(value);
+
+  if (!Number.isFinite(numberValue)) {
+    return null;
+  }
+
+  if (numberValue <= 0) {
+    return 0;
+  }
+
+  if (numberValue >= 100) {
+    return 100;
+  }
+
+  return Math.round(numberValue * 10) / 10;
+};
+
+const toNumber = (value, fallback = 0) => {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+
+  const numberValue = Number(value);
+
+  if (Number.isNaN(numberValue)) {
+    return fallback;
+  }
+
+  return numberValue;
+};
+
+const calculatePercentage = (count, total) => {
+  const normalizedTotal = toNumber(total, 0);
+  const normalizedCount = toNumber(count, 0);
+
+  if (normalizedTotal <= 0) {
+    return null;
+  }
+
+  return clampPercentage((normalizedCount / normalizedTotal) * 100);
+};
+
+const formatDateRange = (startDate, endDate) => {
+  if (!startDate && !endDate) {
+    return null;
+  }
+
+  try {
+    const formatter = new Intl.DateTimeFormat('id-ID', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+
+    if (startDate && endDate) {
+      return `${formatter.format(new Date(startDate))} - ${formatter.format(new Date(endDate))}`;
+    }
+
+    const singleDate = startDate || endDate;
+
+    return formatter.format(new Date(singleDate));
+  } catch (err) {
+    console.warn('Failed to format weekly attendance date range:', err);
+    return null;
+  }
+};
+
+const extractWeeklyPayload = (responseData) => {
+  if (!responseData) {
+    return [];
+  }
+
+  const candidates = [
+    responseData,
+    responseData?.data,
+    responseData?.data?.data,
+    responseData?.result,
+    responseData?.payload,
+    responseData?.items,
+  ];
+
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) {
+      return candidate;
+    }
+  }
+
+  const collections = [
+    responseData?.weeks,
+    responseData?.data?.weeks,
+    responseData?.data?.data?.weeks,
+  ];
+
+  for (const collection of collections) {
+    if (Array.isArray(collection)) {
+      return collection;
+    }
+  }
+
+  return [];
+};
+
+const normalizeWeeklyData = (responseData) => {
+  const weeklyItems = extractWeeklyPayload(responseData);
+
+  return weeklyItems.map((item, index) => {
+    const id = item?.id ?? item?.week_id ?? item?.weekId ?? `week-${index + 1}`;
+    const weekLabel =
+      item?.weekLabel ?? item?.week_label ?? item?.label ?? item?.title ?? `Minggu ${index + 1}`;
+
+    const startDate = item?.startDate ?? item?.start_date ?? item?.start ?? null;
+    const endDate = item?.endDate ?? item?.end_date ?? item?.end ?? null;
+    const dateRangeLabel =
+      item?.dateRange ?? item?.date_range ?? item?.dates ?? formatDateRange(startDate, endDate);
+
+    const presentCount = toNumber(
+      item?.presentCount ?? item?.present_count ?? item?.present ?? item?.hadir,
+      0
+    );
+    const lateCount = toNumber(
+      item?.lateCount ?? item?.late_count ?? item?.late ?? item?.terlambat,
+      0
+    );
+    const absentCount = toNumber(
+      item?.absentCount ?? item?.absent_count ?? item?.absent ?? item?.alpha,
+      0
+    );
+
+    const totalSessions = (() => {
+      const explicitTotal =
+        item?.totalSessions ??
+        item?.total_sessions ??
+        item?.total ??
+        item?.totalChildren ??
+        item?.total_children;
+
+      if (explicitTotal !== undefined && explicitTotal !== null) {
+        return toNumber(explicitTotal, presentCount + lateCount + absentCount);
+      }
+
+      return presentCount + lateCount + absentCount;
+    })();
+
+    const attendanceRate = clampPercentage(
+      item?.attendanceRate ??
+        item?.attendance_rate ??
+        item?.attendancePercentage ??
+        item?.attendance_percentage ??
+        calculatePercentage(presentCount, totalSessions)
+    );
+
+    const summary = {
+      present: {
+        count: presentCount,
+        percentage: calculatePercentage(presentCount, totalSessions),
+      },
+      late: {
+        count: lateCount,
+        percentage: calculatePercentage(lateCount, totalSessions),
+      },
+      absent: {
+        count: absentCount,
+        percentage: calculatePercentage(absentCount, totalSessions),
+      },
+    };
+
+    const verificationData = item?.verification ?? {};
+
+    const verifiedCount = toNumber(
+      verificationData?.verified ??
+        verificationData?.approved ??
+        item?.verifiedCount ??
+        item?.verified_count,
+      0
+    );
+    const pendingCount = toNumber(
+      verificationData?.pending ??
+        verificationData?.waiting ??
+        item?.pendingCount ??
+        item?.pending_count ??
+        item?.pendingVerification ??
+        item?.pending_verification,
+      0
+    );
+    const rejectedCount = toNumber(
+      verificationData?.rejected ??
+        verificationData?.declined ??
+        item?.rejectedCount ??
+        item?.rejected_count,
+      0
+    );
+
+    const verificationTotal = (() => {
+      const totalFromItem =
+        verificationData?.total ??
+        item?.verificationTotal ??
+        item?.verification_total ??
+        item?.totalVerifications ??
+        item?.total_verifications;
+
+      if (totalFromItem !== undefined && totalFromItem !== null) {
+        return toNumber(totalFromItem, verifiedCount + pendingCount + rejectedCount);
+      }
+
+      return verifiedCount + pendingCount + rejectedCount;
+    })();
+
+    return {
+      id,
+      label: weekLabel,
+      dates: {
+        start: startDate,
+        end: endDate,
+        label: dateRangeLabel,
+      },
+      attendanceRate,
+      totals: {
+        sessions: totalSessions,
+      },
+      summary,
+      verification: {
+        total: verificationTotal,
+        verified: verifiedCount,
+        pending: pendingCount,
+        rejected: rejectedCount,
+      },
+    };
+  });
+};
+
+export const useAttendanceWeekly = (params = {}) => {
+  const paramsRef = useRef(params);
+  paramsRef.current = params;
+
+  const isMountedRef = useRef(true);
+
+  const [data, setData] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchWeeklyData = useCallback(
+    async (overrideParams = {}) => {
+      if (isMountedRef.current) {
+        setIsLoading(true);
+        setError(null);
+      }
+
+      try {
+        const response = await adminCabangReportApi.getAttendanceWeekly({
+          ...paramsRef.current,
+          ...overrideParams,
+        });
+
+        const normalizedData = normalizeWeeklyData(response?.data);
+
+        if (isMountedRef.current) {
+          setData(normalizedData);
+        }
+
+        return normalizedData;
+      } catch (err) {
+        const message =
+          err?.response?.data?.message ||
+          err?.message ||
+          'Gagal memuat rekap kehadiran mingguan';
+
+        if (isMountedRef.current) {
+          setError(message);
+          setData([]);
+        }
+
+        return null;
+      } finally {
+        if (isMountedRef.current) {
+          setIsLoading(false);
+        }
+      }
+    },
     []
   );
 
-  return state;
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const serializedParams = useMemo(() => JSON.stringify(params ?? {}), [params]);
+
+  useEffect(() => {
+    fetchWeeklyData();
+  }, [fetchWeeklyData, serializedParams]);
+
+  const refetch = useCallback((overrideParams = {}) => fetchWeeklyData(overrideParams), [
+    fetchWeeklyData,
+  ]);
+
+  return {
+    data,
+    isLoading,
+    error,
+    refetch,
+  };
 };
 
 export default useAttendanceWeekly;

--- a/frontend/src/features/adminCabang/screens/reports/attendance/AdminCabangAttendanceReportScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/attendance/AdminCabangAttendanceReportScreen.js
@@ -14,7 +14,12 @@ import useAttendanceTrend from '../../../hooks/reports/attendance/useAttendanceT
 
 const AdminCabangAttendanceReportScreen = () => {
   const { data: summaryData } = useAttendanceSummary();
-  const { data: weeklyData } = useAttendanceWeekly();
+  const {
+    data: weeklyData,
+    isLoading: isWeeklyLoading,
+    error: weeklyError,
+    refetch: refetchWeekly,
+  } = useAttendanceWeekly();
   const { data: shelterData } = useAttendanceMonthlyShelter();
   const { data: trendData } = useAttendanceTrend();
 
@@ -65,7 +70,12 @@ const AdminCabangAttendanceReportScreen = () => {
 
       <View style={styles.section}>
         <Text style={styles.sectionTitle}>Rekap Mingguan Cabang</Text>
-        <WeeklyBreakdownList data={weeklyData} />
+        <WeeklyBreakdownList
+          data={weeklyData}
+          isLoading={isWeeklyLoading}
+          error={weeklyError}
+          onRetry={refetchWeekly}
+        />
       </View>
 
       <View style={styles.section}>


### PR DESCRIPTION
## Summary
- fetch weekly attendance data from the admin cabang report API and normalise it into week cards
- enhance the weekly breakdown list to present detailed metrics with loading, error, and empty states
- pass loading and error state from the attendance report screen so the UI reflects asynchronous fetches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c9d33f5c8323acc0b726fcc02fbb