### PR TITLE
Add attendance filter controls for attendance report

### DIFF
--- a/frontend/src/features/adminCabang/components/reports/attendance/AttendanceFilterBar.js
+++ b/frontend/src/features/adminCabang/components/reports/attendance/AttendanceFilterBar.js
@@ -1,13 +1,278 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useMemo } from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Picker } from '@react-native-picker/picker';
 
-const AttendanceFilterBar = () => {
+const MONTH_OPTIONS = [
+  { label: 'Januari', value: 1 },
+  { label: 'Februari', value: 2 },
+  { label: 'Maret', value: 3 },
+  { label: 'April', value: 4 },
+  { label: 'Mei', value: 5 },
+  { label: 'Juni', value: 6 },
+  { label: 'Juli', value: 7 },
+  { label: 'Agustus', value: 8 },
+  { label: 'September', value: 9 },
+  { label: 'Oktober', value: 10 },
+  { label: 'November', value: 11 },
+  { label: 'Desember', value: 12 },
+];
+
+const VERIFICATION_OPTIONS = [
+  { label: 'Semua Status', value: 'all' },
+  { label: 'Terverifikasi', value: 'verified' },
+  { label: 'Menunggu', value: 'pending' },
+  { label: 'Ditolak', value: 'rejected' },
+];
+
+const AttendanceFilterBar = ({
+  filters,
+  onFiltersChange,
+  onApply,
+  onReset,
+  weekOptions = [],
+  wilbinOptions = [],
+  shelterOptions = [],
+  isLoading = false,
+}) => {
+  const effectiveFilters = filters ?? {};
+
+  const yearOptions = useMemo(() => {
+    const currentYear = new Date().getFullYear();
+    const availableYears = [];
+
+    for (let offset = 0; offset < 5; offset += 1) {
+      availableYears.push(currentYear - offset);
+    }
+
+    const normalized = availableYears
+      .sort((a, b) => b - a)
+      .map((year) => ({
+        label: `${year}`,
+        value: year,
+      }));
+
+    if (
+      effectiveFilters.year &&
+      !normalized.some((option) => option.value === effectiveFilters.year)
+    ) {
+      normalized.push({ label: `${effectiveFilters.year}`, value: effectiveFilters.year });
+    }
+
+    return normalized.sort((a, b) => b.value - a.value);
+  }, [effectiveFilters.year]);
+
+  const handleUpdateFilters = (updater) => {
+    if (typeof onFiltersChange !== 'function') {
+      return;
+    }
+
+    if (typeof updater === 'function') {
+      onFiltersChange((prev) => updater(prev ?? {}));
+      return;
+    }
+
+    onFiltersChange((prev) => ({ ...(prev ?? {}), ...(updater ?? {}) }));
+  };
+
+  const handleMonthChange = (value) => {
+    const numericValue = Number(value);
+
+    handleUpdateFilters((prev) => ({
+      ...(prev ?? {}),
+      month: numericValue,
+      week: 'all',
+    }));
+  };
+
+  const handleYearChange = (value) => {
+    const numericValue = Number(value);
+
+    handleUpdateFilters((prev) => ({
+      ...(prev ?? {}),
+      year: numericValue,
+      week: 'all',
+    }));
+  };
+
+  const handleWeekChange = (value) => {
+    if (value === 'all') {
+      handleUpdateFilters({ week: 'all' });
+      return;
+    }
+
+    const numericValue = Number(value);
+
+    handleUpdateFilters({ week: Number.isNaN(numericValue) ? 'all' : numericValue });
+  };
+
+  const handleWilbinChange = (value) => {
+    handleUpdateFilters((prev) => ({
+      ...(prev ?? {}),
+      wilbinId: value ?? null,
+      shelterId: null,
+    }));
+  };
+
+  const handleShelterChange = (value) => {
+    handleUpdateFilters({ shelterId: value ?? null });
+  };
+
+  const handleVerificationChange = (value) => {
+    handleUpdateFilters({ verificationStatus: value ?? 'all' });
+  };
+
+  const renderPicker = (props) => {
+    const { label, selectedValue, onValueChange, items = [], enabled = true, placeholder } = props;
+
+    if (items.length === 0 && !placeholder) {
+      return null;
+    }
+
+    return (
+      <View style={styles.pickerGroup}>
+        <Text style={styles.pickerLabel}>{label}</Text>
+        <View style={[styles.pickerWrapper, !enabled && styles.pickerDisabled]}>
+          <Picker
+            enabled={enabled}
+            selectedValue={selectedValue}
+            onValueChange={onValueChange}
+            style={styles.picker}
+            dropdownIconColor="#0984e3"
+          >
+            {placeholder ? (
+              <Picker.Item label={placeholder} value={null} />
+            ) : null}
+            {items.map((item) => (
+              <Picker.Item key={`${label}-${item.value}`} label={item.label} value={item.value} />
+            ))}
+          </Picker>
+        </View>
+      </View>
+    );
+  };
+
+  const normalizedWeekOptions = useMemo(() => {
+    if (!Array.isArray(weekOptions) || weekOptions.length === 0) {
+      return [];
+    }
+
+    return weekOptions.map((option) => ({
+      label: `Minggu ${option}`,
+      value: option,
+    }));
+  }, [weekOptions]);
+
+  const normalizedWilbinOptions = useMemo(() => {
+    if (!Array.isArray(wilbinOptions) || wilbinOptions.length === 0) {
+      return [];
+    }
+
+    return [
+      { label: 'Semua Wilayah', value: null },
+      ...wilbinOptions.map((option) => ({
+        label: option.label ?? `${option.value}`,
+        value: option.value,
+      })),
+    ];
+  }, [wilbinOptions]);
+
+  const normalizedShelterOptions = useMemo(() => {
+    if (!Array.isArray(shelterOptions) || shelterOptions.length === 0) {
+      return [];
+    }
+
+    return [
+      { label: 'Semua Shelter', value: null },
+      ...shelterOptions.map((option) => ({
+        label: option.label ?? `${option.value}`,
+        value: option.value,
+      })),
+    ];
+  }, [shelterOptions]);
+
+  const shouldShowWilbin = normalizedWilbinOptions.length > 0;
+  const shouldShowShelter = normalizedShelterOptions.length > 0;
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Filter Kehadiran</Text>
-      <Text style={styles.description}>
-        Komponen filter akan ditempatkan di sini untuk mengatur rentang waktu dan penyaringan data.
-      </Text>
+      <View style={styles.headerRow}>
+        <Text style={styles.title}>Filter Kehadiran</Text>
+        {isLoading ? <ActivityIndicator size="small" color="#0984e3" /> : null}
+      </View>
+
+      <View style={styles.row}>
+        {renderPicker({
+          label: 'Bulan',
+          selectedValue: effectiveFilters.month ?? null,
+          onValueChange: handleMonthChange,
+          items: MONTH_OPTIONS,
+        })}
+
+        {renderPicker({
+          label: 'Tahun',
+          selectedValue: effectiveFilters.year ?? null,
+          onValueChange: handleYearChange,
+          items: yearOptions,
+        })}
+      </View>
+
+      <View style={styles.row}>
+        {renderPicker({
+          label: 'Minggu',
+          selectedValue: effectiveFilters.week ?? 'all',
+          onValueChange: handleWeekChange,
+          items: [
+            { label: 'Semua Minggu', value: 'all' },
+            ...normalizedWeekOptions,
+          ],
+        })}
+
+        {renderPicker({
+          label: 'Status Verifikasi',
+          selectedValue: effectiveFilters.verificationStatus ?? 'all',
+          onValueChange: handleVerificationChange,
+          items: VERIFICATION_OPTIONS,
+        })}
+      </View>
+
+      {shouldShowWilbin || shouldShowShelter ? (
+        <View style={styles.row}>
+          {shouldShowWilbin
+            ? renderPicker({
+                label: 'Wilayah Binaan',
+                selectedValue: effectiveFilters.wilbinId ?? null,
+                onValueChange: handleWilbinChange,
+                items: normalizedWilbinOptions,
+              })
+            : null}
+
+          {shouldShowShelter
+            ? renderPicker({
+                label: 'Shelter',
+                selectedValue: effectiveFilters.shelterId ?? null,
+                onValueChange: handleShelterChange,
+                items: normalizedShelterOptions,
+                enabled: !shouldShowWilbin || !!effectiveFilters.wilbinId || normalizedWilbinOptions.length === 0,
+              })
+            : null}
+        </View>
+      ) : null}
+
+      <View style={styles.buttonRow}>
+        <TouchableOpacity style={styles.resetButton} onPress={onReset}>
+          <Text style={styles.resetButtonText}>Reset</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity style={styles.applyButton} onPress={onApply}>
+          <Text style={styles.applyButtonText}>Terapkan</Text>
+        </TouchableOpacity>
+      </View>
     </View>
   );
 };
@@ -19,15 +284,71 @@ const styles = StyleSheet.create({
     backgroundColor: '#f1f2f6',
     borderRadius: 12,
   },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
   title: {
     fontSize: 16,
     fontWeight: '600',
-    marginBottom: 4,
     color: '#2d3436',
   },
-  description: {
-    fontSize: 14,
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginHorizontal: -8,
+  },
+  pickerGroup: {
+    width: '50%',
+    paddingHorizontal: 8,
+    marginBottom: 12,
+  },
+  pickerLabel: {
+    fontSize: 13,
     color: '#636e72',
+    marginBottom: 6,
+  },
+  pickerWrapper: {
+    borderWidth: 1,
+    borderColor: '#dfe6e9',
+    borderRadius: 8,
+    overflow: 'hidden',
+    backgroundColor: '#ffffff',
+  },
+  pickerDisabled: {
+    opacity: 0.6,
+  },
+  picker: {
+    width: '100%',
+    height: 44,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    marginTop: 8,
+  },
+  resetButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    marginRight: 8,
+    borderRadius: 8,
+    backgroundColor: '#dfe6e9',
+  },
+  resetButtonText: {
+    color: '#2d3436',
+    fontWeight: '600',
+  },
+  applyButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    backgroundColor: '#0984e3',
+  },
+  applyButtonText: {
+    color: '#ffffff',
+    fontWeight: '600',
   },
 });
 

--- a/frontend/src/features/adminCabang/screens/reports/attendance/AdminCabangAttendanceReportScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/attendance/AdminCabangAttendanceReportScreen.js
@@ -1,6 +1,16 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { ScrollView, StyleSheet, View, Text } from 'react-native';
 
+import {
+  addWeeks,
+  differenceInCalendarWeeks,
+  endOfMonth,
+  endOfWeek,
+  format,
+  startOfMonth,
+  startOfWeek,
+} from 'date-fns';
+
 import AttendanceFilterBar from '../../../components/reports/attendance/AttendanceFilterBar';
 import AttendanceSummarySection from '../../../components/reports/attendance/AttendanceSummarySection';
 import WeeklyBreakdownList from '../../../components/reports/attendance/WeeklyBreakdownList';
@@ -13,24 +23,289 @@ import useAttendanceWeekly from '../../../hooks/reports/attendance/useAttendance
 import useAttendanceWeeklyShelters from '../../../hooks/reports/attendance/useAttendanceWeeklyShelters';
 import useAttendanceTrend from '../../../hooks/reports/attendance/useAttendanceTrend';
 
+const WEEK_START_DAY = 1;
+
+const formatDateForApi = (date) => {
+  try {
+    return format(date, 'yyyy-MM-dd');
+  } catch (error) {
+    console.warn('Failed to format date for filters:', error);
+    return null;
+  }
+};
+
+const safeNumber = (value) => {
+  const parsed = Number(value);
+
+  if (Number.isNaN(parsed)) {
+    return null;
+  }
+
+  return parsed;
+};
+
+const computeWeekOfMonth = (date) => {
+  try {
+    const monthStart = startOfMonth(date);
+    const difference = differenceInCalendarWeeks(date, monthStart, { weekStartsOn: WEEK_START_DAY });
+
+    return Math.max(1, difference + 1);
+  } catch (error) {
+    console.warn('Failed to compute week of month:', error);
+    return 1;
+  }
+};
+
+const getWeekCountForMonth = (year, month) => {
+  if (!year || !month) {
+    return 6;
+  }
+
+  try {
+    const baseDate = new Date(year, month - 1, 1);
+    const start = startOfMonth(baseDate);
+    const end = endOfMonth(baseDate);
+    const difference = differenceInCalendarWeeks(end, start, { weekStartsOn: WEEK_START_DAY });
+
+    return Math.max(1, difference + 1);
+  } catch (error) {
+    console.warn('Failed to compute week count for month:', error);
+    return 6;
+  }
+};
+
+const computeDateRangeFromFilters = ({ year, month, week }) => {
+  if (!year || !month) {
+    return { startDate: null, endDate: null };
+  }
+
+  try {
+    const baseDate = new Date(year, month - 1, 1);
+    const monthStart = startOfMonth(baseDate);
+    const monthEnd = endOfMonth(baseDate);
+
+    if (week === 'all' || week === null || week === undefined) {
+      return {
+        startDate: formatDateForApi(monthStart),
+        endDate: formatDateForApi(monthEnd),
+      };
+    }
+
+    const weekIndex = Math.max(0, Number(week) - 1);
+    const tentativeStart = addWeeks(startOfWeek(monthStart, { weekStartsOn: WEEK_START_DAY }), weekIndex);
+    const weekStart = tentativeStart < monthStart ? monthStart : tentativeStart;
+    const tentativeEnd = endOfWeek(weekStart, { weekStartsOn: WEEK_START_DAY });
+    const weekEnd = tentativeEnd > monthEnd ? monthEnd : tentativeEnd;
+
+    if (weekStart > monthEnd) {
+      return {
+        startDate: formatDateForApi(monthEnd),
+        endDate: formatDateForApi(monthEnd),
+      };
+    }
+
+    return {
+      startDate: formatDateForApi(weekStart),
+      endDate: formatDateForApi(weekEnd),
+    };
+  } catch (error) {
+    console.warn('Failed to compute date range from filters:', error);
+    return { startDate: null, endDate: null };
+  }
+};
+
+const withDateRange = (filters) => {
+  const fallbackNow = new Date();
+  const base = filters ? { ...filters } : {};
+
+  const monthNumber = safeNumber(base.month) ?? fallbackNow.getMonth() + 1;
+  const yearNumber = safeNumber(base.year) ?? fallbackNow.getFullYear();
+  const rawWeek =
+    base.week === 'all' || base.week === null || typeof base.week === 'undefined'
+      ? 'all'
+      : safeNumber(base.week);
+
+  const normalizedWeek =
+    rawWeek === 'all' || rawWeek === null
+      ? 'all'
+      : Math.min(Math.max(1, rawWeek), getWeekCountForMonth(yearNumber, monthNumber));
+
+  const range = computeDateRangeFromFilters({ year: yearNumber, month: monthNumber, week: normalizedWeek });
+
+  return {
+    ...base,
+    month: monthNumber,
+    year: yearNumber,
+    week: normalizedWeek,
+    startDate: range.startDate,
+    endDate: range.endDate,
+  };
+};
+
+const createDefaultFilters = () => {
+  const now = new Date();
+  const defaultMonth = now.getMonth() + 1;
+  const defaultYear = now.getFullYear();
+  const weekCount = getWeekCountForMonth(defaultYear, defaultMonth);
+  const computedWeek = Math.min(weekCount, computeWeekOfMonth(now));
+
+  return {
+    month: defaultMonth,
+    year: defaultYear,
+    week: computedWeek,
+    wilbinId: null,
+    shelterId: null,
+    verificationStatus: 'all',
+  };
+};
+
+const convertFiltersToApiParams = (filters) => {
+  if (!filters) {
+    return {};
+  }
+
+  const params = {};
+
+  if (filters.startDate) {
+    params.start_date = filters.startDate;
+  }
+
+  if (filters.endDate) {
+    params.end_date = filters.endDate;
+  }
+
+  if (filters.month) {
+    params.month = filters.month;
+  }
+
+  if (filters.year) {
+    params.year = filters.year;
+  }
+
+  if (filters.week && filters.week !== 'all') {
+    params.week = filters.week;
+  }
+
+  if (filters.wilbinId) {
+    params.wilbin_id = filters.wilbinId;
+  }
+
+  if (filters.shelterId) {
+    params.shelter_id = filters.shelterId;
+  }
+
+  if (filters.verificationStatus && filters.verificationStatus !== 'all') {
+    params.verification_status = filters.verificationStatus;
+  }
+
+  return params;
+};
+
+const extractWilbinValue = (wilbin) => {
+  if (!wilbin) {
+    return null;
+  }
+
+  if (typeof wilbin === 'object') {
+    return (
+      wilbin.id ??
+      wilbin.value ??
+      wilbin.key ??
+      wilbin.code ??
+      wilbin.slug ??
+      wilbin.identifier ??
+      null
+    );
+  }
+
+  return wilbin;
+};
+
+const extractWilbinLabel = (wilbin) => {
+  if (!wilbin) {
+    return '';
+  }
+
+  if (typeof wilbin === 'object') {
+    return wilbin.name ?? wilbin.label ?? wilbin.title ?? wilbin.text ?? `${extractWilbinValue(wilbin) ?? ''}`;
+  }
+
+  return String(wilbin);
+};
+
 const AdminCabangAttendanceReportScreen = () => {
+  const defaultFilters = useMemo(() => createDefaultFilters(), []);
+  const [filterDraft, setFilterDraft] = useState(defaultFilters);
+  const [appliedFilters, setAppliedFilters] = useState(() => withDateRange(defaultFilters));
+
+  const filterParams = useMemo(() => convertFiltersToApiParams(appliedFilters), [appliedFilters]);
+
   const { data: summaryData } = useAttendanceSummary();
   const {
     data: weeklyData,
     isLoading: isWeeklyLoading,
     error: weeklyError,
     refetch: refetchWeekly,
-  } = useAttendanceWeekly();
+  } = useAttendanceWeekly(filterParams);
   const {
     data: shelterData,
     isLoading: isShelterLoading,
     error: shelterError,
     refetch: refetchShelters,
-  } = useAttendanceWeeklyShelters();
+  } = useAttendanceWeeklyShelters(filterParams);
   const { data: trendData } = useAttendanceTrend();
 
   const [selectedShelter, setSelectedShelter] = useState(null);
   const [isDetailVisible, setDetailVisible] = useState(false);
+
+  const availableWeekOptions = useMemo(() => {
+    const weekCount = getWeekCountForMonth(filterDraft?.year, filterDraft?.month);
+
+    return Array.from({ length: weekCount }, (_, index) => index + 1);
+  }, [filterDraft?.year, filterDraft?.month]);
+
+  const allShelterOptions = useMemo(() => {
+    if (!Array.isArray(shelterData)) {
+      return [];
+    }
+
+    return shelterData.map((item, index) => ({
+      value: item?.id ?? item?.shelterId ?? item?.shelter_id ?? item?.code ?? `shelter-${index + 1}`,
+      label: item?.name ?? item?.shelterName ?? item?.shelter_name ?? `Shelter ${index + 1}`,
+      wilbinValue: extractWilbinValue(item?.wilbin),
+      wilbinLabel: extractWilbinLabel(item?.wilbin),
+    }));
+  }, [shelterData]);
+
+  const wilbinOptions = useMemo(() => {
+    const map = new Map();
+
+    allShelterOptions.forEach((option) => {
+      if (option.wilbinValue === null || typeof option.wilbinValue === 'undefined') {
+        return;
+      }
+
+      if (!map.has(option.wilbinValue)) {
+        map.set(option.wilbinValue, option.wilbinLabel || `${option.wilbinValue}`);
+      }
+    });
+
+    return Array.from(map.entries()).map(([value, label]) => ({ value, label }));
+  }, [allShelterOptions]);
+
+  const shelterOptions = useMemo(() => {
+    if (!Array.isArray(allShelterOptions) || allShelterOptions.length === 0) {
+      return [];
+    }
+
+    if (!filterDraft?.wilbinId) {
+      return allShelterOptions.map((option) => ({ value: option.value, label: option.label }));
+    }
+
+    return allShelterOptions
+      .filter((option) => option.wilbinValue === filterDraft.wilbinId)
+      .map((option) => ({ value: option.value, label: option.label }));
+  }, [allShelterOptions, filterDraft?.wilbinId]);
 
   const activeFilters = useMemo(() => {
     const weeks = Array.isArray(weeklyData) ? weeklyData : [];
@@ -45,33 +320,48 @@ const AdminCabangAttendanceReportScreen = () => {
       return !Number.isNaN(parsed.getTime());
     };
 
-    const startDates = weeks
-      .map((item) => item?.dates?.start)
-      .filter((value) => isValidDate(value));
-    const endDates = weeks
-      .map((item) => item?.dates?.end)
-      .filter((value) => isValidDate(value));
+    const startDates = weeks.map((item) => item?.dates?.start).filter((value) => isValidDate(value));
+    const endDates = weeks.map((item) => item?.dates?.end).filter((value) => isValidDate(value));
 
     const earliestStart =
       startDates.length > 0
-        ? startDates.reduce((earliest, current) => {
-            return new Date(current) < new Date(earliest) ? current : earliest;
-          }, startDates[0])
+        ? startDates.reduce((earliest, current) =>
+            new Date(current) < new Date(earliest) ? current : earliest
+          )
         : undefined;
 
     const latestEnd =
       endDates.length > 0
-        ? endDates.reduce((latest, current) => {
-            return new Date(current) > new Date(latest) ? current : latest;
-          }, endDates[0])
+        ? endDates.reduce((latest, current) =>
+            new Date(current) > new Date(latest) ? current : latest
+          )
         : undefined;
 
-    return {
-      startDate: earliestStart,
-      endDate: latestEnd,
+    const combined = {
+      ...(appliedFilters ?? {}),
       label: summaryData?.periodLabel ?? null,
     };
-  }, [weeklyData, summaryData?.periodLabel]);
+
+    if (!combined.startDate && earliestStart) {
+      combined.startDate = earliestStart;
+    }
+
+    if (!combined.endDate && latestEnd) {
+      combined.endDate = latestEnd;
+    }
+
+    return combined;
+  }, [appliedFilters, weeklyData, summaryData?.periodLabel]);
+
+  const handleApplyFilters = useCallback(() => {
+    setAppliedFilters(withDateRange(filterDraft));
+  }, [filterDraft]);
+
+  const handleResetFilters = useCallback(() => {
+    const defaults = createDefaultFilters();
+    setFilterDraft(defaults);
+    setAppliedFilters(withDateRange(defaults));
+  }, []);
 
   const handleShelterRowPress = useCallback((shelter) => {
     if (!shelter) {
@@ -118,7 +408,16 @@ const AdminCabangAttendanceReportScreen = () => {
 
   return (
     <ScrollView contentContainerStyle={styles.container}>
-      <AttendanceFilterBar />
+      <AttendanceFilterBar
+        filters={filterDraft}
+        onFiltersChange={setFilterDraft}
+        onApply={handleApplyFilters}
+        onReset={handleResetFilters}
+        weekOptions={availableWeekOptions}
+        wilbinOptions={wilbinOptions}
+        shelterOptions={shelterOptions}
+        isLoading={isWeeklyLoading || isShelterLoading}
+      />
 
       <View style={styles.section}>
         <AttendanceSummarySection


### PR DESCRIPTION
## Summary
- replace the placeholder filter bar with month, week, verification, and optional wilbin/shelter selectors plus apply/reset actions
- hoist attendance filter state into the report screen, derive date ranges, and pass them to the weekly hooks so they refetch for the selected period
- expose the active filters to the shelter detail modal and show a loading indicator beside the filter bar during refreshes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5cf686c448323b72eaa4f97e34b15