### PR TITLE
Refine weekly shelter attendance detail summary

### DIFF
--- a/backend/app/Http/Controllers/API/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterDetailController.php
+++ b/backend/app/Http/Controllers/API/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterDetailController.php
@@ -102,6 +102,10 @@ class AttendanceWeeklyShelterDetailController extends Controller
             $endDate,
             [
                 'week' => $weekKey,
+                'period_filters' => [
+                    'start_date' => $validated['start_date'] ?? null,
+                    'end_date' => $validated['end_date'] ?? null,
+                ],
             ]
         );
 

--- a/backend/app/Http/Resources/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterDetailResource.php
+++ b/backend/app/Http/Resources/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterDetailResource.php
@@ -10,69 +10,26 @@ class AttendanceWeeklyShelterDetailResource extends JsonResource
     {
         $data = (array) $this->resource;
 
-        $formatRate = static fn ($value): string => number_format((float) ($value ?? 0), 2, '.', '');
+        $formatPercentage = static fn ($value): string => number_format((float) ($value ?? 0), 2, '.', '');
 
-        $formatVerification = static fn (array $verification): array => [
-            'pending' => (int) ($verification['pending'] ?? 0),
-            'verified' => (int) ($verification['verified'] ?? 0),
-            'rejected' => (int) ($verification['rejected'] ?? 0),
-            'manual' => (int) ($verification['manual'] ?? 0),
-        ];
-
-        $formatMetrics = function (array $metrics) use ($formatRate, $formatVerification): array {
-            return [
-                'present_count' => (int) ($metrics['present_count'] ?? 0),
-                'late_count' => (int) ($metrics['late_count'] ?? 0),
-                'absent_count' => (int) ($metrics['absent_count'] ?? 0),
-                'attendance_rate' => $formatRate($metrics['attendance_rate'] ?? 0),
-                'late_rate' => $formatRate($metrics['late_rate'] ?? 0),
-                'total_sessions' => (int) ($metrics['total_sessions'] ?? 0),
-                'total_activities' => (int) ($metrics['total_activities'] ?? 0),
-                'unique_children' => (int) ($metrics['unique_children'] ?? 0),
-                'verification' => $formatVerification($metrics['verification'] ?? []),
-            ];
-        };
-
-        $groups = collect($data['groups'] ?? [])->map(function ($group) use ($formatMetrics) {
-            $activities = collect($group['activities'] ?? [])->map(function ($activity) use ($formatMetrics) {
-                $metrics = $formatMetrics($activity['metrics'] ?? []);
-
-                return [
-                    'id' => $activity['id'] ?? null,
-                    'date' => $activity['date'] ?? null,
-                    'week' => $activity['week'] ?? null,
-                    'group_name' => $activity['group_name'] ?? null,
-                    'jenis_kegiatan' => $activity['jenis_kegiatan'] ?? null,
-                    'materi' => $activity['materi'] ?? null,
-                    'metrics' => $metrics,
-                ];
-            })->values()->all();
-
+        $groups = collect($data['groups'] ?? [])->map(function ($group) use ($formatPercentage) {
             return [
                 'id' => $group['id'] ?? null,
                 'name' => $group['name'] ?? null,
+                'description' => $group['description'] ?? null,
                 'member_count' => isset($group['member_count']) ? (int) $group['member_count'] : null,
-                'metrics' => $formatMetrics($group['metrics'] ?? []),
-                'activities' => $activities,
-            ];
-        })->values()->all();
-
-        $activities = collect($data['activities'] ?? [])->map(function ($activity) use ($formatMetrics) {
-            return [
-                'id' => $activity['id'] ?? null,
-                'date' => $activity['date'] ?? null,
-                'week' => $activity['week'] ?? null,
-                'group_name' => $activity['group_name'] ?? null,
-                'jenis_kegiatan' => $activity['jenis_kegiatan'] ?? null,
-                'materi' => $activity['materi'] ?? null,
-                'metrics' => $formatMetrics($activity['metrics'] ?? []),
+                'present_count' => (int) ($group['present_count'] ?? 0),
+                'late_count' => (int) ($group['late_count'] ?? 0),
+                'absent_count' => (int) ($group['absent_count'] ?? 0),
+                'attendance_percentage' => $formatPercentage($group['attendance_percentage'] ?? 0),
             ];
         })->values()->all();
 
         $notes = collect($data['notes'] ?? [])->filter(fn ($note) => filled($note))->values()->all();
 
+        $period = $data['period'] ?? [];
         $filters = $data['filters'] ?? [];
-        $metrics = $data['metrics'] ?? [];
+        $summary = $data['summary'] ?? [];
         $shelter = $data['shelter'] ?? [];
 
         return [
@@ -82,14 +39,25 @@ class AttendanceWeeklyShelterDetailResource extends JsonResource
                 'wilbin' => $shelter['wilbin'] ?? null,
                 'wilbin_id' => $shelter['wilbin_id'] ?? null,
             ],
+            'period' => [
+                'week' => $period['week'] ?? null,
+                'start_date' => $period['start_date'] ?? null,
+                'end_date' => $period['end_date'] ?? null,
+            ],
             'filters' => [
-                'week' => $filters['week'] ?? null,
                 'start_date' => $filters['start_date'] ?? null,
                 'end_date' => $filters['end_date'] ?? null,
+                'week' => $filters['week'] ?? null,
             ],
-            'metrics' => $formatMetrics($metrics),
+            'summary' => [
+                'total_students' => (int) ($summary['total_students'] ?? 0),
+                'present_count' => (int) ($summary['present_count'] ?? 0),
+                'late_count' => (int) ($summary['late_count'] ?? 0),
+                'absent_count' => (int) ($summary['absent_count'] ?? 0),
+                'attendance_percentage' => $formatPercentage($summary['attendance_percentage'] ?? 0),
+                'attendance_band' => $summary['attendance_band'] ?? null,
+            ],
             'groups' => $groups,
-            'activities' => $activities,
             'notes' => $notes,
             'generated_at' => $data['generated_at'] ?? null,
         ];

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -207,6 +207,9 @@ Route::middleware('auth:sanctum')->group(function () {
                 Route::get('/weekly', AttendanceWeeklyController::class)
                     ->name('admin-cabang.reports.attendance.weekly.index');
                 Route::get('/weekly/shelters', AttendanceWeeklyShelterController::class);
+                // Level 2 - Shelter weekly attendance detail
+                // Query params: start_date (YYYY-MM-DD), end_date (YYYY-MM-DD), week (ISO-8601, e.g. 2024-W01)
+                // Future hooks: export (csv|xlsx), share_token
                 Route::get('/weekly/shelters/{shelter}', AttendanceWeeklyShelterDetailController::class);
                 Route::get('/monthly-shelter', App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceMonthlyShelterController::class);
                 Route::get('/monthly-branch', App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceMonthlyBranchController::class);


### PR DESCRIPTION
## Summary
- refactor the weekly shelter detail service to emit level-2 summaries with attendance aggregation and group descriptions
- update the admin controller and resource to forward period filters and expose the new summary + groups payload
- document expected query parameters and future hooks on the weekly shelter detail route

## Testing
- php -l app/Services/AdminCabang/Reports/Attendance/WeeklyAttendanceService.php
- php -l app/Http/Controllers/API/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterDetailController.php
- php -l app/Http/Resources/AdminCabang/Reports/Attendance/AttendanceWeeklyShelterDetailResource.php
- php -l routes/api.php

------
https://chatgpt.com/codex/tasks/task_e_68e5e81d63a083239c737c0b25bb8251