### PR TITLE
Add admin cabang weekly group students endpoint

### DIFF
--- a/backend/app/Http/Controllers/API/AdminCabang/Reports/Attendance/AttendanceWeeklyGroupStudentController.php
+++ b/backend/app/Http/Controllers/API/AdminCabang/Reports/Attendance/AttendanceWeeklyGroupStudentController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers\API\AdminCabang\Reports\Attendance;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\AdminCabang\Reports\Attendance\AttendanceWeeklyGroupStudentResource;
+use App\Models\Kelompok;
+use App\Services\AdminCabang\Reports\Attendance\WeeklyAttendanceService;
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class AttendanceWeeklyGroupStudentController extends Controller
+{
+    public function __invoke(
+        Request $request,
+        Kelompok $group,
+        WeeklyAttendanceService $service
+    ): JsonResponse {
+        $user = $request->user();
+        $adminCabang = $user?->adminCabang;
+
+        if (!$adminCabang) {
+            return response()->json([
+                'message' => __('Anda tidak memiliki akses sebagai admin cabang.'),
+            ], 403);
+        }
+
+        $kacab = $adminCabang->loadMissing('kacab')->kacab;
+        $accessibleShelterIds = $kacab
+            ? $kacab->shelters()->pluck('shelter.id_shelter')->all()
+            : [];
+
+        if (!in_array($group->id_shelter, $accessibleShelterIds, true)) {
+            return response()->json([
+                'message' => __('Anda tidak memiliki akses ke kelompok ini.'),
+            ], 403);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'start_date' => ['nullable', 'date'],
+            'end_date' => ['nullable', 'date'],
+            'status' => ['nullable', 'string', 'in:present,late,absent'],
+            'search' => ['nullable', 'string', 'max:255'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'page' => ['nullable', 'integer', 'min:1'],
+        ]);
+
+        $validator->after(function ($validator) use ($request) {
+            $start = $request->input('start_date');
+            $end = $request->input('end_date');
+
+            if ($start && $end && Carbon::parse($end)->lt(Carbon::parse($start))) {
+                $validator->errors()->add('end_date', __('validation.after_or_equal', [
+                    'attribute' => 'end date',
+                    'date' => 'start date',
+                ]));
+            }
+        });
+
+        $validated = $validator->validate();
+
+        $startDate = isset($validated['start_date'])
+            ? Carbon::parse($validated['start_date'])->startOfDay()
+            : Carbon::now()->startOfWeek(Carbon::MONDAY);
+
+        $endDate = isset($validated['end_date'])
+            ? Carbon::parse($validated['end_date'])->endOfDay()
+            : $startDate->copy()->endOfWeek(Carbon::SUNDAY)->endOfDay();
+
+        if ($endDate->lt($startDate)) {
+            $endDate = $startDate->copy()->endOfWeek(Carbon::SUNDAY)->endOfDay();
+        }
+
+        $report = $service->buildGroupWeeklyStudents(
+            $adminCabang,
+            $group->loadMissing(['shelter', 'levelAnakBinaan']),
+            $startDate,
+            $endDate,
+            [
+                'status' => $validated['status'] ?? null,
+                'search' => $validated['search'] ?? null,
+                'per_page' => $validated['per_page'] ?? null,
+                'page' => $validated['page'] ?? null,
+            ]
+        );
+
+        return AttendanceWeeklyGroupStudentResource::make($report)
+            ->additional([
+                'message' => __('Daftar kehadiran mingguan anak per kelompok berhasil diambil.'),
+            ])
+            ->toResponse($request);
+    }
+}

--- a/backend/app/Http/Resources/AdminCabang/Reports/Attendance/AttendanceWeeklyGroupStudentResource.php
+++ b/backend/app/Http/Resources/AdminCabang/Reports/Attendance/AttendanceWeeklyGroupStudentResource.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Resources\AdminCabang\Reports\Attendance;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class AttendanceWeeklyGroupStudentResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        $data = (array) $this->resource;
+
+        $group = $data['group'] ?? [];
+        $period = $data['period'] ?? [];
+        $statusCounts = $data['status_counts'] ?? [];
+        $students = $data['students'] ?? [];
+        $pagination = $data['pagination'] ?? [];
+        $filters = $data['filters'] ?? [];
+
+        $formatStatusCounts = collect($statusCounts)
+            ->map(function ($payload) {
+                return [
+                    'code' => $payload['code'] ?? null,
+                    'label' => $payload['label'] ?? null,
+                    'icon' => $payload['icon'] ?? null,
+                    'count' => (int) ($payload['count'] ?? 0),
+                ];
+            })
+            ->values()
+            ->all();
+
+        $studentsPayload = collect($students)
+            ->map(function ($student) {
+                $status = $student['status'] ?? [];
+
+                return [
+                    'id' => $student['id'] ?? null,
+                    'name' => $student['name'] ?? null,
+                    'nickname' => $student['nickname'] ?? null,
+                    'gender' => $student['gender'] ?? null,
+                    'avatar_url' => $student['avatar_url'] ?? null,
+                    'status' => [
+                        'code' => $status['code'] ?? null,
+                        'label' => $status['label'] ?? null,
+                        'icon' => $status['icon'] ?? null,
+                    ],
+                    'is_recorded' => (bool) ($student['is_recorded'] ?? false),
+                    'arrival_time' => $student['arrival_time'] ?? null,
+                    'arrival_time_label' => $student['arrival_time_label'] ?? null,
+                    'activity_date' => $student['activity_date'] ?? null,
+                    'notes' => $student['notes'] ?? null,
+                    'verification_status' => $student['verification_status'] ?? null,
+                ];
+            })
+            ->values()
+            ->all();
+
+        return [
+            'group' => [
+                'id' => $group['id'] ?? null,
+                'name' => $group['name'] ?? null,
+                'description' => $group['description'] ?? null,
+                'shelter' => [
+                    'id' => $group['shelter']['id'] ?? null,
+                    'name' => $group['shelter']['name'] ?? null,
+                ],
+            ],
+            'period' => [
+                'start_date' => $period['start_date'] ?? null,
+                'end_date' => $period['end_date'] ?? null,
+            ],
+            'status_counts' => $formatStatusCounts,
+            'students' => $studentsPayload,
+            'pagination' => [
+                'total' => (int) ($pagination['total'] ?? 0),
+                'per_page' => (int) ($pagination['per_page'] ?? 0),
+                'current_page' => (int) ($pagination['current_page'] ?? 1),
+                'last_page' => (int) ($pagination['last_page'] ?? 1),
+            ],
+            'filters' => [
+                'start_date' => $filters['start_date'] ?? null,
+                'end_date' => $filters['end_date'] ?? null,
+                'status' => $filters['status'] ?? null,
+                'search' => $filters['search'] ?? null,
+                'per_page' => $filters['per_page'] ?? null,
+                'page' => $filters['page'] ?? null,
+            ],
+            'generated_at' => $data['generated_at'] ?? null,
+        ];
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,6 +3,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceWeeklyController;
 use App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceWeeklyShelterController;
+use App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceWeeklyGroupStudentController;
 use App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceWeeklyShelterDetailController;
 
 
@@ -211,6 +212,7 @@ Route::middleware('auth:sanctum')->group(function () {
                 // Query params: start_date (YYYY-MM-DD), end_date (YYYY-MM-DD), week (ISO-8601, e.g. 2024-W01)
                 // Future hooks: export (csv|xlsx), share_token
                 Route::get('/weekly/shelters/{shelter}', AttendanceWeeklyShelterDetailController::class);
+                Route::get('/weekly/groups/{group}/students', AttendanceWeeklyGroupStudentController::class);
                 Route::get('/monthly-shelter', App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceMonthlyShelterController::class);
                 Route::get('/monthly-branch', App\Http\Controllers\API\AdminCabang\Reports\Attendance\AttendanceMonthlyBranchController::class);
             });


### PR DESCRIPTION
## Summary
- register an admin cabang weekly group students route and controller that validates filters and enforces cabang access before delegating to the attendance service
- extend the weekly attendance service to assemble per-student weekly data with status aggregates, pagination metadata, and status chip counts
- add a JSON resource to format the level 3 group response structure for the frontend

## Testing
- php -l backend/app/Http/Controllers/API/AdminCabang/Reports/Attendance/AttendanceWeeklyGroupStudentController.php
- php -l backend/app/Services/AdminCabang/Reports/Attendance/WeeklyAttendanceService.php
- php -l backend/app/Http/Resources/AdminCabang/Reports/Attendance/AttendanceWeeklyGroupStudentResource.php


------
https://chatgpt.com/codex/tasks/task_e_68e5e9ae1abc832398acc55ec03bc211