### PR TITLE
Add admin cabang attendance group detail screen

### DIFF
--- a/frontend/src/constants/endpoints.js
+++ b/frontend/src/constants/endpoints.js
@@ -157,6 +157,8 @@ export const ADMIN_CABANG_ENDPOINTS = {
       WEEKLY_SHELTERS: '/admin-cabang/laporan/attendance/weekly-shelters',
       WEEKLY_SHELTER_DETAIL: (shelterId) =>
         `/admin-cabang/laporan/attendance/weekly-shelters/${shelterId}`,
+      WEEKLY_GROUP_STUDENTS: (groupId) =>
+        `/admin-cabang/laporan/attendance/weekly-groups/${groupId}/students`,
       MONTHLY_SHELTER: '/admin-cabang/laporan/attendance/monthly-shelter',
       MONTHLY_BRANCH: '/admin-cabang/laporan/attendance/monthly-branch',
     },

--- a/frontend/src/features/adminCabang/api/adminCabangReportApi.js
+++ b/frontend/src/features/adminCabang/api/adminCabangReportApi.js
@@ -60,6 +60,14 @@ export const adminCabangReportApi = {
     return api.get(ATTENDANCE_ENDPOINTS.WEEKLY_SHELTER_DETAIL(shelterId), { params });
   },
 
+  async getAttendanceWeeklyGroupStudents(groupId, params = {}) {
+    if (!groupId) {
+      throw new Error('Group ID is required to fetch weekly attendance group students');
+    }
+
+    return api.get(ATTENDANCE_ENDPOINTS.WEEKLY_GROUP_STUDENTS(groupId), { params });
+  },
+
   async getAttendanceMonthlyShelter(params = {}) {
     return api.get(ATTENDANCE_ENDPOINTS.MONTHLY_SHELTER, { params });
   },

--- a/frontend/src/features/adminCabang/components/reports/attendance/AttendanceStatusChip.js
+++ b/frontend/src/features/adminCabang/components/reports/attendance/AttendanceStatusChip.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+const getBackgroundColor = (color, active) => {
+  if (!active) {
+    return '#ffffff';
+  }
+
+  if (!color) {
+    return 'rgba(9, 132, 227, 0.12)';
+  }
+
+  return `${color}1f`;
+};
+
+const AttendanceStatusChip = ({
+  label,
+  status,
+  icon,
+  color,
+  active,
+  disabled,
+  onPress,
+  style,
+}) => {
+  const backgroundColor = getBackgroundColor(color, active);
+  const borderColor = active ? color || '#0984e3' : '#dfe6e9';
+  const textColor = disabled ? '#b2bec3' : active ? color || '#0984e3' : '#2d3436';
+
+  const content = (
+    <View
+      style={[
+        styles.chip,
+        { backgroundColor, borderColor },
+        disabled ? styles.disabledChip : null,
+        style,
+      ]}
+    >
+      {icon ? <Ionicons name={icon} size={16} color={textColor} style={styles.icon} /> : null}
+      <Text style={[styles.label, { color: textColor }]}>{label || status || 'Status'}</Text>
+    </View>
+  );
+
+  if (disabled) {
+    return <View style={styles.wrapper}>{content}</View>;
+  }
+
+  return (
+    <TouchableOpacity
+      activeOpacity={0.85}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityState={{ selected: !!active, disabled: !!disabled }}
+      style={styles.wrapper}
+    >
+      {content}
+    </TouchableOpacity>
+  );
+};
+
+AttendanceStatusChip.defaultProps = {
+  label: null,
+  status: null,
+  icon: null,
+  color: null,
+  active: false,
+  disabled: false,
+  onPress: undefined,
+  style: null,
+};
+
+const styles = StyleSheet.create({
+  wrapper: {
+    marginRight: 10,
+    marginBottom: 8,
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 18,
+    borderWidth: 1,
+  },
+  icon: {
+    marginRight: 6,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  disabledChip: {
+    backgroundColor: '#f1f2f6',
+    borderColor: '#dfe6e9',
+  },
+});
+
+export default AttendanceStatusChip;

--- a/frontend/src/features/adminCabang/components/reports/attendance/GroupAttendanceSummaryCard.js
+++ b/frontend/src/features/adminCabang/components/reports/attendance/GroupAttendanceSummaryCard.js
@@ -1,0 +1,201 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+const formatNumber = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    return value.toLocaleString('id-ID');
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return null;
+};
+
+const formatPercentage = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const numeric = Number(value);
+
+  if (!Number.isFinite(numeric)) {
+    return null;
+  }
+
+  return `${numeric.toFixed(numeric % 1 === 0 ? 0 : 1)}%`;
+};
+
+const SummaryMetric = ({ icon, label, value, color }) => {
+  const formattedValue = useMemo(() => formatNumber(value) ?? '0', [value]);
+
+  return (
+    <View style={styles.metric}>
+      <View style={[styles.metricIconWrapper, { backgroundColor: `${color}1a` }]}>
+        <Ionicons name={icon} size={18} color={color} />
+      </View>
+      <Text style={styles.metricValue}>{formattedValue}</Text>
+      <Text style={[styles.metricLabel, { color }]}>{label}</Text>
+    </View>
+  );
+};
+
+SummaryMetric.defaultProps = {
+  icon: 'ellipse-outline',
+  value: 0,
+  color: '#2d3436',
+};
+
+const GroupAttendanceSummaryCard = ({
+  groupName,
+  shelterName,
+  mentor,
+  membersCount,
+  periodLabel,
+  summary,
+}) => {
+  const attendanceRate = useMemo(() => formatPercentage(summary?.attendanceRate), [summary?.attendanceRate]);
+  const membersLabel = useMemo(() => {
+    const normalized = formatNumber(membersCount);
+    return normalized ? `${normalized} anggota` : null;
+  }, [membersCount]);
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <View style={styles.titleSection}>
+          <Text style={styles.groupName}>{groupName || 'Kelompok Tanpa Nama'}</Text>
+          {shelterName ? <Text style={styles.shelterName}>{shelterName}</Text> : null}
+          {mentor ? <Text style={styles.mentor}>{`Pendamping: ${mentor}`}</Text> : null}
+          {membersLabel ? <Text style={styles.members}>{membersLabel}</Text> : null}
+          {periodLabel ? <Text style={styles.period}>{periodLabel}</Text> : null}
+        </View>
+        <View style={styles.rateWrapper}>
+          <Text style={styles.rateValue}>{attendanceRate ?? '-'}</Text>
+          <Text style={styles.rateLabel}>Rata-rata hadir</Text>
+        </View>
+      </View>
+
+      <View style={styles.metricsRow}>
+        <SummaryMetric
+          icon="checkmark-circle"
+          label="Hadir"
+          value={summary?.present?.count}
+          color="#2ecc71"
+        />
+        <SummaryMetric icon="time" label="Terlambat" value={summary?.late?.count} color="#f1c40f" />
+        <SummaryMetric
+          icon="close-circle"
+          label="Tidak Hadir"
+          value={summary?.absent?.count}
+          color="#e74c3c"
+        />
+      </View>
+    </View>
+  );
+};
+
+GroupAttendanceSummaryCard.defaultProps = {
+  groupName: null,
+  shelterName: null,
+  mentor: null,
+  membersCount: null,
+  periodLabel: null,
+  summary: null,
+};
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 16,
+    backgroundColor: '#ffffff',
+    padding: 18,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.04,
+    shadowRadius: 8,
+    elevation: 1,
+    marginBottom: 20,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  titleSection: {
+    flex: 1,
+    paddingRight: 16,
+  },
+  groupName: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#2d3436',
+  },
+  shelterName: {
+    marginTop: 6,
+    fontSize: 13,
+    color: '#636e72',
+  },
+  mentor: {
+    marginTop: 6,
+    fontSize: 13,
+    color: '#636e72',
+  },
+  members: {
+    marginTop: 6,
+    fontSize: 12,
+    color: '#636e72',
+  },
+  period: {
+    marginTop: 6,
+    fontSize: 12,
+    color: '#636e72',
+  },
+  rateWrapper: {
+    alignItems: 'flex-end',
+    justifyContent: 'center',
+  },
+  rateValue: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#0984e3',
+  },
+  rateLabel: {
+    marginTop: 4,
+    fontSize: 11,
+    color: '#636e72',
+  },
+  metricsRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 20,
+  },
+  metric: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  metricIconWrapper: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 8,
+  },
+  metricValue: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#2d3436',
+  },
+  metricLabel: {
+    marginTop: 4,
+    fontSize: 12,
+    fontWeight: '600',
+  },
+});
+
+export default GroupAttendanceSummaryCard;

--- a/frontend/src/features/adminCabang/components/reports/attendance/StudentAttendanceRow.js
+++ b/frontend/src/features/adminCabang/components/reports/attendance/StudentAttendanceRow.js
@@ -1,0 +1,150 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Swipeable } from 'react-native-gesture-handler';
+
+const FALLBACK_STATUS = {
+  label: 'Status',
+  icon: 'ellipse-outline',
+  color: '#636e72',
+};
+
+const StudentAttendanceRow = ({
+  student,
+  onPress,
+  renderRightActions,
+  containerStyle,
+  contentStyle,
+  showDivider,
+}) => {
+  const statusMeta = useMemo(() => {
+    if (!student) {
+      return FALLBACK_STATUS;
+    }
+
+    const color = student?.statusColor || FALLBACK_STATUS.color;
+
+    return {
+      label: student?.statusLabel || student?.status || FALLBACK_STATUS.label,
+      icon: student?.statusIcon || FALLBACK_STATUS.icon,
+      color,
+    };
+  }, [student]);
+
+  const RowContent = (
+    <TouchableOpacity
+      style={[styles.row, contentStyle]}
+      activeOpacity={onPress ? 0.85 : 1}
+      onPress={onPress}
+      disabled={!onPress}
+      accessibilityRole={onPress ? 'button' : undefined}
+    >
+      <View style={[styles.statusIconWrapper, { backgroundColor: `${statusMeta.color}1a` }]}>
+        <Ionicons name={statusMeta.icon} size={22} color={statusMeta.color} />
+      </View>
+
+      <View style={styles.infoSection}>
+        <Text style={styles.name}>{student?.name || 'Tanpa Nama'}</Text>
+        {student?.identifier ? (
+          <Text style={styles.identifier}>{student.identifier}</Text>
+        ) : null}
+        {student?.note ? <Text style={styles.note}>{student.note}</Text> : null}
+      </View>
+
+      <View style={styles.statusSection}>
+        <Text style={[styles.statusLabel, { color: statusMeta.color }]}>{statusMeta.label}</Text>
+        {student?.timeLabel ? (
+          <Text style={styles.timeLabel}>{student.timeLabel}</Text>
+        ) : null}
+        {!student?.timeLabel && student?.timestampLabel ? (
+          <Text style={styles.timeLabel}>{student.timestampLabel}</Text>
+        ) : null}
+      </View>
+    </TouchableOpacity>
+  );
+
+  const ContentWithDivider = (
+    <View style={[styles.container, containerStyle]}>
+      {RowContent}
+      {showDivider ? <View style={styles.divider} /> : null}
+    </View>
+  );
+
+  if (renderRightActions) {
+    return (
+      <Swipeable overshootRight={false} renderRightActions={renderRightActions}>
+        {ContentWithDivider}
+      </Swipeable>
+    );
+  }
+
+  return ContentWithDivider;
+};
+
+StudentAttendanceRow.defaultProps = {
+  student: null,
+  onPress: undefined,
+  renderRightActions: undefined,
+  containerStyle: null,
+  contentStyle: null,
+  showDivider: true,
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#ffffff',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 14,
+    paddingHorizontal: 4,
+  },
+  statusIconWrapper: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 12,
+  },
+  infoSection: {
+    flex: 1,
+  },
+  name: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#2d3436',
+  },
+  identifier: {
+    marginTop: 4,
+    fontSize: 12,
+    color: '#636e72',
+  },
+  note: {
+    marginTop: 6,
+    fontSize: 12,
+    color: '#636e72',
+  },
+  statusSection: {
+    alignItems: 'flex-end',
+    minWidth: 80,
+  },
+  statusLabel: {
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  timeLabel: {
+    marginTop: 6,
+    fontSize: 12,
+    color: '#636e72',
+    textAlign: 'right',
+  },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: '#ecf0f1',
+    marginLeft: 52,
+  },
+});
+
+export default StudentAttendanceRow;

--- a/frontend/src/features/adminCabang/hooks/reports/attendance/useAttendanceGroupStudents.js
+++ b/frontend/src/features/adminCabang/hooks/reports/attendance/useAttendanceGroupStudents.js
@@ -1,0 +1,672 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { adminCabangReportApi } from '../../../api/adminCabangReportApi';
+
+const DEFAULT_PAGE_SIZE = 20;
+
+const STATUS_MAP = {
+  H: { status: 'H', label: 'Hadir', icon: 'checkmark-circle', color: '#2ecc71' },
+  A: { status: 'A', label: 'Tidak Hadir', icon: 'close-circle', color: '#e74c3c' },
+  T: { status: 'T', label: 'Terlambat', icon: 'time', color: '#f1c40f' },
+  S: { status: 'S', label: 'Sakit', icon: 'medkit', color: '#00cec9' },
+  I: { status: 'I', label: 'Izin', icon: 'document-text', color: '#0984e3' },
+};
+
+const ensureArray = (value) => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.values(value);
+  }
+
+  return [];
+};
+
+const toNumber = (value, fallback = null) => {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+
+  const numberValue = Number(value);
+
+  if (Number.isNaN(numberValue)) {
+    return fallback;
+  }
+
+  return numberValue;
+};
+
+const clampPercentage = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const numeric = Number(value);
+
+  if (!Number.isFinite(numeric)) {
+    return null;
+  }
+
+  if (numeric <= 0) {
+    return 0;
+  }
+
+  if (numeric >= 100) {
+    return 100;
+  }
+
+  return Math.round(numeric * 10) / 10;
+};
+
+const calculatePercentage = (count, total) => {
+  const normalizedTotal = toNumber(total, 0);
+  const normalizedCount = toNumber(count, 0);
+
+  if (!normalizedTotal || normalizedTotal <= 0) {
+    return null;
+  }
+
+  return clampPercentage((normalizedCount / normalizedTotal) * 100);
+};
+
+const formatTimeLabel = (timestamp) => {
+  if (!timestamp) {
+    return null;
+  }
+
+  try {
+    const date = new Date(timestamp);
+
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+
+    return new Intl.DateTimeFormat('id-ID', {
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(date);
+  } catch (error) {
+    console.warn('Failed to format time label:', error);
+    return null;
+  }
+};
+
+const formatDateTimeLabel = (timestamp) => {
+  if (!timestamp) {
+    return null;
+  }
+
+  try {
+    const date = new Date(timestamp);
+
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+
+    return new Intl.DateTimeFormat('id-ID', {
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(date);
+  } catch (error) {
+    console.warn('Failed to format date time label:', error);
+    return null;
+  }
+};
+
+const normalizeStatus = (value, fallbackLabel = null) => {
+  if (!value) {
+    return {
+      status: null,
+      label: fallbackLabel || 'Tidak diketahui',
+      icon: 'help-circle',
+      color: '#b2bec3',
+    };
+  }
+
+  const statusKey = value.toString().trim().toUpperCase();
+
+  if (STATUS_MAP[statusKey]) {
+    return STATUS_MAP[statusKey];
+  }
+
+  return {
+    status: statusKey,
+    label: fallbackLabel || statusKey,
+    icon: 'ellipse-outline',
+    color: '#636e72',
+  };
+};
+
+const normalizeStudent = (item, index = 0, page = 1) => {
+  const statusValue =
+    item?.status ??
+    item?.statusCode ??
+    item?.status_code ??
+    item?.attendanceStatus ??
+    item?.attendance_status ??
+    item?.kehadiran ??
+    item?.kode_status ??
+    null;
+
+  const statusLabel =
+    item?.statusLabel ??
+    item?.status_label ??
+    item?.attendanceStatusLabel ??
+    item?.attendance_status_label ??
+    item?.keterangan ??
+    null;
+
+  const statusMeta = normalizeStatus(statusValue, statusLabel);
+
+  const timestamp =
+    item?.timestamp ??
+    item?.time ??
+    item?.attendanceTime ??
+    item?.attendance_time ??
+    item?.checkedInAt ??
+    item?.checked_in_at ??
+    item?.waktu ??
+    null;
+
+  const fallbackId = `student-${page}-${index + 1}`;
+
+  return {
+    id:
+      item?.id ??
+      item?.attendanceId ??
+      item?.attendance_id ??
+      item?.studentAttendanceId ??
+      item?.studentAttendance_id ??
+      item?.studentId ??
+      item?.student_id ??
+      fallbackId,
+    studentId:
+      item?.studentId ??
+      item?.student_id ??
+      item?.anakId ??
+      item?.anak_id ??
+      item?.childId ??
+      item?.child_id ??
+      null,
+    name:
+      item?.name ??
+      item?.studentName ??
+      item?.student_name ??
+      item?.nama ??
+      item?.childName ??
+      item?.child_name ??
+      'Tanpa Nama',
+    identifier:
+      item?.studentCode ??
+      item?.student_code ??
+      item?.code ??
+      item?.kode ??
+      item?.nis ??
+      item?.nisn ??
+      null,
+    status: statusMeta.status,
+    statusLabel: statusMeta.label,
+    statusIcon: statusMeta.icon,
+    statusColor: statusMeta.color,
+    timestamp,
+    timeLabel:
+      item?.timeLabel ?? item?.time_label ?? item?.waktuLabel ?? item?.waktu_label ?? formatTimeLabel(timestamp),
+    timestampLabel:
+      item?.timestampLabel ??
+      item?.timestamp_label ??
+      item?.waktuLengkap ??
+      item?.waktu_lengkap ??
+      formatDateTimeLabel(timestamp),
+    note: item?.notes ?? item?.note ?? item?.catatan ?? null,
+    raw: item,
+  };
+};
+
+const normalizeSummary = (summaryPayload = {}) => {
+  if (!summaryPayload || typeof summaryPayload !== 'object') {
+    return null;
+  }
+
+  const presentCount =
+    summaryPayload?.presentCount ??
+    summaryPayload?.present_count ??
+    summaryPayload?.present ??
+    summaryPayload?.hadir ??
+    summaryPayload?.jumlahHadir ??
+    summaryPayload?.jumlah_hadir ??
+    null;
+
+  const lateCount =
+    summaryPayload?.lateCount ??
+    summaryPayload?.late_count ??
+    summaryPayload?.late ??
+    summaryPayload?.terlambat ??
+    summaryPayload?.jumlahTerlambat ??
+    summaryPayload?.jumlah_terlambat ??
+    null;
+
+  const absentCount =
+    summaryPayload?.absentCount ??
+    summaryPayload?.absent_count ??
+    summaryPayload?.absent ??
+    summaryPayload?.alpha ??
+    summaryPayload?.jumlahAlpha ??
+    summaryPayload?.jumlah_alpha ??
+    null;
+
+  const totalSessions =
+    summaryPayload?.total ??
+    summaryPayload?.totalSessions ??
+    summaryPayload?.total_sessions ??
+    summaryPayload?.totalAttendance ??
+    summaryPayload?.total_attendance ??
+    summaryPayload?.totalChildren ??
+    summaryPayload?.total_children ??
+    toNumber(presentCount, 0) + toNumber(lateCount, 0) + toNumber(absentCount, 0);
+
+  const attendanceRate = clampPercentage(
+    summaryPayload?.attendanceRate ??
+      summaryPayload?.attendance_rate ??
+      summaryPayload?.attendancePercentage ??
+      summaryPayload?.attendance_percentage ??
+      calculatePercentage(presentCount, totalSessions)
+  );
+
+  const buildMetric = (count, percentage) => ({
+    count: toNumber(count, 0),
+    percentage:
+      percentage ??
+      calculatePercentage(
+        count,
+        totalSessions ?? summaryPayload?.totalChildren ?? summaryPayload?.total_children ?? null
+      ),
+  });
+
+  return {
+    present: buildMetric(
+      presentCount,
+      summaryPayload?.presentPercentage ??
+        summaryPayload?.present_percentage ??
+        summaryPayload?.presentRate ??
+        summaryPayload?.present_rate ??
+        null
+    ),
+    late: buildMetric(
+      lateCount,
+      summaryPayload?.latePercentage ??
+        summaryPayload?.late_percentage ??
+        summaryPayload?.lateRate ??
+        summaryPayload?.late_rate ??
+        null
+    ),
+    absent: buildMetric(
+      absentCount,
+      summaryPayload?.absentPercentage ??
+        summaryPayload?.absent_percentage ??
+        summaryPayload?.absentRate ??
+        summaryPayload?.absent_rate ??
+        null
+    ),
+    total: toNumber(totalSessions, null),
+    attendanceRate,
+    raw: summaryPayload,
+  };
+};
+
+const extractStudentsPayload = (responseData) => {
+  const payload = responseData?.data ?? responseData ?? {};
+
+  const candidates = [
+    payload?.students,
+    payload?.studentList,
+    payload?.student_list,
+    payload?.items,
+    payload?.data?.students,
+    payload?.data?.items,
+    payload?.data?.data,
+    payload?.data?.list,
+    payload?.result,
+    payload?.results,
+    payload?.list,
+    payload?.data,
+    payload,
+  ];
+
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) {
+      return candidate;
+    }
+
+    if (candidate && typeof candidate === 'object' && Array.isArray(candidate.data)) {
+      return candidate.data;
+    }
+  }
+
+  return [];
+};
+
+const extractSummaryPayload = (responseData) => {
+  const payload = responseData?.data ?? responseData ?? {};
+
+  const candidates = [
+    payload?.summary,
+    payload?.groupSummary,
+    payload?.group_summary,
+    payload?.data?.summary,
+    payload?.data?.groupSummary,
+    payload?.data?.group_summary,
+    payload?.meta?.summary,
+    payload?.meta?.groupSummary,
+    payload?.meta?.group_summary,
+  ];
+
+  for (const candidate of candidates) {
+    if (candidate && typeof candidate === 'object') {
+      return candidate;
+    }
+  }
+
+  return null;
+};
+
+const extractPaginationPayload = (responseData) => {
+  const payload = responseData?.data ?? responseData ?? {};
+
+  const candidates = [
+    payload?.pagination,
+    payload?.meta,
+    payload?.data?.pagination,
+    payload?.data?.meta,
+    payload?.data?.data?.pagination,
+    payload?.data?.data?.meta,
+  ];
+
+  for (const candidate of candidates) {
+    if (candidate && typeof candidate === 'object') {
+      return candidate;
+    }
+  }
+
+  return null;
+};
+
+const normalizePagination = (paginationPayload = {}, pageSize = DEFAULT_PAGE_SIZE) => {
+  if (!paginationPayload || typeof paginationPayload !== 'object') {
+    return {
+      page: 1,
+      perPage: pageSize,
+      total: null,
+      totalPages: null,
+      hasNextPage: false,
+    };
+  }
+
+  const page = toNumber(
+    paginationPayload?.page ??
+      paginationPayload?.currentPage ??
+      paginationPayload?.current_page ??
+      paginationPayload?.pageNumber ??
+      paginationPayload?.page_number ??
+      1,
+    1
+  );
+
+  const perPage = toNumber(
+    paginationPayload?.perPage ??
+      paginationPayload?.per_page ??
+      paginationPayload?.limit ??
+      paginationPayload?.pageSize ??
+      paginationPayload?.page_size ??
+      pageSize,
+    pageSize
+  );
+
+  const totalItems = toNumber(
+    paginationPayload?.total ??
+      paginationPayload?.totalItems ??
+      paginationPayload?.total_items ??
+      paginationPayload?.totalCount ??
+      paginationPayload?.total_count ??
+      paginationPayload?.count ??
+      null,
+    null
+  );
+
+  const totalPages = toNumber(
+    paginationPayload?.totalPages ??
+      paginationPayload?.total_pages ??
+      paginationPayload?.lastPage ??
+      paginationPayload?.last_page ??
+      (totalItems && perPage ? Math.ceil(totalItems / perPage) : null),
+    null
+  );
+
+  const hasNextFromPayload =
+    paginationPayload?.hasNextPage ??
+    paginationPayload?.has_next_page ??
+    paginationPayload?.hasMore ??
+    paginationPayload?.has_more ??
+    null;
+
+  const nextPage = paginationPayload?.nextPage ?? paginationPayload?.next_page ?? null;
+
+  const hasNextPage = (() => {
+    if (hasNextFromPayload !== null && hasNextFromPayload !== undefined) {
+      return Boolean(hasNextFromPayload);
+    }
+
+    if (nextPage !== null && nextPage !== undefined) {
+      return Boolean(nextPage);
+    }
+
+    if (totalPages) {
+      return page < totalPages;
+    }
+
+    if (totalItems && perPage) {
+      return page * perPage < totalItems;
+    }
+
+    return false;
+  })();
+
+  return {
+    page,
+    perPage,
+    total: totalItems,
+    totalPages,
+    hasNextPage,
+  };
+};
+
+const useAttendanceGroupStudents = ({
+  groupId,
+  shelterId = null,
+  startDate = null,
+  endDate = null,
+  search = '',
+  status = null,
+  pageSize = DEFAULT_PAGE_SIZE,
+} = {}) => {
+  const [students, setStudents] = useState([]);
+  const [summary, setSummary] = useState(null);
+  const [pagination, setPagination] = useState(() => ({
+    page: 1,
+    perPage: pageSize,
+    total: null,
+    totalPages: null,
+    hasNextPage: false,
+  }));
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFetchingMore, setIsFetchingMore] = useState(false);
+  const [error, setError] = useState(null);
+
+  const requestIdRef = useRef(0);
+
+  const normalizedStatus = useMemo(() => {
+    if (!status) {
+      return null;
+    }
+
+    return status.toString().trim().toUpperCase();
+  }, [status]);
+
+  const normalizedSearch = useMemo(() => (search ? search.toString().trim() : ''), [search]);
+
+  const buildParams = useCallback(
+    (pageParam = 1) => {
+      const params = {
+        page: pageParam,
+        pageNumber: pageParam,
+        page_number: pageParam,
+        perPage: pageSize,
+        per_page: pageSize,
+      };
+
+      if (normalizedSearch) {
+        params.search = normalizedSearch;
+        params.keyword = normalizedSearch;
+        params.q = normalizedSearch;
+      }
+
+      if (normalizedStatus) {
+        params.status = normalizedStatus;
+        params.attendanceStatus = normalizedStatus;
+        params.attendance_status = normalizedStatus;
+      }
+
+      if (shelterId) {
+        params.shelterId = shelterId;
+        params.shelter_id = shelterId;
+      }
+
+      if (startDate) {
+        params.startDate = startDate;
+        params.start_date = startDate;
+      }
+
+      if (endDate) {
+        params.endDate = endDate;
+        params.end_date = endDate;
+      }
+
+      return params;
+    },
+    [endDate, normalizedSearch, normalizedStatus, pageSize, shelterId, startDate]
+  );
+
+  const fetchStudents = useCallback(
+    async (pageParam = 1, { append = false } = {}) => {
+      if (!groupId) {
+        setStudents([]);
+        setSummary(null);
+        setPagination((prev) => ({ ...prev, page: 1, hasNextPage: false }));
+        setError('Kelompok tidak ditemukan.');
+        return;
+      }
+
+      const params = buildParams(pageParam);
+      const requestId = requestIdRef.current + 1;
+      requestIdRef.current = requestId;
+
+      try {
+        if (append) {
+          setIsFetchingMore(true);
+        } else {
+          setIsLoading(true);
+        }
+
+        setError(null);
+
+        const response = await adminCabangReportApi.getAttendanceWeeklyGroupStudents(groupId, params);
+
+        if (requestIdRef.current !== requestId) {
+          return;
+        }
+
+        const listPayload = extractStudentsPayload(response);
+        const summaryPayload = extractSummaryPayload(response);
+        const paginationPayload = extractPaginationPayload(response);
+
+        const normalizedStudents = ensureArray(listPayload).map((item, index) =>
+          normalizeStudent(item, index, pageParam)
+        );
+
+        setStudents((prev) => (append ? [...prev, ...normalizedStudents] : normalizedStudents));
+
+        const normalizedSummary = normalizeSummary(summaryPayload);
+        if (normalizedSummary) {
+          setSummary(normalizedSummary);
+        } else if (!append && !summaryPayload) {
+          setSummary(null);
+        }
+
+        setPagination(normalizePagination(paginationPayload, pageSize));
+      } catch (err) {
+        if (requestIdRef.current !== requestId) {
+          return;
+        }
+
+        console.warn('Failed to fetch attendance group students:', err);
+        setError(err?.message ?? 'Gagal memuat data kehadiran kelompok.');
+
+        if (!append) {
+          setStudents([]);
+          setSummary(null);
+          setPagination((prev) => ({ ...prev, page: 1, hasNextPage: false }));
+        }
+      } finally {
+        if (requestIdRef.current === requestId) {
+          setIsLoading(false);
+          setIsFetchingMore(false);
+        }
+      }
+    },
+    [buildParams, groupId, pageSize]
+  );
+
+  useEffect(() => {
+    setPagination((prev) => ({ ...prev, perPage: pageSize }));
+  }, [pageSize]);
+
+  useEffect(() => {
+    fetchStudents(1, { append: false });
+  }, [fetchStudents]);
+
+  const refresh = useCallback(() => fetchStudents(1, { append: false }), [fetchStudents]);
+
+  const loadMore = useCallback(() => {
+    if (isLoading || isFetchingMore || !pagination?.hasNextPage) {
+      return;
+    }
+
+    const nextPage = (pagination?.page ?? 1) + 1;
+    fetchStudents(nextPage, { append: true });
+  }, [fetchStudents, isFetchingMore, isLoading, pagination?.hasNextPage, pagination?.page]);
+
+  const isInitialLoading = isLoading && students.length === 0;
+
+  return {
+    students,
+    data: students,
+    summary,
+    pagination,
+    isLoading,
+    isInitialLoading,
+    isFetchingMore,
+    error,
+    refresh,
+    loadMore,
+    hasNextPage: Boolean(pagination?.hasNextPage),
+    filters: {
+      search: normalizedSearch,
+      status: normalizedStatus,
+    },
+  };
+};
+
+export default useAttendanceGroupStudents;

--- a/frontend/src/features/adminCabang/screens/reports/attendance/AdminCabangAttendanceGroupScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/attendance/AdminCabangAttendanceGroupScreen.js
@@ -1,0 +1,425 @@
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
+
+import AttendanceStatusChip from '../../../components/reports/attendance/AttendanceStatusChip';
+import GroupAttendanceSummaryCard from '../../../components/reports/attendance/GroupAttendanceSummaryCard';
+import StudentAttendanceRow from '../../../components/reports/attendance/StudentAttendanceRow';
+import useAttendanceGroupStudents from '../../../hooks/reports/attendance/useAttendanceGroupStudents';
+
+const STATUS_OPTIONS = [
+  { code: 'ALL', label: 'Semua', icon: 'layers-outline', color: '#0984e3' },
+  { code: 'H', label: 'Hadir', icon: 'checkmark-circle', color: '#2ecc71' },
+  { code: 'A', label: 'Alpha', icon: 'close-circle', color: '#e74c3c' },
+  { code: 'T', label: 'Terlambat', icon: 'time', color: '#f1c40f' },
+  { code: 'S', label: 'Sakit', icon: 'medkit', color: '#00cec9', disabled: true },
+  { code: 'I', label: 'Izin', icon: 'document-text', color: '#0984e3', disabled: true },
+];
+
+const AdminCabangAttendanceGroupScreen = () => {
+  const navigation = useNavigation();
+  const route = useRoute();
+
+  const {
+    groupId,
+    groupName,
+    groupMentor,
+    membersCount,
+    summary: initialSummary,
+    shelterId,
+    shelterName,
+    startDate,
+    endDate,
+    periodLabel,
+  } = route.params ?? {};
+
+  const [searchValue, setSearchValue] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState('ALL');
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedSearch(searchValue.trim());
+    }, 300);
+
+    return () => clearTimeout(handler);
+  }, [searchValue]);
+
+  const {
+    students,
+    summary,
+    isLoading,
+    isInitialLoading,
+    isFetchingMore,
+    error,
+    refresh,
+    loadMore,
+    hasNextPage,
+  } = useAttendanceGroupStudents({
+    groupId,
+    shelterId,
+    startDate,
+    endDate,
+    search: debouncedSearch,
+    status: statusFilter === 'ALL' ? null : statusFilter,
+    pageSize: 20,
+  });
+
+  const combinedSummary = useMemo(() => summary || initialSummary || null, [initialSummary, summary]);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerTitle: groupName || 'Detail Kelompok',
+      headerLeft: () => (
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          style={styles.headerButton}
+          accessibilityRole="button"
+        >
+          <Ionicons name="arrow-back" size={22} color="#2d3436" />
+        </TouchableOpacity>
+      ),
+      headerRight: () => (
+        <TouchableOpacity
+          style={[styles.headerButton, styles.headerButtonDisabled]}
+          accessibilityRole="button"
+          disabled
+        >
+          <Ionicons name="ellipsis-vertical" size={20} color="#b2bec3" />
+        </TouchableOpacity>
+      ),
+    });
+  }, [groupName, navigation]);
+
+  const handleStatusPress = useCallback((option) => {
+    if (!option || option.disabled) {
+      return;
+    }
+
+    if (option.code === 'ALL') {
+      setStatusFilter('ALL');
+      return;
+    }
+
+    setStatusFilter((prev) => (prev === option.code ? 'ALL' : option.code));
+  }, []);
+
+  const handleRefresh = useCallback(async () => {
+    try {
+      setIsRefreshing(true);
+      await refresh();
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [refresh]);
+
+  const handleEndReached = useCallback(() => {
+    if (!hasNextPage || isLoading || isFetchingMore) {
+      return;
+    }
+
+    loadMore();
+  }, [hasNextPage, isFetchingMore, isLoading, loadMore]);
+
+  const renderStudentItem = useCallback(
+    ({ item, index }) => (
+      <StudentAttendanceRow student={item} showDivider={index < students.length - 1} />
+    ),
+    [students.length]
+  );
+
+  const keyExtractor = useCallback((item, index) => {
+    if (!item) {
+      return `student-${index}`;
+    }
+
+    const idCandidate =
+      item.id || item.attendanceId || item.attendance_id || item.studentId || item.student_id;
+
+    if (idCandidate) {
+      return idCandidate.toString();
+    }
+
+    return `student-${index}`;
+  }, []);
+
+  const listHeader = useMemo(() => {
+    return (
+      <View>
+        <GroupAttendanceSummaryCard
+          groupName={groupName}
+          shelterName={shelterName}
+          mentor={groupMentor}
+          membersCount={membersCount}
+          periodLabel={periodLabel}
+          summary={combinedSummary}
+        />
+
+        <View style={styles.searchContainer}>
+          <Ionicons name="search" size={18} color="#636e72" style={styles.searchIcon} />
+          <TextInput
+            style={styles.searchInput}
+            value={searchValue}
+            onChangeText={setSearchValue}
+            placeholder="Cari nama atau kode siswa"
+            placeholderTextColor="#b2bec3"
+            autoCorrect={false}
+          />
+        </View>
+
+        <View style={styles.filterRow}>
+          {STATUS_OPTIONS.map((option) => (
+            <AttendanceStatusChip
+              key={option.code}
+              label={option.label}
+              status={option.code}
+              icon={option.icon}
+              color={option.color}
+              disabled={option.disabled}
+              active={statusFilter === option.code || (statusFilter === 'ALL' && option.code === 'ALL')}
+              onPress={() => handleStatusPress(option)}
+            />
+          ))}
+        </View>
+
+        {error ? (
+          <View style={styles.errorBanner}>
+            <Ionicons name="alert-circle" size={18} color="#e74c3c" />
+            <Text style={styles.errorText}>{error}</Text>
+            <TouchableOpacity onPress={refresh} style={styles.retryInlineButton} accessibilityRole="button">
+              <Text style={styles.retryInlineText}>Coba lagi</Text>
+            </TouchableOpacity>
+          </View>
+        ) : null}
+
+        <Text style={styles.sectionTitle}>Daftar Kehadiran Siswa</Text>
+      </View>
+    );
+  }, [
+    combinedSummary,
+    error,
+    groupMentor,
+    groupName,
+    handleStatusPress,
+    membersCount,
+    periodLabel,
+    refresh,
+    searchValue,
+    shelterName,
+    statusFilter,
+  ]);
+
+  const listEmptyComponent = useMemo(() => {
+    if (isInitialLoading) {
+      return (
+        <View style={styles.emptyState}>
+          <ActivityIndicator color="#0984e3" />
+          <Text style={styles.emptyText}>Memuat data kehadiran...</Text>
+        </View>
+      );
+    }
+
+    if (error) {
+      return (
+        <View style={styles.emptyState}>
+          <Ionicons name="alert-circle" size={28} color="#e74c3c" />
+          <Text style={styles.emptyTitle}>Gagal memuat kehadiran</Text>
+          <Text style={styles.emptyText}>{error}</Text>
+          <TouchableOpacity
+            style={styles.retryButton}
+            onPress={refresh}
+            accessibilityRole="button"
+            activeOpacity={0.85}
+          >
+            <Ionicons name="refresh" size={16} color="#ffffff" />
+            <Text style={styles.retryLabel}>Coba Lagi</Text>
+          </TouchableOpacity>
+        </View>
+      );
+    }
+
+    return (
+      <View style={styles.emptyState}>
+        <Ionicons name="people-circle-outline" size={32} color="#b2bec3" />
+        <Text style={styles.emptyTitle}>Belum ada catatan</Text>
+        <Text style={styles.emptyText}>
+          Tidak ditemukan data kehadiran siswa untuk filter yang dipilih.
+        </Text>
+      </View>
+    );
+  }, [error, isInitialLoading, refresh]);
+
+  const listFooterComponent = useMemo(() => {
+    if (!isFetchingMore) {
+      return null;
+    }
+
+    return (
+      <View style={styles.footerLoading}>
+        <ActivityIndicator color="#0984e3" size="small" />
+      </View>
+    );
+  }, [isFetchingMore]);
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={students}
+        keyExtractor={keyExtractor}
+        renderItem={renderStudentItem}
+        ListHeaderComponent={listHeader}
+        ListEmptyComponent={listEmptyComponent}
+        ListFooterComponent={listFooterComponent}
+        contentContainerStyle={students.length ? styles.listContent : styles.emptyListContent}
+        onEndReachedThreshold={0.4}
+        onEndReached={handleEndReached}
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefreshing}
+            onRefresh={handleRefresh}
+            colors={["#0984e3"]}
+            tintColor="#0984e3"
+          />
+        }
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f6fa',
+  },
+  listContent: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  emptyListContent: {
+    flexGrow: 1,
+    padding: 16,
+    paddingBottom: 32,
+  },
+  headerButton: {
+    marginHorizontal: 8,
+    padding: 6,
+    borderRadius: 18,
+    backgroundColor: 'rgba(9, 132, 227, 0.08)',
+  },
+  headerButtonDisabled: {
+    opacity: 0.6,
+  },
+  searchContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#ffffff',
+    borderRadius: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderWidth: 1,
+    borderColor: '#dfe6e9',
+    marginBottom: 16,
+  },
+  searchIcon: {
+    marginRight: 8,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 14,
+    color: '#2d3436',
+  },
+  filterRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginBottom: 12,
+  },
+  errorBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#fdecea',
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    marginBottom: 16,
+  },
+  errorText: {
+    flex: 1,
+    marginLeft: 8,
+    fontSize: 13,
+    color: '#c0392b',
+  },
+  retryInlineButton: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 8,
+    backgroundColor: '#e74c3c',
+  },
+  retryInlineText: {
+    color: '#ffffff',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  sectionTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#2d3436',
+    marginBottom: 4,
+  },
+  emptyState: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 40,
+    paddingHorizontal: 20,
+  },
+  emptyTitle: {
+    marginTop: 12,
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#2d3436',
+    textAlign: 'center',
+  },
+  emptyText: {
+    marginTop: 6,
+    fontSize: 13,
+    color: '#636e72',
+    textAlign: 'center',
+    lineHeight: 18,
+  },
+  retryButton: {
+    marginTop: 18,
+    backgroundColor: '#0984e3',
+    borderRadius: 20,
+    paddingHorizontal: 18,
+    paddingVertical: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  retryLabel: {
+    marginLeft: 8,
+    color: '#ffffff',
+    fontWeight: '600',
+    fontSize: 13,
+  },
+  footerLoading: {
+    paddingVertical: 20,
+  },
+});
+
+export default AdminCabangAttendanceGroupScreen;

--- a/frontend/src/features/adminCabang/screens/reports/attendance/AdminCabangAttendanceShelterScreen.js
+++ b/frontend/src/features/adminCabang/screens/reports/attendance/AdminCabangAttendanceShelterScreen.js
@@ -286,7 +286,49 @@ const AdminCabangAttendanceShelterScreen = () => {
     navigation,
   ]);
 
-  const renderGroupItem = useCallback(({ item }) => <ShelterGroupCard group={item} />, []);
+  const handleGroupPress = useCallback(
+    (group) => {
+      if (!group) {
+        return;
+      }
+
+      const periodStart = selectedWeek?.dateRange?.start || startDate;
+      const periodEnd = selectedWeek?.dateRange?.end || endDate;
+      const label =
+        selectedWeek?.dateRange?.label ||
+        periodLabel ||
+        formatDateRangeLabel(periodStart, periodEnd) ||
+        initialPeriodLabel;
+
+      navigation.navigate('AdminCabangAttendanceGroup', {
+        groupId: group?.id,
+        groupName: group?.name,
+        groupMentor: group?.mentor,
+        membersCount: group?.membersCount,
+        summary: group?.summary,
+        shelterId: derivedShelter?.id || shelterId,
+        shelterName: derivedShelter?.name || shelterName,
+        startDate: periodStart,
+        endDate: periodEnd,
+        periodLabel: label,
+      });
+    },
+    [
+      derivedShelter,
+      endDate,
+      initialPeriodLabel,
+      navigation,
+      periodLabel,
+      selectedWeek,
+      shelterId,
+      shelterName,
+      startDate,
+    ]
+  );
+
+  const renderGroupItem = useCallback(
+    ({ item }) => <ShelterGroupCard group={item} onPress={() => handleGroupPress(item)} />, [handleGroupPress]
+  );
 
   const listHeader = useMemo(() => {
     return (

--- a/frontend/src/navigation/AdminCabangNavigator.js
+++ b/frontend/src/navigation/AdminCabangNavigator.js
@@ -27,6 +27,7 @@ import AdminCabangTutorReportScreen from '../features/adminCabang/screens/report
 import AdminCabangAttendanceReportScreen from '../features/adminCabang/screens/reports/attendance/AdminCabangAttendanceReportScreen';
 import AdminCabangAttendanceWeeklyScreen from '../features/adminCabang/screens/reports/attendance/AdminCabangAttendanceWeeklyScreen';
 import AdminCabangAttendanceShelterScreen from '../features/adminCabang/screens/reports/attendance/AdminCabangAttendanceShelterScreen';
+import AdminCabangAttendanceGroupScreen from '../features/adminCabang/screens/reports/attendance/AdminCabangAttendanceGroupScreen';
 import ChartFullScreenScreen from '../features/adminCabang/components/reports/ChartFullScreenScreen';
 
 // Kurikulum screens
@@ -228,6 +229,11 @@ const ReportsStackNavigator = () => (
       name="AdminCabangAttendanceShelterDetail"
       component={AdminCabangAttendanceShelterScreen}
       options={{ headerTitle: 'Detail Kehadiran Shelter' }}
+    />
+    <ReportsStack.Screen
+      name="AdminCabangAttendanceGroup"
+      component={AdminCabangAttendanceGroupScreen}
+      options={{ headerTitle: 'Detail Kehadiran Kelompok' }}
     />
     <ReportsStack.Screen
       name="AdminCabangChildDetail"


### PR DESCRIPTION
## Summary
- add endpoint and API client helper for weekly group student attendance data
- build reusable attendance UI components and the group detail screen with filtering and pagination
- wire shelter group cards and navigation stack to open the new attendance group view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e608cafb188323aa0ae6e2cd0f71c1