### PR TITLE
Add logging and fallback error handling to weekly attendance hook

### DIFF
--- a/frontend/src/features/adminCabang/hooks/reports/attendance/useWeeklyAttendanceDashboard.js
+++ b/frontend/src/features/adminCabang/hooks/reports/attendance/useWeeklyAttendanceDashboard.js
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { adminCabangReportApi } from '../../../api/adminCabangReportApi';
 
 const DEFAULT_PAGE_SIZE = 10;
+const DEFAULT_ERROR_MESSAGE = 'Gagal memuat data kehadiran mingguan cabang.';
 
 const ensureArray = (value) => {
   if (Array.isArray(value)) {
@@ -479,8 +480,15 @@ const useWeeklyAttendanceDashboard = ({
 
         return normalized;
       } catch (err) {
-        const message = err?.message || 'Gagal memuat data kehadiran mingguan cabang.';
-        setError(message);
+        console.error('Failed to fetch weekly attendance dashboard', {
+          params,
+          status: err?.response?.status,
+          data: err?.response?.data,
+          error: err,
+        });
+
+        const message = err?.message;
+        setError(message || DEFAULT_ERROR_MESSAGE);
         throw err;
       } finally {
         setIsLoading(false);


### PR DESCRIPTION
## Summary
- add console error logging for failed weekly attendance dashboard fetches with request context
- surface a default fallback message when the API error does not include a message

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e61aaf83bc8323992c0b40c627a323