### PR TITLE
Refactor donation ad modal and hook

### DIFF
--- a/frontend/src/common/components/DonationAdModal.js
+++ b/frontend/src/common/components/DonationAdModal.js
@@ -12,8 +12,8 @@ import {
 import { Ionicons, FontAwesome5 } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 
-import Button from '../../../common/components/Button';
-import { DONATION_ASSET_BASE_URL } from '../../../constants/config';
+import Button from './Button';
+import { DONATION_ASSET_BASE_URL } from '../../constants/config';
 
 const DonationAdModal = ({ visible, ad, onClose, onActionPress }) => {
   const assetBase = DONATION_ASSET_BASE_URL.replace(/\/$/, '');
@@ -32,7 +32,13 @@ const DonationAdModal = ({ visible, ad, onClose, onActionPress }) => {
   };
 
   const imageUrl = getFullUrl(ad?.file_url);
-  const [imageAspectRatio, setImageAspectRatio] = useState(16 / 9);
+  const [imageAspectRatio, setImageAspectRatio] = useState(
+    () => ad?.imageAspectRatio || 16 / 9
+  );
+
+  useEffect(() => {
+    setImageAspectRatio(ad?.imageAspectRatio || 16 / 9);
+  }, [ad]);
 
   useEffect(() => {
     let isMounted = true;
@@ -51,12 +57,14 @@ const DonationAdModal = ({ visible, ad, onClose, onActionPress }) => {
           }
         }
       );
+    } else if (isMounted) {
+      setImageAspectRatio(ad?.imageAspectRatio || 16 / 9);
     }
 
     return () => {
       isMounted = false;
     };
-  }, [imageUrl]);
+  }, [ad, imageUrl]);
 
   const getTextValue = (...values) => {
     for (const value of values) {

--- a/frontend/src/common/hooks/useDonationAd.js
+++ b/frontend/src/common/hooks/useDonationAd.js
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const DONATION_AD_ENDPOINT = 'https://home.kilauindonesia.org/api/iklandonasi';
+const REQUEST_TIMEOUT = 30000;
+const FALLBACK_ASPECT_RATIO = 16 / 9;
+
+const parseAspectRatio = (ad) => {
+  if (!ad) {
+    return FALLBACK_ASPECT_RATIO;
+  }
+
+  const aspectRatioCandidates = [
+    ad.imageAspectRatio,
+    ad.image_aspect_ratio,
+    ad.aspect_ratio,
+    ad.ratio,
+  ];
+
+  for (const candidate of aspectRatioCandidates) {
+    const value =
+      typeof candidate === 'string' ? parseFloat(candidate) : candidate;
+
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      return value;
+    }
+  }
+
+  return FALLBACK_ASPECT_RATIO;
+};
+
+export const useDonationAd = () => {
+  const [ad, setAd] = useState(null);
+  const [visible, setVisible] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const controllerRef = useRef(null);
+  const dismissedRef = useRef(false);
+
+  const cleanupController = useCallback(() => {
+    if (controllerRef.current) {
+      controllerRef.current.abort();
+      controllerRef.current = null;
+    }
+  }, []);
+
+  const fetchDonationAd = useCallback(async () => {
+    cleanupController();
+
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    setIsLoading(true);
+
+    const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT);
+
+    try {
+      const response = await fetch(DONATION_AD_ENDPOINT, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const result = await response.json();
+      console.log('Donation ads response:', result);
+
+      const ads = Array.isArray(result?.data) ? result.data : [];
+      console.log('Donation ads data:', ads);
+
+      const activeAd = ads.find((item) => item?.status === '1');
+      console.log('Active donation ad:', activeAd);
+
+      const normalizedAd =
+        activeAd != null
+          ? { ...activeAd, imageAspectRatio: parseAspectRatio(activeAd) }
+          : null;
+
+      setAd(normalizedAd);
+      setVisible(Boolean(normalizedAd) && !dismissedRef.current);
+      setError(null);
+    } catch (err) {
+      if (err?.name === 'AbortError') {
+        console.log('Donation ads request aborted.');
+      } else {
+        console.error('Donation ads request failed:', err);
+        try {
+          const errorResponse = await err.response?.text?.();
+          if (errorResponse) {
+            console.log('Error response:', errorResponse);
+          }
+        } catch (parseError) {
+          console.error('Failed to parse donation ads error response:', parseError);
+        }
+        setError(err?.message || 'Failed to load donation advertisement.');
+      }
+    } finally {
+      clearTimeout(timeoutId);
+      if (controllerRef.current === controller) {
+        controllerRef.current = null;
+      }
+      setIsLoading(false);
+    }
+  }, [cleanupController]);
+
+  useEffect(() => {
+    fetchDonationAd();
+
+    return () => {
+      cleanupController();
+    };
+  }, [cleanupController, fetchDonationAd]);
+
+  const showAd = useCallback(() => {
+    dismissedRef.current = false;
+    setVisible((currentVisible) => currentVisible || Boolean(ad));
+  }, [ad]);
+
+  const dismissAd = useCallback(() => {
+    dismissedRef.current = true;
+    setVisible(false);
+  }, []);
+
+  const markActionTaken = useCallback(() => {
+    dismissedRef.current = true;
+    setVisible(false);
+  }, []);
+
+  const refreshAd = useCallback(() => {
+    return fetchDonationAd();
+  }, [fetchDonationAd]);
+
+  return {
+    ad,
+    visible,
+    isLoading,
+    error,
+    showAd,
+    dismissAd,
+    markActionTaken,
+    refreshAd,
+  };
+};
+
+export default useDonationAd;


### PR DESCRIPTION
## Summary
- move the donation ad modal into the shared common components directory and fix internal imports
- add a reusable `useDonationAd` hook that encapsulates fetching and dismissal logic for donation ads
- update the Donatur dashboard to consume the new hook and modal location

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e61f6b6bd88323ad110db163b83983