### PR TITLE
Improve monthly date filtering in weekly attendance screen

### DIFF
--- a/frontend/src/features/adminCabang/components/reports/attendance/WeeklyAttendanceFilterSheet.js
+++ b/frontend/src/features/adminCabang/components/reports/attendance/WeeklyAttendanceFilterSheet.js
@@ -28,10 +28,9 @@ const WeeklyAttendanceFilterSheet = ({
   onYearChange,
   onMonthChange,
   onWeekChange,
-  startDate,
-  endDate,
-  onStartDateChange,
-  onEndDateChange,
+  onMonthYearPick,
+  monthYearLabel,
+  monthYearValue,
 }) => {
   const safeBands = Array.isArray(bands) ? bands : [];
   const selectedSet = new Set(selectedBands || []);
@@ -43,105 +42,46 @@ const WeeklyAttendanceFilterSheet = ({
     monthList.find((month) => month.id === selectedMonth) || monthList[0] || null;
   const weekList = Array.isArray(activeMonth?.weeks) ? activeMonth.weeks : [];
 
-  const [showStartPicker, setShowStartPicker] = useState(false);
-  const [showEndPicker, setShowEndPicker] = useState(false);
+  const [showMonthYearPicker, setShowMonthYearPicker] = useState(false);
 
-  const parseDateValue = useCallback((value) => {
-    if (!value) {
-      return null;
+  const monthYearPickerValue = useMemo(() => {
+    if (monthYearValue instanceof Date) {
+      return monthYearValue;
     }
 
-    const parsed = new Date(value);
+    if (monthYearValue) {
+      const parsed = new Date(monthYearValue);
 
-    if (Number.isNaN(parsed.getTime())) {
-      return null;
+      if (!Number.isNaN(parsed.getTime())) {
+        return parsed;
+      }
     }
 
-    return parsed;
+    return new Date();
+  }, [monthYearValue]);
+
+  const effectiveMonthYearLabel = monthYearLabel || 'Semua periode';
+
+  const openMonthYearPicker = useCallback(() => {
+    setShowMonthYearPicker(true);
   }, []);
 
-  const toISODate = useCallback((date) => {
-    if (!date) {
-      return null;
-    }
-
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-
-    return `${year}-${month}-${day}`;
+  const handleMonthYearPickerCancel = useCallback(() => {
+    setShowMonthYearPicker(false);
   }, []);
 
-  const parsedStartDate = useMemo(() => parseDateValue(startDate), [parseDateValue, startDate]);
-  const parsedEndDate = useMemo(() => parseDateValue(endDate), [parseDateValue, endDate]);
-
-  const startPickerValue = parsedStartDate ?? new Date();
-  const endPickerValue = parsedEndDate ?? new Date();
-
-  const startDateLabel = parsedStartDate
-    ? parsedStartDate.toLocaleDateString('id-ID', {
-        day: 'numeric',
-        month: 'long',
-        year: 'numeric',
-      })
-    : 'Pilih tanggal';
-
-  const endDateLabel = parsedEndDate
-    ? parsedEndDate.toLocaleDateString('id-ID', {
-        day: 'numeric',
-        month: 'long',
-        year: 'numeric',
-      })
-    : 'Pilih tanggal';
-
-  const openStartPicker = useCallback(() => {
-    setShowStartPicker(true);
-  }, []);
-
-  const openEndPicker = useCallback(() => {
-    setShowEndPicker(true);
-  }, []);
-
-  const handleStartPickerCancel = useCallback(() => {
-    setShowStartPicker(false);
-  }, []);
-
-  const handleEndPickerCancel = useCallback(() => {
-    setShowEndPicker(false);
-  }, []);
-
-  const handleStartPickerChange = useCallback(
+  const handleMonthYearPickerChange = useCallback(
     (date) => {
-      setShowStartPicker(false);
+      setShowMonthYearPicker(false);
 
       if (!date) {
+        onMonthYearPick?.(null);
         return;
       }
 
-      const isoDate = toISODate(date);
-
-      onWeekChange?.(null, { start: isoDate, end: endDate || null });
-      onStartDateChange?.(isoDate);
-      onClose?.();
+      onMonthYearPick?.(date);
     },
-    [endDate, onClose, onStartDateChange, onWeekChange, toISODate],
-  );
-
-  const handleEndPickerChange = useCallback(
-    (date) => {
-      setShowEndPicker(false);
-
-      if (!date) {
-        return;
-      }
-
-      const isoDate = toISODate(date);
-
-      onWeekChange?.(null, { start: startDate || null, end: isoDate });
-      onEndDateChange?.(isoDate);
-      onClose?.();
-    },
-    [onClose, onEndDateChange, onWeekChange, startDate, toISODate],
+    [onMonthYearPick],
   );
 
   const toggleBand = (bandId) => {
@@ -275,56 +215,16 @@ const WeeklyAttendanceFilterSheet = ({
               <Text style={styles.emptyPeriodText}>Tidak ada minggu pada bulan ini.</Text>
             )}
 
-            <Text style={styles.subSectionLabel}>Rentang Tanggal Manual</Text>
-            <View style={styles.dateRangeRow}>
-              <TouchableOpacity
-                style={[
-                  styles.dateInput,
-                  styles.dateInputStart,
-                  parsedStartDate ? styles.dateInputActive : null,
-                ]}
-                onPress={openStartPicker}
-              >
-                <View style={styles.dateTextWrapper}>
-                  <Text style={styles.dateLabel}>Mulai</Text>
-                  <Text
-                    style={[
-                      styles.dateValue,
-                      !parsedStartDate ? styles.datePlaceholder : null,
-                    ]}
-                  >
-                    {startDateLabel}
-                  </Text>
-                </View>
-                <Ionicons name="calendar-outline" size={18} color="#0984e3" />
-              </TouchableOpacity>
-
-              <Text style={styles.dateSeparatorText}>s/d</Text>
-
-              <TouchableOpacity
-                style={[
-                  styles.dateInput,
-                  styles.dateInputEnd,
-                  parsedEndDate ? styles.dateInputActive : null,
-                ]}
-                onPress={openEndPicker}
-              >
-                <View style={styles.dateTextWrapper}>
-                  <Text style={styles.dateLabel}>Selesai</Text>
-                  <Text
-                    style={[
-                      styles.dateValue,
-                      !parsedEndDate ? styles.datePlaceholder : null,
-                    ]}
-                  >
-                    {endDateLabel}
-                  </Text>
-                </View>
-                <Ionicons name="calendar-outline" size={18} color="#0984e3" />
-              </TouchableOpacity>
-            </View>
-            <Text style={styles.dateHelperText}>
-              Memilih tanggal manual akan menghapus pilihan minggu.
+            <Text style={styles.subSectionLabel}>Bulan & Tahun</Text>
+            <TouchableOpacity style={styles.monthYearButton} onPress={openMonthYearPicker}>
+              <View style={styles.monthYearTextWrapper}>
+                <Text style={styles.monthYearButtonLabel}>Pilih Bulan & Tahun</Text>
+                <Text style={styles.monthYearValueLabel}>{effectiveMonthYearLabel}</Text>
+              </View>
+              <Ionicons name="calendar-outline" size={18} color="#0984e3" />
+            </TouchableOpacity>
+            <Text style={styles.monthYearHelperText}>
+              Rentang laporan akan mengikuti bulan yang Anda pilih.
             </Text>
           </View>
         ) : (
@@ -372,23 +272,12 @@ const WeeklyAttendanceFilterSheet = ({
         </View>
       </View>
 
-      {showStartPicker ? (
+      {showMonthYearPicker ? (
         <DatePicker
-          value={startPickerValue}
-          onChange={handleStartPickerChange}
-          onCancel={handleStartPickerCancel}
-          maximumDate={parsedEndDate || undefined}
-          title="Pilih Tanggal Mulai"
-        />
-      ) : null}
-
-      {showEndPicker ? (
-        <DatePicker
-          value={endPickerValue}
-          onChange={handleEndPickerChange}
-          onCancel={handleEndPickerCancel}
-          minimumDate={parsedStartDate || undefined}
-          title="Pilih Tanggal Selesai"
+          value={monthYearPickerValue}
+          onChange={handleMonthYearPickerChange}
+          onCancel={handleMonthYearPickerCancel}
+          title="Pilih Bulan & Tahun"
         />
       ) : null}
     </Modal>
@@ -411,10 +300,9 @@ WeeklyAttendanceFilterSheet.defaultProps = {
   onYearChange: undefined,
   onMonthChange: undefined,
   onWeekChange: undefined,
-  startDate: null,
-  endDate: null,
-  onStartDateChange: undefined,
-  onEndDateChange: undefined,
+  onMonthYearPick: undefined,
+  monthYearLabel: 'Semua periode',
+  monthYearValue: null,
 };
 
 const styles = StyleSheet.create({
@@ -585,57 +473,33 @@ const styles = StyleSheet.create({
   weekRangeActive: {
     color: '#0984e3',
   },
-  dateRangeRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginTop: 12,
-  },
-  dateInput: {
-    flex: 1,
+  monthYearButton: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    paddingHorizontal: 14,
-    paddingVertical: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
     borderRadius: 14,
     backgroundColor: '#ffffff',
     borderWidth: 1,
     borderColor: '#dfe6e9',
+    marginTop: 12,
   },
-  dateInputStart: {
-    marginRight: 12,
-  },
-  dateInputEnd: {
-    marginLeft: 12,
-  },
-  dateInputActive: {
-    borderColor: '#0984e3',
-    backgroundColor: 'rgba(9, 132, 227, 0.12)',
-  },
-  dateTextWrapper: {
+  monthYearTextWrapper: {
     flex: 1,
     marginRight: 12,
   },
-  dateLabel: {
+  monthYearButtonLabel: {
     fontSize: 12,
     color: '#636e72',
-    marginBottom: 2,
+    marginBottom: 4,
   },
-  dateValue: {
-    fontSize: 13,
+  monthYearValueLabel: {
+    fontSize: 14,
     fontWeight: '600',
     color: '#2d3436',
   },
-  datePlaceholder: {
-    color: '#b2bec3',
-    fontWeight: '500',
-  },
-  dateSeparatorText: {
-    fontSize: 12,
-    fontWeight: '600',
-    color: '#636e72',
-  },
-  dateHelperText: {
+  monthYearHelperText: {
     marginTop: 8,
     fontSize: 11,
     color: '#636e72',


### PR DESCRIPTION
## Summary
- replace manual date range handlers with a month/year picker flow that computes month boundaries and avoids redundant updates
- align weekly attendance screen state management with the new month filter, including refreshed labels and reset handling
- update the filter sheet UI to expose a single month/year picker button and remove the old start/end date controls

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e685fd74008323a5febc936efe5a1e